### PR TITLE
Feat: implement --all flag for detach and remove commands

### DIFF
--- a/commands/cloudapi-v5/backupunit.go
+++ b/commands/cloudapi-v5/backupunit.go
@@ -367,7 +367,7 @@ func DeleteAllBackupUnits(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/cdrom.go
+++ b/commands/cloudapi-v5/cdrom.go
@@ -306,7 +306,7 @@ func DetachllCdRoms(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/cdrom_test.go
+++ b/commands/cloudapi-v5/cdrom_test.go
@@ -24,6 +24,36 @@ var (
 			Items: &[]ionoscloud.Image{testImage.Image},
 		},
 	}
+	testCdromsList = resources.Cdroms{
+		Cdroms: ionoscloud.Cdroms{
+			Id: &testCdromVar,
+			Items: &[]ionoscloud.Image{
+				testImageCdRoms.Image,
+				testImageCdRoms.Image,
+			},
+		},
+	}
+	testImageCdRoms = resources.Image{
+		Image: ionoscloud.Image{
+			Id: &testCdromVar,
+			Properties: &ionoscloud.ImageProperties{
+				Name:         &testImageVar,
+				Location:     &testImageVar,
+				Description:  &testImageVar,
+				Size:         &testImageSize,
+				LicenceType:  &testImageUpperVar,
+				ImageType:    &testImageUpperVar,
+				Public:       &testImagePublic,
+				ImageAliases: &[]string{testImageVar},
+				CloudInit:    &testImageVar,
+			},
+			Metadata: &ionoscloud.DatacenterElementMetadata{
+				CreatedDate:     &testIonosTime,
+				CreatedBy:       &testImageVar,
+				CreatedByUserId: &testImageVar,
+			},
+		},
+	}
 	testCdromVar = "test-cdrom"
 	testCdromErr = errors.New("cdrom test error")
 )
@@ -195,6 +225,26 @@ func TestRunServerCdromDetach(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgCdromId), testCdromVar)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
 		rm.CloudApiV5Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar).Return(nil, nil)
+		err := RunServerCdromDetach(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunServerCdromDetachAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testCdromVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testCdromVar)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar).Return(testCdromsList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar).Return(&testResponse, nil)
+		rm.CloudApiV5Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar).Return(&testResponse, nil)
 		err := RunServerCdromDetach(cfg)
 		assert.NoError(t, err)
 	})

--- a/commands/cloudapi-v5/datacenter.go
+++ b/commands/cloudapi-v5/datacenter.go
@@ -317,7 +317,7 @@ func DeleteAllDatacenters(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/firewallrule.go
+++ b/commands/cloudapi-v5/firewallrule.go
@@ -500,7 +500,7 @@ func DeleteAllFirewallRules(c *core.CommandConfig) (*resources.Response, error) 
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/group.go
+++ b/commands/cloudapi-v5/group.go
@@ -460,7 +460,7 @@ func DeleteAllGroups(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/ipblock.go
+++ b/commands/cloudapi-v5/ipblock.go
@@ -307,7 +307,7 @@ func DeleteAllIpBlocks(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/ipfailover.go
+++ b/commands/cloudapi-v5/ipfailover.go
@@ -331,7 +331,7 @@ func RemoveAllIpFailovers(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func getIpFailoverInfo(c *core.CommandConfig) resources.LanProperties {

--- a/commands/cloudapi-v5/ipfailover_test.go
+++ b/commands/cloudapi-v5/ipfailover_test.go
@@ -32,6 +32,12 @@ var (
 			},
 		},
 	}
+	lansIpFailover = resources.Lans{
+		Lans: ionoscloud.Lans{
+			Id:    &testIpFailoverVar,
+			Items: &[]ionoscloud.Lan{l},
+		},
+	}
 	testLanIpFailoverRemove = resources.Lan{
 		Lan: ionoscloud.Lan{
 			Id: &testIpFailoverVar,
@@ -307,6 +313,34 @@ func TestRunIpFailoverRemove(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testIpFailoverVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgNicId), testIpFailoverVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgIp), testIpFailoverVar)
+		rm.CloudApiV5Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar).Return(&testLanIpFailover, &testResponse, nil)
+		rm.CloudApiV5Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+			LanProperties: ionoscloud.LanProperties{
+				IpFailover: &[]ionoscloud.IPFailover{},
+			},
+		}).Return(&testLanIpFailoverRemove, nil, nil)
+		err := RunIpFailoverRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunIpFailoverRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgForce, true)
+		viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testIpFailoverVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLanId), testIpFailoverVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testIpFailoverVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgNicId), testIpFailoverVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Lan.EXPECT().List(testIpFailoverVar).Return(lansIpFailover, &testResponse, nil)
 		rm.CloudApiV5Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar).Return(&testLanIpFailover, &testResponse, nil)
 		rm.CloudApiV5Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
 			LanProperties: ionoscloud.LanProperties{

--- a/commands/cloudapi-v5/k8s_cluster.go
+++ b/commands/cloudapi-v5/k8s_cluster.go
@@ -451,7 +451,7 @@ func DeleteAllK8sClusters(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/k8s_node.go
+++ b/commands/cloudapi-v5/k8s_node.go
@@ -318,7 +318,7 @@ func DeleteAllK8sNodes(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/k8s_nodepool.go
+++ b/commands/cloudapi-v5/k8s_nodepool.go
@@ -544,7 +544,7 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/label.go
+++ b/commands/cloudapi-v5/label.go
@@ -182,7 +182,7 @@ func LabelCmd() *core.Command {
 		ShortDesc:  "Remove a Label from a Resource",
 		LongDesc:   "Use this command to remove a Label from a Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key",
 		Example:    removeLabelExample,
-		PreCmdRun:  PreRunResourceTypeLabelKey,
+		PreCmdRun:  PreRunResourceTypeLabelKeyRemove,
 		CmdRun:     RunLabelRemove,
 		InitClient: true,
 	})
@@ -211,6 +211,7 @@ func LabelCmd() *core.Command {
 	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv5.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{cloudapiv5.DatacenterResource, cloudapiv5.VolumeResource, cloudapiv5.ServerResource, cloudapiv5.SnapshotResource, cloudapiv5.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
 	})
+	removeLabel.AddBoolFlag(cloudapiv5.ArgAll, cloudapiv5.ArgAllShort, false, "Remove all Labels.")
 
 	return labelCmd
 }
@@ -222,6 +223,22 @@ func PreRunResourceTypeLabelKey(c *core.PreCommandConfig) error {
 		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgLabelKey},
 		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgSnapshotId, cloudapiv5.ArgLabelKey},
 		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgIpBlockId, cloudapiv5.ArgLabelKey},
