### PR TITLE
Use environment variables as auth config fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Folders
 .idea/
 builds/
+
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOCS_OUT=$${DOCS_OUT:-$(shell pwd)/docs/commands/}
 .PHONY: test_unit
 test_unit:
 	@echo "--- Run unit tests ---"
-	@go test -cover ./commands/... ./pkg/utils/...
+	@go test -cover ./commands/... ./pkg/utils/... ./pkg/config/...
 	@echo "DONE"
 
 .PHONY: test

--- a/commands/datacenter.go
+++ b/commands/datacenter.go
@@ -282,7 +282,7 @@ func getDataCentersKVMaps(dcs []resources.Datacenter) []map[string]interface{} {
 }
 
 func getDataCentersIds(outErr io.Writer) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/lan.go
+++ b/commands/lan.go
@@ -325,7 +325,7 @@ func getLanPostsKVMaps(ls []resources.LanPost) []map[string]interface{} {
 }
 
 func getLansIds(outErr io.Writer, parentCmdName string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 	clientSvc, err := resources.NewClientService(
 		viper.GetString(config.Username),

--- a/commands/loadbalancer.go
+++ b/commands/loadbalancer.go
@@ -303,7 +303,7 @@ func getLoadbalancersKVMaps(vs []resources.Loadbalancer) []map[string]interface{
 }
 
 func getLoadbalancersIds(outErr io.Writer, parentCmdName string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/location.go
+++ b/commands/location.go
@@ -112,7 +112,7 @@ func getLocationsKVMaps(dcs []resources.Location) []map[string]interface{} {
 }
 
 func getLocationIds(outErr io.Writer) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/nic.go
+++ b/commands/nic.go
@@ -548,7 +548,7 @@ func getNicsKVMaps(ns []resources.Nic) []map[string]interface{} {
 }
 
 func getNicsIds(outErr io.Writer, parentCmdName string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(
@@ -577,7 +577,7 @@ func getNicsIds(outErr io.Writer, parentCmdName string) []string {
 }
 
 func getAttachedNicsIds(outErr io.Writer, parentCmdName, nameCmd string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/request.go
+++ b/commands/request.go
@@ -184,7 +184,7 @@ func getRequestsKVMaps(requests []resources.Request) []map[string]interface{} {
 }
 
 func getRequestsIds(outErr io.Writer) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/server.go
+++ b/commands/server.go
@@ -479,7 +479,7 @@ func getServersKVMaps(ss []resources.Server) []map[string]interface{} {
 }
 
 func getServersIds(outErr io.Writer, parentCmdName string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/commands/volume.go
+++ b/commands/volume.go
@@ -557,7 +557,7 @@ func getVolumesKVMaps(vs []resources.Volume) []map[string]interface{} {
 }
 
 func getVolumesIds(outErr io.Writer, parentCmdName string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(
@@ -583,7 +583,7 @@ func getVolumesIds(outErr io.Writer, parentCmdName string) []string {
 }
 
 func getAttachedVolumesIds(outErr io.Writer, parentCmdDcId, parentCmdName, nameCmd string) []string {
-	err := config.LoadFile()
+	err := config.Load()
 	clierror.CheckError(err, outErr)
 
 	clientSvc, err := resources.NewClientService(

--- a/pkg/builder/command.go
+++ b/pkg/builder/command.go
@@ -197,7 +197,7 @@ func NewCommandConfig(ctx context.Context, in io.Reader, p printer.PrintService,
 		Context:    ctx,
 
 		initServices: func(c *CommandConfig) error {
-			err := config.LoadFile()
+			err := config.Load()
 			if err != nil {
 				return err
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	sdk "github.com/ionos-cloud/sdk-go/v5"
 	"github.com/spf13/viper"
 )
 
@@ -37,6 +38,19 @@ func LoadFile() error {
 		return err
 	}
 	return nil
+}
+
+// Load collects config data from the config file, using environment variables as fallback.
+func Load() (err error) {
+	if err = LoadFile(); err != nil {
+		pathErr := &os.PathError{}
+		if errors.As(err, &viper.ConfigFileNotFoundError{}) || errors.As(err, &pathErr) {
+			_ = viper.BindEnv(Username, sdk.IonosUsernameEnvVar)
+			_ = viper.BindEnv(Password, sdk.IonosPasswordEnvVar)
+			return nil
+		}
+	}
+	return err
 }
 
 func WriteFile() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	sdk "github.com/ionos-cloud/sdk-go/v5"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadFile(t *testing.T) {
+	viper.Reset()
+	viper.SetConfigFile(filepath.Join("..", "testdata", "config.json"))
+	assert.NoError(t, Load())
+	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
+	assert.Equal(t, "test", viper.GetString(Password))
+}
+
+func TestLoadEnvFallback(t *testing.T) {
+	viper.Reset()
+	os.Setenv(sdk.IonosUsernameEnvVar, "user")
+	os.Setenv(sdk.IonosPasswordEnvVar, "pass")
+	assert.NoError(t, Load())
+	assert.Equal(t, "user", viper.GetString(Username))
+	assert.Equal(t, "pass", viper.GetString(Password))
+
+	viper.Reset()
+	viper.SetConfigFile("notfound.json")
+	assert.NoError(t, Load())
+	assert.Equal(t, "user", viper.GetString(Username))
+	assert.Equal(t, "pass", viper.GetString(Password))
+}


### PR DESCRIPTION
This makes the CLI less reliant on the config file and allows to use it without calling `login` first.

Fallback is only used when the config file is not found.