### PR TITLE
Fix: ionosctl login command for token authentication [v5]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCS_OUT?=$(shell pwd)/docs/subcommands/
 .PHONY: test_unit
 test_unit:
 	@echo "--- Run unit tests ---"
-	@go test -cover ./internal/...
+	@go test -cover ./commands/ ./internal/...
 	@echo "DONE"
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ username
 Enter your password:
 ```
 
-You can also use token for authentication. After providing credentials, you will be notified if you logged in successfully or not:
+You can also use token for authentication via `--token` flag. After providing credentials, you will be notified if you logged in successfully or not:
 
 ```text
 Status: Authentication successful!

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -18,10 +18,36 @@ const (
 	testPassword = "test"
 )
 
+func TestPreRunLoginCmd(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
+		viper.Reset()
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), testUsername)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), testPassword)
+		err := PreRunLoginCmd(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestPreRunLoginCmdErr(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
+		viper.Reset()
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), testUsername)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), testPassword)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgToken), testPassword)
+		err := PreRunLoginCmd(cfg)
+		assert.Error(t, err)
+	})
+}
+
 func TestRunLoginUserBufferUserErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), "")
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), testPassword)
 		cfg.Stdin = bytes.NewReader([]byte(testUsername + "\n"))
@@ -34,6 +60,7 @@ func TestRunLoginUserBufferErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), "")
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), testPassword)
 		cfg.Stdin = bytes.NewReader([]byte(testUsername))
@@ -46,6 +73,7 @@ func TestRunLoginUserUnauthorizedErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), testUsername)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), testPassword)
 		err := RunLoginUser(cfg)
@@ -57,6 +85,7 @@ func TestRunLoginUserBufferPwdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgUser), testUsername)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgPassword), "")
 		err := RunLoginUser(cfg)
@@ -68,6 +97,7 @@ func TestRunLoginUserConfigSet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
 		err := os.Setenv(ionoscloud.IonosUsernameEnvVar, "user")
 		assert.NoError(t, err)
 		err = os.Setenv(ionoscloud.IonosPasswordEnvVar, "pass")

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ username
 Enter your password:
 ```
 
-You can also use token for authentication. After providing credentials, you will be notified if you logged in successfully or not:
+You can also use token for authentication via `--token` flag. After providing credentials, you will be notified if you logged in successfully or not:
 
 ```text
 Status: Authentication successful!

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,10 +14,15 @@ import (
 )
 
 func GetUserData() map[string]string {
+	if viper.GetString(Token) != "" {
+		return map[string]string{
+			Token:     viper.GetString(Token),
+			ServerUrl: viper.GetString(ServerUrl),
+		}
+	}
 	return map[string]string{
 		Username:  viper.GetString(Username),
 		Password:  viper.GetString(Password),
-		Token:     viper.GetString(Token),
 		ServerUrl: viper.GetString(ServerUrl),
 	}
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -25,6 +25,7 @@ const (
 	ArgCols                = "cols"
 	ArgUpdates             = "updates"
 	ArgToken               = "token"
+	ArgTokenShort          = "t"
 	ArgUser                = "user"
 	ArgPassword            = "password"
 	ArgPasswordShort       = "p"

--- a/internal/core/test.go
+++ b/internal/core/test.go
@@ -28,10 +28,10 @@ type PreCmdRunTest func(c *PreCommandConfig)
 func PreCmdConfigTest(t *testing.T, writer io.Writer, preRunner PreCmdRunTest) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	p, _ := printer.NewPrinterRegistry(writer, writer)
 	if viper.GetString(config.ArgOutput) == "" {
 		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
 	}
+	p, _ := printer.NewPrinterRegistry(writer, writer)
 	prt := p[viper.GetString(config.ArgOutput)]
 	preCmdCfg := &PreCommandConfig{
 		Command: &Command{
@@ -58,10 +58,10 @@ type ResourcesMocksTest struct {
 func CmdConfigTest(t *testing.T, writer io.Writer, runner CmdRunnerTest) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	printReg, _ := printer.NewPrinterRegistry(writer, writer)
 	if viper.GetString(config.ArgOutput) == "" {
 		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
 	}
+	printReg, _ := printer.NewPrinterRegistry(writer, writer)
 	prt := printReg[viper.GetString(config.ArgOutput)]
 	// Init Test Mock Resources and Services
 	testMocks := initMockResources(ctrl)


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Right now, the ionosctl command does not support running only with the token set. This PR adds fix for that and stores the credentials in a file based on the credentials provided (username+pwd/token).
Added verbosity level as well.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR Title containing `Feat`/`Fix`/`Doc`
- [x] Tests added or updated
- [x] Documentation updated
- [ ] SONAR Cloud Scan - warnings checked
- [ ] Task updated (Jira/Github)