+	)
+}
+
+func PreRunResourceTypeLabelKeyRemove(c *core.PreCommandConfig) error {
+	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgLabelKey},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgVolumeId, cloudapiv5.ArgLabelKey},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgLabelKey},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgSnapshotId, cloudapiv5.ArgLabelKey},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgIpBlockId, cloudapiv5.ArgLabelKey},
+
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgAll},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgVolumeId, cloudapiv5.ArgAll},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgAll},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgSnapshotId, cloudapiv5.ArgAll},
+		[]string{cloudapiv5.ArgResourceType, cloudapiv5.ArgIpBlockId, cloudapiv5.ArgAll},
 	)
 }
 

--- a/commands/cloudapi-v5/labelresource.go
+++ b/commands/cloudapi-v5/labelresource.go
@@ -119,7 +119,7 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, erro
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func RunServerLabelsList(c *core.CommandConfig) error {
@@ -237,7 +237,7 @@ func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func RunVolumeLabelsList(c *core.CommandConfig) error {
@@ -354,7 +354,7 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func RunIpBlockLabelsList(c *core.CommandConfig) error {
@@ -468,7 +468,7 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) 
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func RunSnapshotLabelsList(c *core.CommandConfig) error {
@@ -578,7 +578,7 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error)
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/labelresource.go
+++ b/commands/cloudapi-v5/labelresource.go
@@ -2,9 +2,11 @@ package cloudapi_v5
 
 import (
 	"github.com/fatih/structs"
+	"github.com/ionos-cloud/ionosctl/commands/cloudapi-v5/waiter"
 	"github.com/ionos-cloud/ionosctl/internal/config"
 	"github.com/ionos-cloud/ionosctl/internal/core"
 	"github.com/ionos-cloud/ionosctl/internal/printer"
+	"github.com/ionos-cloud/ionosctl/internal/utils"
 	cloudapiv5 "github.com/ionos-cloud/ionosctl/services/cloudapi-v5"
 	"github.com/ionos-cloud/ionosctl/services/cloudapi-v5/resources"
 	"github.com/spf13/viper"
@@ -51,17 +53,73 @@ func RunDataCenterLabelAdd(c *core.CommandConfig) error {
 }
 
 func RunDataCenterLabelRemove(c *core.CommandConfig) error {
-	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
-	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
-	c.Printer.Verbose("Removing label with key: %v for Datacenter with id: %v...", labelKey, dcId)
-	resp, err := c.CloudApiV5Services.Labels().DatacenterDelete(dcId, labelKey)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllDatacenterLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for Datacenter with id: %v...", labelKey, dcId)
+		resp, err = c.CloudApiV5Services.Labels().DatacenterDelete(dcId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
-	}
+
 	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
+func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, error) {
+	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+	_ = c.Printer.Print("Labels to be removed from Datacenter with Id: " + dcId)
+	labels, resp, err := c.CloudApiV5Services.Labels().DatacenterList(dcId)
+	if err != nil {
+		return nil, err
+	}
+	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					_ = c.Printer.Print(" Label Key: " + *key)
+				}
+				if value, ok := properties.GetValueOk(); ok && value != nil {
+					_ = c.Printer.Print(" Label Value: " + *value)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Datacenter with Id: "+dcId); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Deleting all the Labels from Datacenter with Id: %v...", dcId)
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					c.Printer.Verbose("Starting deleting Label with id: %v...", *key)
+					resp, err = c.CloudApiV5Services.Labels().DatacenterDelete(dcId, *key)
+					if resp != nil {
+						c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+						c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+					}
+					if err != nil {
+						return nil, err
+					}
+					if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+	return resp, err
 }
 
 func RunServerLabelsList(c *core.CommandConfig) error {
@@ -110,18 +168,76 @@ func RunServerLabelAdd(c *core.CommandConfig) error {
 }
 
 func RunServerLabelRemove(c *core.CommandConfig) error {
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllServerLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+		serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgServerId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for Server with id: %v...", labelKey, serverId)
+		resp, err = c.CloudApiV5Services.Labels().ServerDelete(dcId, serverId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
+func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgServerId))
-	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
-	c.Printer.Verbose("Removing label with key: %v for Server with id: %v...", labelKey, serverId)
-	resp, err := c.CloudApiV5Services.Labels().ServerDelete(dcId, serverId, labelKey)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
+	_ = c.Printer.Print("Labels to be removed from Server with Id: " + serverId)
+	labels, resp, err := c.CloudApiV5Services.Labels().ServerList(dcId, serverId)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return c.Printer.Print(getLabelResourcePrint(c, nil))
+	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					_ = c.Printer.Print(" Label Key: " + *key)
+				}
+				if value, ok := properties.GetValueOk(); ok && value != nil {
+					_ = c.Printer.Print(" Label Value: " + *value)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Server with Id: "+serverId); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Deleting all the Labels from Server with Id: %v...", serverId)
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					c.Printer.Verbose("Starting deleting Label with id: %v...", *key)
+					resp, err = c.CloudApiV5Services.Labels().ServerDelete(dcId, serverId, *key)
+					if resp != nil {
+						c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+						c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+					}
+					if err != nil {
+						return nil, err
+					}
+					if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+						return nil, err
+					}
+				}
+
+			}
+		}
+	}
+	return resp, err
 }
 
 func RunVolumeLabelsList(c *core.CommandConfig) error {
@@ -170,18 +286,75 @@ func RunVolumeLabelAdd(c *core.CommandConfig) error {
 }
 
 func RunVolumeLabelRemove(c *core.CommandConfig) error {
-	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
-	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgVolumeId))
-	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
-	c.Printer.Verbose("Removing label with key: %v for Volume with id: %v...", labelKey, volumeId)
-	resp, err := c.CloudApiV5Services.Labels().VolumeDelete(dcId, volumeId, labelKey)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
-	if err != nil {
-		return err
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllVolumeLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+		volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgVolumeId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for Volume with id: %v...", labelKey, volumeId)
+		resp, err = c.CloudApiV5Services.Labels().VolumeDelete(dcId, volumeId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
+func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
+	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgVolumeId))
+	_ = c.Printer.Print("Labels to be removed from Volume with Id: " + volumeId)
+	labels, resp, err := c.CloudApiV5Services.Labels().VolumeList(dcId, volumeId)
+	if err != nil {
+		return nil, err
+	}
+	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					_ = c.Printer.Print(" Label Key: " + *key)
+				}
+				if value, ok := properties.GetValueOk(); ok && value != nil {
+					_ = c.Printer.Print(" Label Value: " + *value)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Volume with Id: "+volumeId); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Deleting all the Labels from Volume with Id: %v...", volumeId)
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					c.Printer.Verbose("Starting deleting Label with id: %v...", *key)
+					resp, err = c.CloudApiV5Services.Labels().VolumeDelete(dcId, volumeId, *key)
+					if resp != nil {
+						c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+						c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+					}
+					if err != nil {
+						return nil, err
+					}
+					if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+						return nil, err
+					}
+				}
+
+			}
+		}
+	}
+	return resp, err
 }
 
 func RunIpBlockLabelsList(c *core.CommandConfig) error {
@@ -229,17 +402,73 @@ func RunIpBlockLabelAdd(c *core.CommandConfig) error {
 }
 
 func RunIpBlockLabelRemove(c *core.CommandConfig) error {
-	ipBlockId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgIpBlockId))
-	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
-	c.Printer.Verbose("Removing label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId)
-	resp, err := c.CloudApiV5Services.Labels().IpBlockDelete(ipBlockId, labelKey)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
-	if err != nil {
-		return err
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllIpBlockLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		ipBlockId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgIpBlockId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId)
+		resp, err = c.CloudApiV5Services.Labels().IpBlockDelete(ipBlockId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
+func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) {
+	ipBlockId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgIpBlockId))
+	_ = c.Printer.Print("Labels to be removed from IpBlock with Id: " + ipBlockId)
+	labels, resp, err := c.CloudApiV5Services.Labels().IpBlockList(ipBlockId)
+	if err != nil {
+		return nil, err
+	}
+	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					_ = c.Printer.Print(" Label Key: " + *key)
+				}
+				if value, ok := properties.GetValueOk(); ok && value != nil {
+					_ = c.Printer.Print(" Label Value: " + *value)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from IpBlock with Id: "+ipBlockId); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Deleting all the Labels from IpBlock with Id: %v...", ipBlockId)
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					c.Printer.Verbose("Starting deleting Label with id: %v...", *key)
+					resp, err = c.CloudApiV5Services.Labels().IpBlockDelete(ipBlockId, *key)
+					if resp != nil {
+						c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+						c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+					}
+					if err != nil {
+						return nil, err
+					}
+					if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+						return nil, err
+					}
+				}
+
+			}
+		}
+	}
+	return resp, err
 }
 
 func RunSnapshotLabelsList(c *core.CommandConfig) error {
@@ -283,17 +512,73 @@ func RunSnapshotLabelAdd(c *core.CommandConfig) error {
 }
 
 func RunSnapshotLabelRemove(c *core.CommandConfig) error {
-	snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgSnapshotId))
-	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
-	c.Printer.Verbose("Removing label with key: %v for Snapshot with id: %v...", labelKey, snapshotId)
-	resp, err := c.CloudApiV5Services.Labels().SnapshotDelete(snapshotId, labelKey)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
-	if err != nil {
-		return err
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllSnapshotLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgSnapshotId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for Snapshot with id: %v...", labelKey, snapshotId)
+		resp, err = c.CloudApiV5Services.Labels().SnapshotDelete(snapshotId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
+func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error) {
+	snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgSnapshotId))
+	_ = c.Printer.Print("Labels to be removed from Snapshot with Id: " + snapshotId)
+	labels, resp, err := c.CloudApiV5Services.Labels().SnapshotList(snapshotId)
+	if err != nil {
+		return nil, err
+	}
+	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					_ = c.Printer.Print(" Label Key: " + *key)
+				}
+				if value, ok := properties.GetValueOk(); ok && value != nil {
+					_ = c.Printer.Print(" Label Value: " + *value)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Snapshot with Id: "+snapshotId); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Deleting all the Labels from Snapshot with Id: %v...", snapshotId)
+		for _, label := range *labelsItems {
+			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
+				if key, ok := properties.GetKeyOk(); ok && key != nil {
+					c.Printer.Verbose("Starting deleting Label with id: %v...", *key)
+					resp, err = c.CloudApiV5Services.Labels().SnapshotDelete(snapshotId, *key)
+					if resp != nil {
+						c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+						c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+					}
+					if err != nil {
+						return nil, err
+					}
+					if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+						return nil, err
+					}
+				}
+
+			}
+		}
+	}
+	return resp, err
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/labelresource_test.go
+++ b/commands/cloudapi-v5/labelresource_test.go
@@ -23,10 +23,26 @@ var (
 			Value: &testLabelResourceVar,
 		},
 	}
