### PR TITLE
Fix wait for non-default API URLs

### DIFF
--- a/pkg/utils/printer/printer.go
+++ b/pkg/utils/printer/printer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 
@@ -78,9 +79,7 @@ func (p *JSONPrinter) Print(v interface{}) error {
 			if err != nil {
 				return err
 			}
-			if requestId != nil {
-				resultPrint.RequestId = *requestId
-			}
+			resultPrint.RequestId = requestId
 		}
 		resultPrint.Output = v.(Result).OutputJSON
 		if !structs.IsZero(resultPrint) {
@@ -136,9 +135,7 @@ func (p *TextPrinter) Print(v interface{}) error {
 			if err != nil {
 				return err
 			}
-			if requestId != nil {
-				resultPrint.RequestId = *requestId
-			}
+			resultPrint.RequestId = requestId
 		}
 		if v.(Result).KeyValue != nil && v.(Result).Columns != nil {
 			err := printText(p.Stdout, v.(Result).Columns, v.(Result).KeyValue)
@@ -281,12 +278,13 @@ func WriteJSON(item interface{}, writer io.Writer) error {
 	return nil
 }
 
-func GetRequestId(path string) (*string, error) {
-	if !strings.Contains(path, config.DefaultApiURL) {
-		return nil, errors.New("path does not contain " + config.DefaultApiURL)
+var requestPathRegex = regexp.MustCompile(`https?://[a-zA-Z0-9./-]+/requests/([a-z0-9-]+)/status`)
+
+func GetRequestId(path string) (string, error) {
+	if !requestPathRegex.MatchString(path) {
+		return "", fmt.Errorf("%s does not contain requestId", path)
 	}
-	str := strings.Split(path, "/")
-	return &str[len(str)-2], nil
+	return requestPathRegex.FindStringSubmatch(path)[1], nil
 }
 
 func GetRequestPath(r *resources.Response) string {

--- a/pkg/utils/printer/printer_test.go
+++ b/pkg/utils/printer/printer_test.go
@@ -166,7 +166,7 @@ func TestPrinterResultJsonRequestId(t *testing.T) {
 			},
 		},
 	}
-	res.ApiResponse.Header.Add("location", "https://api.ionos.com/cloudapi/v5/requests/123456/status")
+	res.ApiResponse.Header.Add("location", "https://api.test.ionos.com/cloudapi/v5/requests/123456/status")
 
 	p.Print(res)
 	err = w.Flush()
@@ -179,7 +179,7 @@ func TestPrinterResultJsonRequestId(t *testing.T) {
 func TestPrinterResultJsonRequestIdErr(t *testing.T) {
 	var (
 		b      bytes.Buffer
-		strErr = `path does not contain https://api.ionos.com/cloudapi/v5`
+		strErr = `https://api.ionos.com/servers/123456 does not contain requestId`
 	)
 
 	viper.Set(config.ArgOutput, "json")
@@ -200,11 +200,11 @@ func TestPrinterResultJsonRequestIdErr(t *testing.T) {
 			},
 		},
 	}
-	res.ApiResponse.Header.Add("location", "https://api.ionos.com/requests/123456/status")
+	res.ApiResponse.Header.Add("location", "https://api.ionos.com/servers/123456")
 
 	err = p.Print(res)
 	assert.Error(t, err)
-	assert.True(t, err.Error() == strErr)
+	assert.EqualError(t, err, strErr)
 }
 
 func TestPrinterGetStdoutJSON(t *testing.T) {
@@ -483,4 +483,13 @@ func TestPrinterGetStderrText(t *testing.T) {
 	err = w.Flush()
 	assert.NoError(t, err)
 	assert.True(t, out == w)
+}
+
+func TestGetRequestId(t *testing.T) {
+	id, err := GetRequestId(config.DefaultApiURL)
+	assert.Error(t, err)
+	assert.Empty(t, id)
+	id, err = GetRequestId("https://api.test.ionos.com/cloudapi/v5/requests/test/status")
+	assert.NoError(t, err)
+	assert.Equal(t, "test", id)
 }

--- a/pkg/utils/wait.go
+++ b/pkg/utils/wait.go
@@ -53,7 +53,7 @@ func WaitForRequest(c *core.CommandConfig, requestPath string) error {
 			progress.Start()
 			defer progress.Finish()
 
-			_, errCh := WatchRequestProgress(ctxTimeout, c, *requestId)
+			_, errCh := WatchRequestProgress(ctxTimeout, c, requestId)
 			if err := <-errCh; err != nil {
 				progress.SetTemplateString(requestProgressCircleTpl + " " + failed)
 				return err
@@ -61,7 +61,7 @@ func WaitForRequest(c *core.CommandConfig, requestPath string) error {
 			progress.SetTemplateString(requestProgressCircleTpl + " " + done)
 		} else {
 			c.Printer.Print(waitingForRequestMsg)
-			_, errCh := WatchRequestProgress(ctxTimeout, c, *requestId)
+			_, errCh := WatchRequestProgress(ctxTimeout, c, requestId)
 			if err := <-errCh; err != nil {
 				c.Printer.Print(failed)
 				return err

--- a/pkg/utils/wait_test.go
+++ b/pkg/utils/wait_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	pathRequest              = fmt.Sprintf("%s/%s/status/test/test", config.DefaultApiURL, testWaitForRequestVar)
+	pathRequest              = fmt.Sprintf("%s/%s/requests/test/status", config.DefaultApiURL, testWaitForRequestVar)
 	testWaitForRequestVar    = "test-wait-for-action"
 	testRunningRequestStatus = &resources.RequestStatus{
 		RequestStatus: ionoscloud.RequestStatus{


### PR DESCRIPTION
Use a regex to extract the request ID instead of checking for the hard-coded default v5 API URL.

This also should fix printing in general for non-default API URLs, like staging.