### PR TITLE
Use Makefile syntax to define defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ export CGO_ENABLED = 0
 export GO111MODULE := on
 
 GOFILES_NOVENDOR=$(shell find . -type f -name '*.go' | grep -v vendor)
-GOOS=${GOOS:-$(shell go env GOOS)}
-GOARCH=${GOARCH:-$(shell go env GOARCH)}
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
 
-OUT_D=$${OUT_D:-$(shell pwd)/builds}
-DOCS_OUT=$${DOCS_OUT:-$(shell pwd)/docs/subcommands/}
+OUT_D?=$(shell pwd)/builds
+DOCS_OUT?=$(shell pwd)/docs/subcommands/
 
 .PHONY: test_unit
 test_unit:
@@ -22,6 +22,7 @@ test: test_unit
 .PHONY: docs_update
 docs_update:
 	@echo "--- Generate Markdown documentation in ${DOCS_OUT} ---"
+	@mkdir -p ${DOCS_OUT}
 	@DOCS_OUT=${DOCS_OUT} go run tools/doc.go
 	@echo "DONE"
 


### PR DESCRIPTION
Makefile uses `?=` to define a variable that is set if the variable on the left side is not defined. This also fixes the binary name when running `make build`.

Additionally, ensure that the docs directory exists before updating.

Before:

```sh
$ make
--- Building ionosctl via go build ---
built /home/mv/Projects/CORE/ionosctl/builds/ionosctl__
DONE
```

After:

```sh
make
--- Building ionosctl via go build ---
built /home/mv/Projects/CORE/ionosctl/builds/ionosctl_linux_amd64
DONE
```