+	//testLabelResourceId = ionoscloud.LabelResource{
+	//	Id: &testLabelResourceVar,
+	//	Properties: &ionoscloud.LabelResourceProperties{
+	//		Key:   &testLabelResourceVar,
+	//		Value: &testLabelResourceVar,
+	//	},
+	//}
 	testLabelResources = resources.LabelResources{
 		LabelResources: ionoscloud.LabelResources{
 			Id:    &testLabelVar,
 			Items: &[]ionoscloud.LabelResource{testLabelResource},
+		},
+	}
+	testLabelResourcesList = resources.LabelResources{
+		LabelResources: ionoscloud.LabelResources{
+			Id: &testLabelVar,
+			Items: &[]ionoscloud.LabelResource{
+				testLabelResource,
+				testLabelResource,
+			},
 		},
 	}
 	testLabelResourceRes = resources.LabelResource{LabelResource: testLabelResource}
@@ -137,6 +153,26 @@ func TestRunDatacenterLabelRemove(t *testing.T) {
 		viper.Set(config.ArgVerbose, true)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
+		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		err := RunDataCenterLabelRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunDatacenterLabelRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
+		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterList(testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		err := RunDataCenterLabelRemove(cfg)
 		assert.NoError(t, err)
@@ -267,6 +303,25 @@ func TestRunIpBlockLabelRemove(t *testing.T) {
 	})
 }
 
+func TestRunIpBlockLabelRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgIpBlockId), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Label.EXPECT().IpBlockList(testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		err := RunIpBlockLabelRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
 func TestRunIpBlockLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -385,6 +440,25 @@ func TestRunSnapshotLabelRemove(t *testing.T) {
 		viper.Set(config.ArgVerbose, true)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgSnapshotId), testLabelResourceVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
+		rm.CloudApiV5Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		err := RunSnapshotLabelRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunSnapshotLabelRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgSnapshotId), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Label.EXPECT().SnapshotList(testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		rm.CloudApiV5Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		err := RunSnapshotLabelRemove(cfg)
 		assert.NoError(t, err)
@@ -523,6 +597,27 @@ func TestRunServerLabelRemove(t *testing.T) {
 	})
 }
 
+func TestRunServerLabelRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testLabelResourceVar)
+		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Label.EXPECT().ServerList(testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		err := RunServerLabelRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
 func TestRunServerLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -650,6 +745,26 @@ func TestRunVolumeLabelRemove(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgVolumeId), testLabelResourceVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
+		rm.CloudApiV5Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
+		err := RunVolumeLabelRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunVolumeLabelRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgVolumeId), testLabelResourceVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Label.EXPECT().VolumeList(testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		rm.CloudApiV5Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
 		err := RunVolumeLabelRemove(cfg)
 		assert.NoError(t, err)

--- a/commands/cloudapi-v5/labelresource_test.go
+++ b/commands/cloudapi-v5/labelresource_test.go
@@ -162,7 +162,6 @@ func TestRunDatacenterLabelRemoveAll(t *testing.T) {
 		viper.Set(config.ArgVerbose, true)
 		viper.Set(config.ArgForce, true)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLabelResourceVar)
-		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLabelKey), testLabelResourceVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
 		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterList(testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
 		rm.CloudApiV5Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)

--- a/commands/cloudapi-v5/labelresource_test.go
+++ b/commands/cloudapi-v5/labelresource_test.go
@@ -23,13 +23,6 @@ var (
 			Value: &testLabelResourceVar,
 		},
 	}
