### PR TITLE
Use build as default target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Folders
 .idea/
+builds/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 export CGO_ENABLED = 0
 export GO111MODULE := on
 


### PR DESCRIPTION
To my knowledge it is common practice to invoke a compile/build target when calling `make` without arguments.