### PR TITLE
Store API URL in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can set the environment variables using the next commands:
 export IONOS_USERNAME="ionos username"
 export IONOS_PASSWORD="ionos password"
 export IONOS_TOKEN="ionos token"
+export IONOS_API_URL="ionos api url"
 ```
 
 * Using `login` command
@@ -118,6 +119,8 @@ Status: Authentication successful!
 ```text
 Error: 401 Unauthorized
 ```
+
+Setting `--api-url` will overwrite the default value of `https://api.ionos.com` for subsequent requests.
 
 After a successful authentication with the `login` command, you will no longer need to provide credentials unless you want to change them. By default, they will be stored in
 

--- a/commands/backupunit.go
+++ b/commands/backupunit.go
@@ -407,7 +407,7 @@ func getBackupUnitsIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	backupUnitSvc := v5.NewBackupUnitService(clientSvc.Get(), context.TODO())

--- a/commands/cdrom.go
+++ b/commands/cdrom.go
@@ -249,7 +249,7 @@ func getAttachedCdromsIds(outErr io.Writer, datacenterId, serverId string) []str
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	serverSvc := v5.NewServerService(clientSvc.Get(), context.TODO())
@@ -275,7 +275,7 @@ func getImagesCdromIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	imageSvc := v5.NewImageService(clientSvc.Get(), context.TODO())

--- a/commands/datacenter.go
+++ b/commands/datacenter.go
@@ -351,7 +351,7 @@ func getDataCentersIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	datacenterSvc := v5.NewDataCenterService(clientSvc.Get(), context.TODO())

--- a/commands/firewallrule.go
+++ b/commands/firewallrule.go
@@ -502,7 +502,7 @@ func getFirewallRulesIds(outErr io.Writer, datacenterId, serverId, nicId string)
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	firewallRuleSvc := v5.NewFirewallRuleService(clientSvc.Get(), context.TODO())

--- a/commands/group.go
+++ b/commands/group.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fatih/structs"
 	"github.com/ionos-cloud/ionosctl/pkg/config"
 	"github.com/ionos-cloud/ionosctl/pkg/core"
-	"github.com/ionos-cloud/ionosctl/pkg/resources/v5"
+	v5 "github.com/ionos-cloud/ionosctl/pkg/resources/v5"
 	"github.com/ionos-cloud/ionosctl/pkg/utils"
 	"github.com/ionos-cloud/ionosctl/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/pkg/utils/printer"
@@ -510,7 +510,7 @@ func getGroupsIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	groupSvc := v5.NewGroupService(clientSvc.Get(), context.TODO())

--- a/commands/image.go
+++ b/commands/image.go
@@ -300,7 +300,7 @@ func getImageIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	imageSvc := v5.NewImageService(clientSvc.Get(), context.TODO())

--- a/commands/ipblock.go
+++ b/commands/ipblock.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fatih/structs"
 	"github.com/ionos-cloud/ionosctl/pkg/config"
 	"github.com/ionos-cloud/ionosctl/pkg/core"
-	"github.com/ionos-cloud/ionosctl/pkg/resources/v5"
+	v5 "github.com/ionos-cloud/ionosctl/pkg/resources/v5"
 	"github.com/ionos-cloud/ionosctl/pkg/utils"
 	"github.com/ionos-cloud/ionosctl/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/pkg/utils/printer"
@@ -354,7 +354,7 @@ func getIpBlocksIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	ipBlockSvc := v5.NewIpBlockService(clientSvc.Get(), context.TODO())

--- a/commands/k8s_cluster.go
+++ b/commands/k8s_cluster.go
@@ -542,7 +542,7 @@ func getK8sClustersIds(outErr io.Writer) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	k8sSvc := v5.NewK8sService(clientSvc.Get(), context.TODO())

--- a/commands/k8s_node.go
+++ b/commands/k8s_node.go
@@ -351,7 +351,7 @@ func getK8sNodesIds(outErr io.Writer, clusterId, nodepoolId string) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	k8sSvc := v5.NewK8sService(clientSvc.Get(), context.TODO())