-	//testLabelResourceId = ionoscloud.LabelResource{
-	//	Id: &testLabelResourceVar,
-	//	Properties: &ionoscloud.LabelResourceProperties{
-	//		Key:   &testLabelResourceVar,
-	//		Value: &testLabelResourceVar,
-	//	},
-	//}
 	testLabelResources = resources.LabelResources{
 		LabelResources: ionoscloud.LabelResources{
 			Id:    &testLabelVar,

--- a/commands/cloudapi-v5/lan.go
+++ b/commands/cloudapi-v5/lan.go
@@ -380,7 +380,7 @@ func DeleteAllLans(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/loadbalancer.go
+++ b/commands/cloudapi-v5/loadbalancer.go
@@ -359,7 +359,7 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) (*resources.Response, error) 
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/nic.go
+++ b/commands/cloudapi-v5/nic.go
@@ -414,7 +414,7 @@ func DeleteAllNics(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // LoadBalancer Nic Commands
@@ -722,7 +722,7 @@ func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/nic.go
+++ b/commands/cloudapi-v5/nic.go
@@ -560,7 +560,7 @@ Required values to run command:
 * Load Balancer Id
 * NIC Id`,
 		Example:    detachNicLoadbalancerExample,
-		PreCmdRun:  PreRunDcNicLoadBalancerIds,
+		PreCmdRun:  PreRunNicDetach,
 		CmdRun:     RunLoadBalancerNicDetach,
 		InitClient: true,
 	})
@@ -582,12 +582,20 @@ Required values to run command:
 	})
 	detachNic.AddBoolFlag(config.ArgWaitForRequest, config.ArgWaitForRequestShort, config.DefaultWait, "Wait for the Request for NIC detachment to be executed")
 	detachNic.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, config.DefaultTimeoutSeconds, "Timeout option for Request for NIC detachment [seconds]")
+	detachNic.AddBoolFlag(cloudapiv5.ArgAll, cloudapiv5.ArgAllShort, false, "Detach all Nics.")
 
 	return loadbalancerNicCmd
 }
 
 func PreRunDcNicLoadBalancerIds(c *core.PreCommandConfig) error {
 	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgNicId, cloudapiv5.ArgLoadBalancerId)
+}
+
+func PreRunNicDetach(c *core.PreCommandConfig) error {
+	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+		[]string{cloudapiv5.ArgDataCenterId, cloudapiv5.ArgNicId, cloudapiv5.ArgLoadBalancerId},
+		[]string{cloudapiv5.ArgDataCenterId, cloudapiv5.ArgNicId, cloudapiv5.ArgAll},
+	)
 }
 
 func RunLoadBalancerNicAttach(c *core.CommandConfig) error {
@@ -641,26 +649,80 @@ func RunLoadBalancerNicGet(c *core.CommandConfig) error {
 }
 
 func RunLoadBalancerNicDetach(c *core.CommandConfig) error {
-	if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach nic from loadbalancer"); err != nil {
-		return err
-	}
-	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
-	lbId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLoadBalancerId))
-	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgNicId))
-	c.Printer.Verbose("Datacenter ID: %v", dcId)
-	c.Printer.Verbose("Detaching NIC with ID: %v from LoadBalancer with ID: %v", nicId, lbId)
-	resp, err := c.CloudApiV5Services.Loadbalancers().DetachNic(dcId, lbId, nicId)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
-	if err != nil {
-		return err
-	}
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = DetachAllNics(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach nic from loadbalancer"); err != nil {
+			return err
+		}
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+		lbId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLoadBalancerId))
+		nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgNicId))
+		c.Printer.Verbose("Datacenter ID: %v", dcId)
+		c.Printer.Verbose("Detaching NIC with ID: %v from LoadBalancer with ID: %v", nicId, lbId)
+		resp, err := c.CloudApiV5Services.Loadbalancers().DetachNic(dcId, lbId, nicId)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 
-	if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
-		return err
+		if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getNicPrint(resp, c, nil))
+}
+
+func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
+	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+	lbId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgLoadBalancerId))
+	_ = c.Printer.Print("Nics to be detached:")
+	nics, resp, err := c.CloudApiV5Services.Loadbalancers().ListNics(dcId, lbId)
+	if err != nil {
+		return nil, err
+	}
+	if nicsItems, ok := nics.GetItemsOk(); ok && nicsItems != nil {
+		for _, nic := range *nicsItems {
+			if id, ok := nic.GetIdOk(); ok && id != nil {
+				_ = c.Printer.Print("Nic Id: " + *id)
+			}
+			if properties, ok := nic.GetPropertiesOk(); ok && properties != nil {
+				if name, ok := properties.GetNameOk(); ok && name != nil {
+					_ = c.Printer.Print(" Nic Name: " + *name)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the Nics"); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Detaching all the Nics...")
+		for _, nic := range *nicsItems {
+			if id, ok := nic.GetIdOk(); ok && id != nil {
+				c.Printer.Verbose("Starting detaching Nic with id: %v...", *id)
+				resp, err = c.CloudApiV5Services.Loadbalancers().DetachNic(dcId, lbId, *id)
+				if resp != nil {
+					c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+					c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+				}
+				if err != nil {
+					return nil, err
+				}
+				if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return resp, err
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/nic_test.go
+++ b/commands/cloudapi-v5/nic_test.go
@@ -638,7 +638,6 @@ func TestRunLoadBalancerNicDetachAll(t *testing.T) {
 		viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testLoadbalancerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgLoadBalancerId), testLoadbalancerVar)
-		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgNicId), testLoadbalancerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
 		rm.CloudApiV5Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar).Return(balancednsList, nil, nil)

--- a/commands/cloudapi-v5/pcc.go
+++ b/commands/cloudapi-v5/pcc.go
@@ -305,7 +305,7 @@ func DeleteAllPccs(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func getPccInfo(oldUser *resources.PrivateCrossConnect, c *core.CommandConfig) *resources.PrivateCrossConnectProperties {

--- a/commands/cloudapi-v5/s3key.go
+++ b/commands/cloudapi-v5/s3key.go
@@ -328,7 +328,7 @@ func DeleteAllS3Keys(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/server.go
+++ b/commands/cloudapi-v5/server.go
@@ -687,7 +687,7 @@ func DeleteAllServers(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/share.go
+++ b/commands/cloudapi-v5/share.go
@@ -382,7 +382,7 @@ func DeleteAllShares(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/snapshot.go
+++ b/commands/cloudapi-v5/snapshot.go
@@ -456,7 +456,7 @@ func DeleteAllSnapshots(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/user.go
+++ b/commands/cloudapi-v5/user.go
@@ -538,7 +538,7 @@ func RunGroupUserRemove(c *core.CommandConfig) error {
 		}
 		id := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgUserId))
 		groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgGroupId))
-		c.Printer.Verbose("Adding User with id: %v to group with id: %v...", id, groupId)
+		c.Printer.Verbose("Removing User with id: %v to group with id: %v...", id, groupId)
 		resp, err := c.CloudApiV5Services.Groups().RemoveUser(groupId, id)
 		if resp != nil {
 			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)

--- a/commands/cloudapi-v5/user.go
+++ b/commands/cloudapi-v5/user.go
@@ -387,7 +387,7 @@ func DeleteAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 func GroupUserCmd() *core.Command {
@@ -593,7 +593,7 @@ func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/user.go
+++ b/commands/cloudapi-v5/user.go
@@ -465,7 +465,7 @@ func GroupUserCmd() *core.Command {
 		ShortDesc:  "Remove User from a Group",
 		LongDesc:   "Use this command to remove a User from a Group.\n\nRequired values to run command:\n\n* Group Id\n* User Id",
 		Example:    removeGroupUserExample,
-		PreCmdRun:  PreRunGroupUserIds,
+		PreCmdRun:  PreRunGroupUserRemove,
 		CmdRun:     RunGroupUserRemove,
 		InitClient: true,
 	})
@@ -481,8 +481,16 @@ func GroupUserCmd() *core.Command {
 	_ = removeUser.Command.RegisterFlagCompletionFunc(cloudapiv5.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupUsersIds(os.Stderr, viper.GetString(core.GetFlagName(removeUser.NS, cloudapiv5.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	removeUser.AddBoolFlag(cloudapiv5.ArgAll, cloudapiv5.ArgAllShort, false, "Remove all Users fro a group.")
 
 	return groupUserCmd
+}
+
+func PreRunGroupUserRemove(c *core.PreCommandConfig) error {
+	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+		[]string{cloudapiv5.ArgGroupId, cloudapiv5.ArgUserId},
+		[]string{cloudapiv5.ArgGroupId, cloudapiv5.ArgAll},
+	)
 }
 
 func RunGroupUserList(c *core.CommandConfig) error {
@@ -516,20 +524,76 @@ func RunGroupUserAdd(c *core.CommandConfig) error {
 }
 
 func RunGroupUserRemove(c *core.CommandConfig) error {
-	if err := utils.AskForConfirm(c.Stdin, c.Printer, "remove user from group"); err != nil {
-		return err
-	}
-	id := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgUserId))
-	groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgGroupId))
-	c.Printer.Verbose("Adding User with id: %v to group with id: %v...", id, groupId)
-	resp, err := c.CloudApiV5Services.Groups().RemoveUser(groupId, id)
-	if resp != nil {
-		c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
-	}
-	if err != nil {
-		return err
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllUsers(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "remove user from group"); err != nil {
+			return err
+		}
+		id := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgUserId))
+		groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgGroupId))
+		c.Printer.Verbose("Adding User with id: %v to group with id: %v...", id, groupId)
+		resp, err := c.CloudApiV5Services.Groups().RemoveUser(groupId, id)
+		if resp != nil {
+			c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getGroupPrint(resp, c, nil))
+}
+
+func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
+	groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgGroupId))
+	_ = c.Printer.Print("Users to be removed from Group with id: " + groupId)
+	users, resp, err := c.CloudApiV5Services.Groups().ListUsers(groupId)
+	if err != nil {
+		return nil, err
+	}
+	if usersItems, ok := users.GetItemsOk(); ok && usersItems != nil {
+		for _, user := range *usersItems {
+			if id, ok := user.GetIdOk(); ok && id != nil {
+				_ = c.Printer.Print("User Id: " + *id)
+			}
+			if properties, ok := user.GetPropertiesOk(); ok && properties != nil {
+				if firstName, ok := properties.GetFirstnameOk(); ok && firstName != nil {
+					_ = c.Printer.Print(" User Name: " + *firstName)
+				}
+				if lastName, ok := properties.GetLastnameOk(); ok && lastName != nil {
+					_ = c.Printer.Print(" User Name: " + *lastName)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "removing all the Users"); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Removing all the Users from Group with id: %v...", groupId)
+		for _, user := range *usersItems {
+			if id, ok := user.GetIdOk(); ok && id != nil {
+				c.Printer.Verbose("Starting removing User with id: %v...", *id)
+				resp, err = c.CloudApiV5Services.Groups().RemoveUser(groupId, *id)
+				if resp != nil {
+					c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+					c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+				}
+				if err != nil {
+					return nil, err
+				}
+				if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return resp, err
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/user_test.go
+++ b/commands/cloudapi-v5/user_test.go
@@ -445,6 +445,14 @@ var (
 			Items: &[]ionoscloud.User{userTestGet.User},
 		},
 	}
+	groupUsersTestList = resources.GroupMembers{
+		GroupMembers: ionoscloud.GroupMembers{
+			Items: &[]ionoscloud.User{
+				userTestGet.User,
+				userTestGet.User,
+			},
+		},
+	}
 	groupUserTest = resources.User{
 		User: ionoscloud.User{
 			Id: &testUserVar,
@@ -543,6 +551,26 @@ func TestRunGroupUserRemove(t *testing.T) {
 		viper.Set(config.ArgVerbose, true)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgGroupId), testGroupVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgUserId), testUserVar)
+		rm.CloudApiV5Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar).Return(&testResponse, nil)
+		err := RunGroupUserRemove(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunGroupUserRemoveAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgForce, true)
+		viper.Set(config.ArgVerbose, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgGroupId), testGroupVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		rm.CloudApiV5Mocks.Group.EXPECT().ListUsers(testGroupVar).Return(groupUsersTestList, &testResponse, nil)
+		rm.CloudApiV5Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar).Return(&testResponse, nil)
 		rm.CloudApiV5Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar).Return(&testResponse, nil)
 		err := RunGroupUserRemove(cfg)
 		assert.NoError(t, err)

--- a/commands/cloudapi-v5/volume.go
+++ b/commands/cloudapi-v5/volume.go
@@ -574,7 +574,7 @@ func DeleteAllVolumes(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Server Volume Commands
@@ -864,7 +864,7 @@ func DetachAllServers(c *core.CommandConfig) (*resources.Response, error) {
 			}
 		}
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/volume.go
+++ b/commands/cloudapi-v5/volume.go
@@ -712,7 +712,7 @@ Required values to run command:
 * Server Id
 * Volume Id`,
 		Example:    detachVolumeServerExample,
-		PreCmdRun:  PreRunDcServerVolumeIds,
+		PreCmdRun:  PreRunDcServerVolumeDetach,
 		CmdRun:     RunServerVolumeDetach,
 		InitClient: true,
 	})
@@ -735,12 +735,20 @@ Required values to run command:
 	})
 	detachVolume.AddBoolFlag(config.ArgWaitForRequest, config.ArgWaitForRequestShort, config.DefaultWait, "Wait for the Request for Volume detachment to be executed")
 	detachVolume.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, config.DefaultTimeoutSeconds, "Timeout option for Request for Volume detachment [seconds]")
