### PR TITLE
Feat: Add completion for k8s-version flag

### DIFF
--- a/commands/cloudapi-v6/completer/versions.go
+++ b/commands/cloudapi-v6/completer/versions.go
@@ -1,0 +1,33 @@
+package completer
+
+import (
+	"context"
+	"io"
+
+	"github.com/ionos-cloud/ionosctl/internal/utils/clierror"
+	"github.com/ionos-cloud/ionosctl/services/cloudapi-v6/resources"
+)
+
+func K8sClusterUpgradeVersions(outErr io.Writer, clusterId string) []string {
+	client, err := getClient()
+	clierror.CheckError(err, outErr)
+	k8sSvc := resources.NewK8sService(client, context.Background())
+	cluster, _, err := k8sSvc.GetCluster(clusterId)
+	clierror.CheckError(err, outErr)
+	if cluster.Properties == nil || cluster.Properties.AvailableUpgradeVersions == nil {
+		return nil
+	}
+	return *cluster.Properties.AvailableUpgradeVersions
+}
+
+func K8sNodePoolUpgradeVersions(outErr io.Writer, clusterId, nodepoolId string) []string {
+	client, err := getClient()
+	clierror.CheckError(err, outErr)
+	k8sSvc := resources.NewK8sService(client, context.Background())
+	nodepool, _, err := k8sSvc.GetNodePool(clusterId, nodepoolId)
+	clierror.CheckError(err, outErr)
+	if nodepool.Properties == nil || nodepool.Properties.AvailableUpgradeVersions == nil {
+		return nil
+	}
+	return *nodepool.Properties.AvailableUpgradeVersions
+}

--- a/commands/cloudapi-v6/completer/versions_test.go
+++ b/commands/cloudapi-v6/completer/versions_test.go
@@ -1,0 +1,42 @@
+package completer
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/ionos-cloud/ionosctl/internal/config"
+	"github.com/ionos-cloud/ionosctl/internal/utils/clierror"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestK8sClusterUpgradeVersions(t *testing.T) {
+	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
+	clierror.ErrAction = func() { return }
+	assert.NoError(t, os.Setenv(ionoscloud.IonosUsernameEnvVar, "user"))
+	assert.NoError(t, os.Setenv(ionoscloud.IonosPasswordEnvVar, "pass"))
+	assert.NoError(t, os.Setenv(ionoscloud.IonosTokenEnvVar, "tok"))
+	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+	viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+
+	buf := new(bytes.Buffer)
+	K8sClusterUpgradeVersions(buf, "123")
+	assert.True(t, regexp.MustCompile(`401 Unauthorized`).Match(buf.Bytes()))
+}
+
+func TestK8sNodePoolUpgradeVersions(t *testing.T) {
+	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
+	clierror.ErrAction = func() { return }
+	assert.NoError(t, os.Setenv(ionoscloud.IonosUsernameEnvVar, "user"))
+	assert.NoError(t, os.Setenv(ionoscloud.IonosPasswordEnvVar, "pass"))
+	assert.NoError(t, os.Setenv(ionoscloud.IonosTokenEnvVar, "tok"))
+	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+	viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+
+	buf := new(bytes.Buffer)
+	K8sNodePoolUpgradeVersions(buf, "123", "456")
+	assert.True(t, regexp.MustCompile(`401 Unauthorized`).Match(buf.Bytes()))
+}

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -144,6 +144,11 @@ Required values to run command:
 	})
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the K8s Cluster")
 	update.AddStringFlag(cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the Cluster")
+	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sVersion,
+		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			clusterId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgK8sClusterId))
+			return completer.K8sClusterUpgradeVersions(os.Stderr, clusterId), cobra.ShellCompDirectiveNoFileComp
+		})
 	update.AddStringFlag(cloudapiv6.ArgS3Bucket, "", "", "S3 Bucket name configured for K8s usage. It will overwrite the previous value")
 	update.AddStringSliceFlag(cloudapiv6.ArgApiSubnets, "", []string{""}, "Access to the K8s API server is restricted to these CIDRs. Cluster-internal traffic is not affected by this restriction. If no allowlist is specified, access is not restricted. If an IP without subnet mask is provided, the default value will be used: 32 for IPv4 and 128 for IPv6. This will overwrite the existing ones")
 	update.AddStringFlag(cloudapiv6.ArgK8sMaintenanceDay, "", "", "The day of the week for Maintenance Window has the English day format as following: Monday or Saturday")

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -176,6 +176,12 @@ Required values to run command:
 		InitClient: true,
 	})
 	update.AddStringFlag(cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the NodePool. K8s version downgrade is not supported")
+	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sVersion,
+		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			clusterId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgK8sClusterId))
+			nodepoolId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgK8sNodePoolId))
+			return completer.K8sNodePoolUpgradeVersions(os.Stderr, clusterId, nodepoolId), cobra.ShellCompDirectiveNoFileComp
+		})
 	update.AddIntFlag(cloudapiv6.ArgK8sNodeCount, "", 1, "The number of worker Nodes that the NodePool should contain")
 	update.AddIntFlag(cloudapiv6.ArgK8sMinNodeCount, "", 1, "The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count")
 	update.AddIntFlag(cloudapiv6.ArgK8sMaxNodeCount, "", 1, "The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count")


### PR DESCRIPTION
## What does this fix or implement?

Completion for the `--k8s-version` flag when updating a cluster or node pool. Requires necessary ID flags to be set, i.e. `--cluster-id` for clusters and `--nodepool-id` for node pools.
The completion is based on the `availableUpgradeVersions` property.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR Title containing `Feat`/`Fix`/`Doc`
- [x] Tests added or updated
- [ ] Documentation updated
- [ ] SONAR Cloud Scan - warnings checked
- [ ] Task updated (Jira/Github)