--- a/commands/k8s_nodepool.go
+++ b/commands/k8s_nodepool.go
@@ -633,7 +633,7 @@ func getK8sNodePoolsIds(outErr io.Writer, clusterId string) []string {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	clierror.CheckError(err, outErr)
 	k8sSvc := v5.NewK8sService(clientSvc.Get(), context.TODO())

--- a/commands/login.go
+++ b/commands/login.go
@@ -75,12 +75,13 @@ func RunLoginUser(c *core.CommandConfig) error {
 	viper.Set(config.Username, username)
 	viper.Set(config.Password, pwd)
 	viper.Set(config.Token, token)
+	viper.Set(config.ServerUrl, viper.GetString(config.ArgServerUrl))
 
 	clientSvc, err := v5.NewClientService(
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token),
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	if err != nil {
 		return err

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ You can set the environment variables using the next commands:
 export IONOS_USERNAME="ionos username"
 export IONOS_PASSWORD="ionos password"
 export IONOS_TOKEN="ionos token"
+export IONOS_API_URL="ionos api url"
 ```
 
 * Using `login` command
@@ -109,6 +110,8 @@ Status: Authentication successful!
 ```text
 Error: 401 Unauthorized
 ```
+
+Setting `--api-url` will overwrite the default value of `https://api.ionos.com` for subsequent requests.
 
 After a successful authentication with the `login` command, you will no longer need to provide credentials unless you want to change them. By default, they will be stored in
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,10 +15,28 @@ import (
 
 func GetUserData() map[string]string {
 	return map[string]string{
-		Username: viper.GetString(Username),
-		Password: viper.GetString(Password),
-		Token:    viper.GetString(Token),
+		Username:  viper.GetString(Username),
+		Password:  viper.GetString(Password),
+		Token:     viper.GetString(Token),
+		ServerUrl: viper.GetString(ServerUrl),
 	}
+}
+
+// GetServerUrl returns the API URL from flags, config or env in order of priority.
+// The caller must ensure to load config or env vars beforehand, so they can be included.
+//
+// Priority:
+// 1. Explicit flag
+// 2. Env/config file
+// 3. Flag default value
+func GetServerUrl() string {
+	if viper.IsSet(ArgServerUrl) {
+		return viper.GetString(ArgServerUrl)
+	}
+	if url := viper.GetString(ServerUrl); url != "" {
+		return url
+	}
+	return viper.GetString(ArgServerUrl)
 }
 
 func GetConfigFile() string {
@@ -81,8 +99,9 @@ func Load() (err error) {
 	_ = viper.BindEnv(Username, sdk.IonosUsernameEnvVar)
 	_ = viper.BindEnv(Password, sdk.IonosPasswordEnvVar)
 	_ = viper.BindEnv(Token, sdk.IonosTokenEnvVar)
+	_ = viper.BindEnv(ServerUrl, IonosServerUrlEnvVar)
 
-	if viper.GetString(Username) == "" || viper.GetString(Password) == "" {
+	if viper.GetString(Username) == "" && viper.GetString(Token) == "" {
 		if err = LoadFile(); err != nil {
 			return err
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,6 +25,7 @@ func TestGetServerUrl(t *testing.T) {
 	viper.Reset()
 	viper.SetConfigFile(filepath.Join("..", "testdata", "config.json"))
 	viper.Set(ArgConfig, filepath.Join("..", "testdata", "config.json"))
+	assert.NoError(t, os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600))
 	assert.NoError(t, Load())
 	assert.Equal(t, "https://api.ionos.com/cloudapi/v5", GetServerUrl())
 
@@ -44,8 +45,7 @@ func TestLoadFile(t *testing.T) {
 
 	viper.SetConfigFile(filepath.Join("..", "testdata", "config.json"))
 	viper.Set(ArgConfig, filepath.Join("..", "testdata", "config.json"))
-	err := os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600)
-	assert.NoError(t, err)
+	assert.NoError(t, os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600))
 	assert.NoError(t, LoadFile())
 	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
 	assert.Equal(t, "test", viper.GetString(Password))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,7 +27,7 @@ func TestGetServerUrl(t *testing.T) {
 	viper.Set(ArgConfig, filepath.Join("..", "testdata", "config.json"))
 	assert.NoError(t, os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600))
 	assert.NoError(t, Load())
-	assert.Equal(t, "https://api.ionos.com/cloudapi/v5", GetServerUrl())
+	assert.Equal(t, "https://api.ionos.com", GetServerUrl())
 
 	viper.Reset()
 	fs := pflag.NewFlagSet(ArgServerUrl, pflag.ContinueOnError)
@@ -50,7 +50,7 @@ func TestLoadFile(t *testing.T) {
 	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
 	assert.Equal(t, "test", viper.GetString(Password))
 	assert.Equal(t, "jwt-token", viper.GetString(Token))
-	assert.Equal(t, "https://api.ionos.com/cloudapi/v5", viper.GetString(ServerUrl))
+	assert.Equal(t, "https://api.ionos.com", viper.GetString(ServerUrl))
 }
 
 func TestLoadEnvFallback(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,12 +6,42 @@ import (
 	"testing"
 
 	sdk "github.com/ionos-cloud/sdk-go/v5"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadFile(t *testing.T) {
+func TestGetServerUrl(t *testing.T) {
+	os.Clearenv()
 	viper.Reset()
+
+	// use env
+	assert.NoError(t, os.Setenv(IonosServerUrlEnvVar, "url"))
+	_ = Load() // ignore error since we just want to load the URL
+	assert.Equal(t, "url", GetServerUrl())
+
+	// from config
+	os.Clearenv()
+	viper.Reset()
+	viper.SetConfigFile(filepath.Join("..", "testdata", "config.json"))
+	viper.Set(ArgConfig, filepath.Join("..", "testdata", "config.json"))
+	assert.NoError(t, Load())
+	assert.Equal(t, "https://api.ionos.com/cloudapi/v5", GetServerUrl())
+
+	viper.Reset()
+	fs := pflag.NewFlagSet(ArgServerUrl, pflag.ContinueOnError)
+	_ = fs.String(ArgServerUrl, "default", "test flag")
+	viper.BindPFlags(fs)
+	assert.Equal(t, "default", GetServerUrl())
+
+	assert.NoError(t, fs.Parse([]string{"--" + ArgServerUrl, "explicit"}))
+	assert.Equal(t, "explicit", GetServerUrl())
+}
+
+func TestLoadFile(t *testing.T) {
+	os.Clearenv()
+	viper.Reset()
+
 	viper.SetConfigFile(filepath.Join("..", "testdata", "config.json"))
 	viper.Set(ArgConfig, filepath.Join("..", "testdata", "config.json"))
 	err := os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600)
@@ -20,25 +50,20 @@ func TestLoadFile(t *testing.T) {
 	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
 	assert.Equal(t, "test", viper.GetString(Password))
 	assert.Equal(t, "jwt-token", viper.GetString(Token))
+	assert.Equal(t, "https://api.ionos.com/cloudapi/v5", viper.GetString(ServerUrl))
 }
 
 func TestLoadEnvFallback(t *testing.T) {
+	os.Clearenv()
 	viper.Reset()
-	err := os.Setenv(sdk.IonosUsernameEnvVar, "user")
-	assert.NoError(t, err)
-	err = os.Setenv(sdk.IonosPasswordEnvVar, "pass")
-	assert.NoError(t, err)
-	err = os.Setenv(sdk.IonosTokenEnvVar, "token")
-	assert.NoError(t, err)
-	assert.NoError(t, Load())
-	assert.Equal(t, "user", viper.GetString(Username))
-	assert.Equal(t, "pass", viper.GetString(Password))
-	assert.Equal(t, "token", viper.GetString(Token))
 
-	viper.Reset()
-	viper.SetConfigFile("notfound.json")
+	assert.NoError(t, os.Setenv(sdk.IonosUsernameEnvVar, "user"))
+	assert.NoError(t, os.Setenv(sdk.IonosPasswordEnvVar, "pass"))
+	assert.NoError(t, os.Setenv(sdk.IonosTokenEnvVar, "token"))
+	assert.NoError(t, os.Setenv(IonosServerUrlEnvVar, "url"))
 	assert.NoError(t, Load())
 	assert.Equal(t, "user", viper.GetString(Username))
 	assert.Equal(t, "pass", viper.GetString(Password))
 	assert.Equal(t, "token", viper.GetString(Token))
+	assert.Equal(t, "url", viper.GetString(ServerUrl))
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -192,4 +192,10 @@ const (
 	Username               = "userdata.name"
 	Password               = "userdata.password"
 	Token                  = "userdata.token"
+	ServerUrl              = "userdata.api-url"
+)
+
+// Custom env vars
+const (
+	IonosServerUrlEnvVar = "IONOS_API_URL"
 )

--- a/pkg/core/command_runner.go
+++ b/pkg/core/command_runner.go
@@ -159,7 +159,7 @@ func (c *CommandConfig) InitV5Client() (*v5.Client, error) {
 		viper.GetString(config.Username),
 		viper.GetString(config.Password),
 		viper.GetString(config.Token), // Token support
-		viper.GetString(config.ArgServerUrl),
+		config.GetServerUrl(),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/resources/v5/client.go
+++ b/pkg/resources/v5/client.go
@@ -2,7 +2,7 @@ package v5
 
 import (
 	"errors"
-	"fmt"
+	"strings"
 
 	"github.com/ionos-cloud/ionosctl/pkg/config"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v5"
@@ -32,6 +32,9 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 	if hostUrl == "" {
 		return nil, errors.New("host-url incorrect")
 	}
+	if !strings.HasSuffix(hostUrl, config.DefaultV5BasePath) {
+		hostUrl += config.DefaultV5BasePath
+	}
 	if token == "" && (name == "" || pwd == "") {
 		return nil, errors.New("username, password or token incorrect")
 	}
@@ -41,7 +44,7 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 		Token:    token,
 		Servers: ionoscloud.ServerConfigurations{
 			ionoscloud.ServerConfiguration{
-				URL: fmt.Sprintf("%s%s", hostUrl, config.DefaultV5BasePath),
+				URL: hostUrl,
 			},
 		},
 	}

--- a/pkg/testdata/config.json
+++ b/pkg/testdata/config.json
@@ -1,5 +1,5 @@
 {
-  "api-url": "https://api.ionos.com/cloudapi/v5",
+  "userdata.api-url": "https://api.ionos.com/cloudapi/v5",
   "userdata.name": "test@ionos.com",
   "userdata.password": "test",
   "userdata.token": "jwt-token"

--- a/pkg/testdata/config.json
+++ b/pkg/testdata/config.json
@@ -1,5 +1,5 @@
 {
-  "userdata.api-url": "https://api.ionos.com/cloudapi/v5",
+  "userdata.api-url": "https://api.ionos.com",
   "userdata.name": "test@ionos.com",
   "userdata.password": "test",
   "userdata.token": "jwt-token"


### PR DESCRIPTION
API URL is stored as `userdata.api-url` in the config file when `login` command is called. Subsequent calls read the URL from the config file.

The API URL can also be set via `IONOS_API_URL` environment variable.
This variable name is also used by the [terraform provider].

The sources for API URL have the following priority:

1. Explicitly set `--api-url` flag
2. Config file
3. Env var `IONOS_API_URL`
4. `--api-url` default value

Other changes:

- Fix login when the value of `--api-url` ends in `cloudapi/v5`
- Use config file over env when both `IONOS_USERNAME` and `IONOS_TOKEN` are not defined, was (`IONOS_USERNAME` **or** `IONOS_PASSWORD` before)

These changes make using `ionosctl` in staging environments a lot easier.

[terraform provider]: https://registry.terraform.io/providers/ionos-cloud/ionoscloud/latest/docs#usage