+	detachVolume.AddBoolFlag(cloudapiv5.ArgAll, cloudapiv5.ArgAllShort, false, "Detach all Volumes.")
 
 	return serverVolumeCmd
 }
 
 func PreRunDcServerVolumeIds(c *core.PreCommandConfig) error {
 	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgVolumeId)
+}
+
+func PreRunDcServerVolumeDetach(c *core.PreCommandConfig) error {
+	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+		[]string{cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgVolumeId},
+		[]string{cloudapiv5.ArgDataCenterId, cloudapiv5.ArgServerId, cloudapiv5.ArgAll},
+	)
 }
 
 func RunServerVolumeAttach(c *core.CommandConfig) error {
@@ -786,23 +794,77 @@ func RunServerVolumeGet(c *core.CommandConfig) error {
 }
 
 func RunServerVolumeDetach(c *core.CommandConfig) error {
-	if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach volume from server"); err != nil {
-		return err
-	}
-	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
-	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgServerId))
-	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgVolumeId))
-	c.Printer.Verbose("Datacenter ID: %v", dcId)
-	c.Printer.Verbose("Detaching Volume with ID: %v from Server with ID: %v...", volumeId, serverId)
-	resp, err := c.CloudApiV5Services.Servers().DetachVolume(dcId, serverId, volumeId)
-	if err != nil {
-		return err
-	}
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv5.ArgAll))
+	if allFlag {
+		resp, err = DetachAllServers(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach volume from server"); err != nil {
+			return err
+		}
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+		serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgServerId))
+		volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgVolumeId))
+		c.Printer.Verbose("Datacenter ID: %v", dcId)
+		c.Printer.Verbose("Detaching Volume with ID: %v from Server with ID: %v...", volumeId, serverId)
+		resp, err := c.CloudApiV5Services.Servers().DetachVolume(dcId, serverId, volumeId)
+		if err != nil {
+			return err
+		}
 
