### PR TITLE
Fix: print dev version

### DIFF
--- a/commands/backupunit.go
+++ b/commands/backupunit.go
@@ -27,7 +27,7 @@ func backupunit() *core.Command {
 			Use:              "backupunit",
 			Aliases:          []string{"b", "backup"},
 			Short:            "BackupUnit Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl backupunit` + "`" + ` allow you to list, get, create, update, delete BackupUnits under your account.`,
+			Long:             "The sub-commands of `ionosctl backupunit` allow you to list, get, create, update, delete BackupUnits under your account.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/cdrom.go
+++ b/commands/cdrom.go
@@ -24,7 +24,7 @@ func serverCdrom() *core.Command {
 			Use:              "cdrom",
 			Aliases:          []string{"cd"},
 			Short:            "Server CD-ROM Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl server cdrom` + "`" + ` allow you to attach, get, list, detach CD-ROMs from Servers.`,
+			Long:             "The sub-commands of `ionosctl server cdrom` allow you to attach, get, list, detach CD-ROMs from Servers.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/contract.go
+++ b/commands/contract.go
@@ -25,7 +25,7 @@ func contract() *core.Command {
 			Use:              "contract",
 			Aliases:          []string{"c"},
 			Short:            "Contract Resources Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl contract` + "`" + ` allows you to see information about Contract Resources for your account.`,
+			Long:             "The sub-command of `ionosctl contract` allows you to see information about Contract Resources for your account.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/datacenter.go
+++ b/commands/datacenter.go
@@ -24,7 +24,7 @@ func datacenter() *core.Command {
 			Use:              "datacenter",
 			Aliases:          []string{"d", "dc"},
 			Short:            "Data Center Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl datacenter` + "`" + ` allow you to create, list, get, update and delete Data Centers.`,
+			Long:             "The sub-commands of `ionosctl datacenter` allow you to create, list, get, update and delete Data Centers.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/firewallrule.go
+++ b/commands/firewallrule.go
@@ -26,7 +26,7 @@ func firewallrule() *core.Command {
 			Use:              "firewallrule",
 			Aliases:          []string{"f", "fr", "firewall"},
 			Short:            "Firewall Rule Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl firewallrule` + "`" + ` allow you to create, list, get, update, delete Firewall Rules.`,
+			Long:             "The sub-commands of `ionosctl firewallrule` allow you to create, list, get, update, delete Firewall Rules.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/group.go
+++ b/commands/group.go
@@ -25,7 +25,7 @@ func group() *core.Command {
 			Use:              "group",
 			Aliases:          []string{"g"},
 			Short:            "Group Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl group` + "`" + ` allow you to list, get, create, update, delete Groups, but also operations: add/remove/list/update User from the Group.`,
+			Long:             "The sub-commands of `ionosctl group` allow you to list, get, create, update, delete Groups, but also operations: add/remove/list/update User from the Group.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/image.go
+++ b/commands/image.go
@@ -25,7 +25,7 @@ func image() *core.Command {
 			Use:              "image",
 			Aliases:          []string{"img"},
 			Short:            "Image Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl image` + "`" + ` allow you to see information about the Images available.`,
+			Long:             "The sub-commands of `ionosctl image` allow you to see information about the Images available.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/ipblock.go
+++ b/commands/ipblock.go
@@ -24,7 +24,7 @@ func ipblock() *core.Command {
 			Use:              "ipblock",
 			Aliases:          []string{"ipb"},
 			Short:            "IpBlock Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl ipblock` + "`" + ` allow you to create/reserve, list, get, update, delete IpBlocks.`,
+			Long:             "The sub-commands of `ionosctl ipblock` allow you to create/reserve, list, get, update, delete IpBlocks.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/ipconsumer.go
+++ b/commands/ipconsumer.go
@@ -24,7 +24,7 @@ func ipconsumer() *core.Command {
 			Use:              "ipconsumer",
 			Aliases:          []string{"ipc"},
 			Short:            "Ip Consumer Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl ipconsumer` + "`" + ` allows you to list information about where each IP address from an IpBlock is being used.`,
+			Long:             "The sub-command of `ionosctl ipconsumer` allows you to list information about where each IP address from an IpBlock is being used.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/ipfailover.go
+++ b/commands/ipfailover.go
@@ -25,7 +25,7 @@ func ipfailover() *core.Command {
 			Use:              "ipfailover",
 			Aliases:          []string{"ipf"},
 			Short:            "IP Failover Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl ipfailover` + "`" + ` allows you to see information about IP Failovers groups available on a LAN, to add/remove IP Failover group from a LAN.`,
+			Long:             "The sub-command of `ionosctl ipfailover` allows you to see information about IP Failovers groups available on a LAN, to add/remove IP Failover group from a LAN.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/k8s_cluster.go
+++ b/commands/k8s_cluster.go
@@ -24,7 +24,7 @@ func k8s() *core.Command {
 		Command: &cobra.Command{
 			Use:              "k8s",
 			Short:            "Kubernetes Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl k8s` + "`" + ` allow you to list, get, create, update, delete Kubernetes Clusters.`,
+			Long:             "The sub-commands of `ionosctl k8s` allow you to list, get, create, update, delete Kubernetes Clusters.",
 			TraverseChildren: true,
 		},
 	}
@@ -44,7 +44,7 @@ func k8sCluster() *core.Command {
 			Use:              "cluster",
 			Aliases:          []string{"c"},
 			Short:            "Kubernetes Cluster Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl k8s cluster` + "`" + ` allow you to list, get, create, update, delete Kubernetes Clusters.`,
+			Long:             "The sub-commands of `ionosctl k8s cluster` allow you to list, get, create, update, delete Kubernetes Clusters.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/k8s_kubeconfig.go
+++ b/commands/k8s_kubeconfig.go
@@ -18,7 +18,7 @@ func k8sKubeconfig() *core.Command {
 			Use:              "kubeconfig",
 			Aliases:          []string{"cfg", "config"},
 			Short:            "Kubernetes Kubeconfig Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl k8s kubeconfig` + "`" + ` allows you to get the configuration file of a Kubernetes Cluster.`,
+			Long:             "The sub-command of `ionosctl k8s kubeconfig` allows you to get the configuration file of a Kubernetes Cluster.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/k8s_node.go
+++ b/commands/k8s_node.go
@@ -24,7 +24,7 @@ func k8sNode() *core.Command {
 			Use:              "node",
 			Aliases:          []string{"n"},
 			Short:            "Kubernetes Node Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl k8s node` + "`" + ` allow you to list, get, recreate, delete Kubernetes Nodes.`,
+			Long:             "The sub-commands of `ionosctl k8s node` allow you to list, get, recreate, delete Kubernetes Nodes.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/k8s_nodepool.go
+++ b/commands/k8s_nodepool.go
@@ -27,7 +27,7 @@ func k8sNodePool() *core.Command {
 			Use:              "nodepool",
 			Aliases:          []string{"np"},
 			Short:            "Kubernetes NodePool Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl k8s nodepool` + "`" + ` allow you to list, get, create, update, delete Kubernetes NodePools.`,
+			Long:             "The sub-commands of `ionosctl k8s nodepool` allow you to list, get, create, update, delete Kubernetes NodePools.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/k8s_version.go
+++ b/commands/k8s_version.go
@@ -15,7 +15,7 @@ func k8sVersion() *core.Command {
 			Use:              "version",
 			Aliases:          []string{"v"},
 			Short:            "Kubernetes Version Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl k8s version` + "`" + ` allow you to get information about available Kubernetes versions.`,
+			Long:             "The sub-commands of `ionosctl k8s version` allow you to get information about available Kubernetes versions.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/label.go
+++ b/commands/label.go
@@ -21,7 +21,7 @@ func label() *core.Command {
 		Command: &cobra.Command{
 			Use:              "label",
 			Short:            "Label Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl label` + "`" + ` allow you to get, list, add, remove Labels from a Resource.`,
+			Long:             "The sub-commands of `ionosctl label` allow you to get, list, add, remove Labels from a Resource.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/lan.go
+++ b/commands/lan.go
@@ -26,7 +26,7 @@ func lan() *core.Command {
 			Use:              "lan",
 			Aliases:          []string{"l"},
 			Short:            "LAN Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl lan` + "`" + ` allow you to create, list, get, update, delete LANs.`,
+			Long:             "The sub-commands of `ionosctl lan` allow you to create, list, get, update, delete LANs.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/loadbalancer.go
+++ b/commands/loadbalancer.go
@@ -24,7 +24,7 @@ func loadBalancer() *core.Command {
 			Use:              "loadbalancer",
 			Aliases:          []string{"lb"},
 			Short:            "Load Balancer Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl loadbalancer` + "`" + ` manage your Load Balancers on your account. With the ` + "`" + `ionosctl loadbalancer` + "`" + ` command, you can list, create, delete Load Balancers and manage their configuration details.`,
+			Long:             "The sub-commands of `ionosctl loadbalancer` manage your Load Balancers on your account. With the `ionosctl loadbalancer` command, you can list, create, delete Load Balancers and manage their configuration details.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/location.go
+++ b/commands/location.go
@@ -25,7 +25,7 @@ func location() *core.Command {
 			Use:              "location",
 			Aliases:          []string{"loc"},
 			Short:            "Location Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl location` + "`" + ` allows you to see information about locations available to create objects.`,
+			Long:             "The sub-command of `ionosctl location` allows you to see information about locations available to create objects.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/nic.go
+++ b/commands/nic.go
@@ -25,7 +25,7 @@ func nic() *core.Command {
 			Use:              "nic",
 			Aliases:          []string{"n"},
 			Short:            "Network Interfaces Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl nic` + "`" + ` allow you to create, list, get, update, delete NICs. To attach a NIC to a Load Balancer, use the Load Balancer command ` + "`" + `ionosctl loadbalancer nic attach` + "`" + `.`,
+			Long:             "The sub-commands of `ionosctl nic` allow you to create, list, get, update, delete NICs. To attach a NIC to a Load Balancer, use the Load Balancer command `ionosctl loadbalancer nic attach`.",
 			TraverseChildren: true,
 		},
 	}
@@ -309,7 +309,7 @@ func loadBalancerNic() *core.Command {
 			Use:              "nic",
 			Aliases:          []string{"n"},
 			Short:            "Load Balancer Nic Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl loadbalancer nic` + "`" + ` allow you to manage NICs on Load Balancers on your account.`,
+			Long:             "The sub-commands of `ionosctl loadbalancer nic` allow you to manage NICs on Load Balancers on your account.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/pcc.go
+++ b/commands/pcc.go
@@ -24,7 +24,7 @@ func pcc() *core.Command {
 		Command: &cobra.Command{
 			Use:              "pcc",
 			Short:            "Private Cross-Connect Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl pcc` + "`" + ` allow you to list, get, create, update, delete Private Cross-Connect. To add Private Cross-Connect to a Lan, check the ` + "`" + `ionosctl lan update` + "`" + ` command.`,
+			Long:             "The sub-commands of `ionosctl pcc` allow you to list, get, create, update, delete Private Cross-Connect. To add Private Cross-Connect to a Lan, check the `ionosctl lan update` command.",
 			TraverseChildren: true,
 		},
 	}
@@ -256,7 +256,7 @@ func peers() *core.Command {
 		Command: &cobra.Command{
 			Use:              "peers",
 			Short:            "Private Cross-Connect Peers Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl pcc peers` + "`" + ` allows you to get a list of Peers from a Private Cross-Connect.`,
+			Long:             "The sub-command of `ionosctl pcc peers` allows you to get a list of Peers from a Private Cross-Connect.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/request.go
+++ b/commands/request.go
@@ -26,7 +26,7 @@ func request() *core.Command {
 			Use:              "request",
 			Aliases:          []string{"req"},
 			Short:            "Request Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl request` + "`" + ` allow you to see information about requests on your account. With the ` + "`" + `ionosctl request` + "`" + ` command, you can list, get or wait for a Request.`,
+			Long:             "The sub-commands of `ionosctl request` allow you to see information about requests on your account. With the `ionosctl request` command, you can list, get or wait for a Request.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/resource.go
+++ b/commands/resource.go
@@ -24,7 +24,7 @@ func resource() *core.Command {
 			Use:              "resource",
 			Aliases:          []string{"res"},
 			Short:            "Resource Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl resource` + "`" + ` allow you to list, get Resources.`,
+			Long:             "The sub-commands of `ionosctl resource` allow you to list, get Resources.",
 			TraverseChildren: true,
 		},
 	}
@@ -118,7 +118,7 @@ func groupResource() *core.Command {
 			Use:              "resource",
 			Aliases:          []string{"res"},
 			Short:            "Group Resource Operations",
-			Long:             `The sub-command of ` + "`" + `ionosctl group resource` + "`" + ` allows you to list Resources from a Group.`,
+			Long:             "The sub-command of `ionosctl group resource` allows you to list Resources from a Group.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -123,7 +123,7 @@ func initVersion() {
 		IonosctlVersion.patch = i
 	}
 	if Label == "" {
-		IonosctlVersion.label = "dev"
+		IonosctlVersion.label = "DEV"
 	} else {
 		IonosctlVersion.label = Label
 	}
@@ -138,7 +138,7 @@ type cliVersion struct {
 
 func (v cliVersion) GetVersion() string {
 	if v.label != "release" {
-		return fmt.Sprintf("%d.%d.%d-%s", v.major, v.minor, v.patch, v.label)
+		return fmt.Sprintf("%s", v.label)
 	} else {
 		return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
 	}

--- a/commands/s3key.go
+++ b/commands/s3key.go
@@ -25,7 +25,7 @@ func userS3key() *core.Command {
 			Use:              "s3key",
 			Aliases:          []string{"k", "s3k"},
 			Short:            "User S3Key Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl user s3key` + "`" + ` allow you to see information, to list, get, create, update, delete Users S3Keys.`,
+			Long:             "The sub-commands of `ionosctl user s3key` allow you to see information, to list, get, create, update, delete Users S3Keys.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -27,7 +27,7 @@ func server() *core.Command {
 			Use:              "server",
 			Aliases:          []string{"s", "svr"},
 			Short:            "Server Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl server` + "`" + ` allow you to create, list, get, update, delete, start, stop, reboot Servers.`,
+			Long:             "The sub-commands of `ionosctl server` allow you to create, list, get, update, delete, start, stop, reboot Servers.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/share.go
+++ b/commands/share.go
@@ -24,7 +24,7 @@ func share() *core.Command {
 		Command: &cobra.Command{
 			Use:              "share",
 			Short:            "Resource Share Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl share` + "`" + ` allow you to list, get, create, update, delete Resource Shares.`,
+			Long:             "The sub-commands of `ionosctl share` allow you to list, get, create, update, delete Resource Shares.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/snapshot.go
+++ b/commands/snapshot.go
@@ -24,7 +24,7 @@ func snapshot() *core.Command {
 			Use:              "snapshot",
 			Aliases:          []string{"ss", "snap"},
 			Short:            "Snapshot Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl snapshot` + "`" + ` allow you to see information, to create, update, delete Snapshots.`,
+			Long:             "The sub-commands of `ionosctl snapshot` allow you to see information, to create, update, delete Snapshots.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/user.go
+++ b/commands/user.go
@@ -25,7 +25,7 @@ func user() *core.Command {
 			Use:              "user",
 			Aliases:          []string{"u"},
 			Short:            "User Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl user` + "`" + ` allow you to list, get, create, update, delete Users under your account. To add Users to a Group, check the ` + "`" + `ionosctl group user` + "`" + ` commands. To add S3Keys to a User, check the ` + "`" + `ionosctl user s3key` + "`" + ` commands.`,
+			Long:             "The sub-commands of `ionosctl user` allow you to list, get, create, update, delete Users under your account. To add Users to a Group, check the `ionosctl group user` commands. To add S3Keys to a User, check the `ionosctl user s3key` commands.",
 			TraverseChildren: true,
 		},
 	}
@@ -299,7 +299,7 @@ func groupUser() *core.Command {
 			Use:              "user",
 			Aliases:          []string{"u"},
 			Short:            "Group User Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl group user` + "`" + ` allow you to list, add, remove Users from a Group.`,
+			Long:             "The sub-commands of `ionosctl group user` allow you to list, add, remove Users from a Group.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/version.go
+++ b/commands/version.go
@@ -37,7 +37,7 @@ func version() *core.Command {
 }
 
 func RunVersion(c *core.CommandConfig) error {
-	err := c.Printer.Print("You are currently using ionosctl version: " + rootCmd.Command.Version)
+	err := c.Printer.Print("You are currently using ionosctl the " + rootCmd.Command.Version + " version.")
 	if err != nil {
 		return err
 	}

--- a/commands/volume.go
+++ b/commands/volume.go
@@ -28,7 +28,7 @@ func volume() *core.Command {
 			Use:              "volume",
 			Aliases:          []string{"v", "vol"},
 			Short:            "Volume Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl volume` + "`" + ` manage your block storage volumes by creating, updating, getting specific information, deleting Volumes. To attach a Volume to a Server, use the Server command ` + "`" + `ionosctl server volume attach` + "`" + `.`,
+			Long:             "The sub-commands of `ionosctl volume` manage your block storage volumes by creating, updating, getting specific information, deleting Volumes. To attach a Volume to a Server, use the Server command `ionosctl server volume attach`.",
 			TraverseChildren: true,
 		},
 	}
@@ -449,7 +449,7 @@ func serverVolume() *core.Command {
 			Use:              "volume",
 			Aliases:          []string{"v", "vol"},
 			Short:            "Server Volume Operations",
-			Long:             `The sub-commands of ` + "`" + `ionosctl server volume` + "`" + ` allow you to attach, get, list, detach Volumes from Servers.`,
+			Long:             "The sub-commands of `ionosctl server volume` allow you to attach, get, list, detach Volumes from Servers.",
 			TraverseChildren: true,
 		},
 	}


### PR DESCRIPTION
Description: 

* Improve documentation
* With both the v6 and v5 support, the print of v(latest tag)-dev for version was not valid anymore: print: DEV version for unofficial releases. 