-	if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
-		return err
+		if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+			return err
+		}
 	}
 	return c.Printer.Print(getVolumePrint(resp, c, nil))
+}
+
+func DetachAllServers(c *core.CommandConfig) (*resources.Response, error) {
+	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgDataCenterId))
+	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv5.ArgServerId))
+	_ = c.Printer.Print("Volumes to be detached:")
+	volumes, resp, err := c.CloudApiV5Services.Servers().ListVolumes(dcId, serverId)
+	if err != nil {
+		return nil, err
+	}
+	if volumesItems, ok := volumes.GetItemsOk(); ok && volumesItems != nil {
+		for _, volume := range *volumesItems {
+			if id, ok := volume.GetIdOk(); ok && id != nil {
+				_ = c.Printer.Print("Volume Id: " + *id)
+			}
+			if properties, ok := volume.GetPropertiesOk(); ok && properties != nil {
+				if name, ok := properties.GetNameOk(); ok && name != nil {
+					_ = c.Printer.Print(" Volume Name: " + *name)
+				}
+			}
+		}
+
+		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the Volumes"); err != nil {
+			return nil, err
+		}
+		c.Printer.Verbose("Detaching all the Volumes...")
+		for _, volume := range *volumesItems {
+			if id, ok := volume.GetIdOk(); ok && id != nil {
+				c.Printer.Verbose("Starting detaching Volume with id: %v...", *id)
+				resp, err = c.CloudApiV5Services.Servers().DetachVolume(dcId, serverId, *id)
+				if resp != nil {
+					c.Printer.Verbose("Request Id: %v", printer.GetId(resp))
+					c.Printer.Verbose(config.RequestTimeMessage, resp.RequestTime)
+				}
+				if err != nil {
+					return nil, err
+				}
+				if err = utils.WaitForRequest(c, waiter.RequestInterrogator, printer.GetId(resp)); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return resp, err
 }
 
 // Output Printing

--- a/commands/cloudapi-v5/volume_test.go
+++ b/commands/cloudapi-v5/volume_test.go
@@ -890,7 +890,6 @@ func TestRunServerVolumeDetachAll(t *testing.T) {
 		viper.Set(config.ArgForce, true)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testServerVar)
-		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgVolumeId), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
 		rm.CloudApiV5Mocks.Server.EXPECT().ListVolumes(testServerVar, testServerVar).Return(vsAttachedList, nil, nil)

--- a/commands/cloudapi-v5/volume_test.go
+++ b/commands/cloudapi-v5/volume_test.go
@@ -46,6 +46,30 @@ var (
 			State: &testVolumeVar,
 		},
 	}
+	serverVolume = ionoscloud.Volume{
+		Id: &testServerVar,
+		Properties: &ionoscloud.VolumeProperties{
+			Name:                &testVolumeVar,
+			Size:                &sizeVolume,
+			LicenceType:         &testVolumeVar,
+			Type:                &testVolumeVar,
+			Bus:                 &testVolumeVar,
+			Image:               &testVolumeVar,
+			ImageAlias:          &testVolumeVar,
+			AvailabilityZone:    &zoneVolume,
+			BackupunitId:        &testVolumeVar,
+			UserData:            &testVolumeVar,
+			CpuHotPlug:          &testVolumeBoolVar,
+			RamHotPlug:          &testVolumeBoolVar,
+			NicHotPlug:          &testVolumeBoolVar,
+			NicHotUnplug:        &testVolumeBoolVar,
+			DiscVirtioHotPlug:   &testVolumeBoolVar,
+			DiscVirtioHotUnplug: &testVolumeBoolVar,
+		},
+		Metadata: &ionoscloud.DatacenterElementMetadata{
+			State: &testVolumeVar,
+		},
+	}
 	testVolume = resources.Volume{
 		Volume: ionoscloud.Volume{
 			Properties: &ionoscloud.VolumeProperties{
@@ -139,6 +163,12 @@ var (
 		AttachedVolumes: ionoscloud.AttachedVolumes{
 			Id:    &testVolumeVar,
 			Items: &[]ionoscloud.Volume{v},
+		},
+	}
+	vsAttachedList = resources.AttachedVolumes{
+		AttachedVolumes: ionoscloud.AttachedVolumes{
+			Id:    &testVolumeVar,
+			Items: &[]ionoscloud.Volume{serverVolume, serverVolume},
 		},
 	}
 	testVolumeVar      = "test-volume"
@@ -849,6 +879,28 @@ func TestRunServerVolumeDetach(t *testing.T) {
 	})
 }
 
+func TestRunServerVolumeDetachAll(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(config.ArgForce, true)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgDataCenterId), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testServerVar)
+		//viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgVolumeId), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgAll), true)
+		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
+		rm.CloudApiV5Mocks.Server.EXPECT().ListVolumes(testServerVar, testServerVar).Return(vsAttachedList, nil, nil)
+		rm.CloudApiV5Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar).Return(&testResponse, nil)
+		rm.CloudApiV5Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar).Return(&testResponse, nil)
+		err := RunServerVolumeDetach(cfg)
+		assert.NoError(t, err)
+	})
+}
+
 func TestRunServerVolumeDetachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -862,7 +914,7 @@ func TestRunServerVolumeDetachErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgServerId), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv5.ArgVolumeId), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, config.ArgWaitForRequest), false)
-		rm.CloudApiV5Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar).Return(&testResponseErr, nil)
+		rm.CloudApiV5Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar).Return(nil, testVolumeErr)
 		err := RunServerVolumeDetach(cfg)
 		assert.Error(t, err)
 	})

--- a/docs/subcommands/group-user-remove.md
+++ b/docs/subcommands/group-user-remove.md
@@ -42,6 +42,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all               Remove all Users fro a group.
   -u, --api-url string    Override default host url (default "https://api.ionos.com")
       --cols strings      Set of columns to be printed on output 
                           Available columns: [UserId Firstname Lastname Email S3CanonicalUserId Administrator ForceSecAuth SecAuthActive Active] (default [UserId,Firstname,Lastname,Email,S3CanonicalUserId,Administrator,ForceSecAuth,SecAuthActive,Active])

--- a/docs/subcommands/ipfailover-remove.md
+++ b/docs/subcommands/ipfailover-remove.md
@@ -39,6 +39,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all                    Remove all IP Failovers.
   -u, --api-url string         Override default host url (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [NicId Ip] (default [NicId,Ip])

--- a/docs/subcommands/label-remove.md
+++ b/docs/subcommands/label-remove.md
@@ -31,6 +31,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all                    Remove all Labels.
   -u, --api-url string         Override default host url (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [Key Value] (default [Key,Value])

--- a/docs/subcommands/loadbalancer-nic-detach.md
+++ b/docs/subcommands/loadbalancer-nic-detach.md
@@ -45,6 +45,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all                      Detach all Nics.
   -u, --api-url string           Override default host url (default "https://api.ionos.com")
       --cols strings             Set of columns to be printed on output 
                                  Available columns: [NicId Name Dhcp LanId Ips State FirewallActive Mac] (default [NicId,Name,Dhcp,LanId,Ips,State])

--- a/docs/subcommands/server-cdrom-detach.md
+++ b/docs/subcommands/server-cdrom-detach.md
@@ -45,6 +45,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all                    Detach all BackupUnits.
   -u, --api-url string         Override default host url (default "https://api.ionos.com")
   -i, --cdrom-id string        The unique Cdrom Id (required)
       --cols strings           Set of columns to be printed on output 

--- a/docs/subcommands/server-volume-detach.md
+++ b/docs/subcommands/server-volume-detach.md
@@ -45,6 +45,7 @@ Required values to run command:
 ## Options
 
 ```text
+  -a, --all                    Detach all Volumes.
   -u, --api-url string         Override default host url (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [VolumeId Name Size Type LicenceType State Image Bus AvailabilityZone BackupunitId ImageAlias DeviceNumber UserData] (default [VolumeId,Name,Size,Type,LicenceType,State,Image])


### PR DESCRIPTION
## What does this fix or implement?
implemented --all flag for detach and remove commands

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
like --all flag for delete command, for every resource that has the detach or remove command, it will detach or remove all the resources associated to another resource or in data center case, all the data centers from a account

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR Title containing `Feat`/`Fix`/`Doc`
- [x] Tests added or updated
- [x] Documentation updated
- [x] SONAR Cloud Scan - warnings checked
- [x] Task updated (Jira/Github)
