### PR TITLE
feat: add user agent [v6]

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const CLIVersionDev = "DEV"
+
 var (
 	// RootCmd is the root level command that all other commands attach to
 	rootCmd = &core.Command{
@@ -75,6 +77,11 @@ func init() {
 	// Init version
 	initVersion()
 	rootCmd.Command.Version = IonosctlVersion.GetVersion()
+	if rootCmd.Command.Version != CLIVersionDev {
+		viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/v%v", IonosctlVersion.GetVersion()))
+	} else {
+		viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", IonosctlVersion.GetVersion()))
+	}
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -135,7 +142,7 @@ func initVersion() {
 		IonosctlVersion.version = Version
 	}
 	if Label == "" {
-		IonosctlVersion.label = "DEV"
+		IonosctlVersion.label = CLIVersionDev
 	} else {
 		IonosctlVersion.label = Label
 	}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -33,8 +33,9 @@ const (
 	DefaultWait           = false
 	DefaultTimeoutSeconds = int(60)
 
-	Username  = "userdata.name"
-	Password  = "userdata.password"
-	Token     = "userdata.token"
-	ServerUrl = "userdata.api-url"
+	Username         = "userdata.name"
+	Password         = "userdata.password"
+	Token            = "userdata.token"
+	ServerUrl        = "userdata.api-url"
+	CLIHttpUserAgent = "cli-user-agent"
 )

--- a/services/auth-v1/resources/client.go
+++ b/services/auth-v1/resources/client.go
@@ -2,8 +2,11 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/ionos-cloud/ionosctl/internal/config"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
+	"github.com/spf13/viper"
 )
 
 type Client struct {
@@ -31,6 +34,7 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 		return nil, errors.New("username, password or token incorrect")
 	}
 	clientConfig := sdkgoauth.NewConfiguration(name, pwd, token, hostUrl)
+	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(config.CLIHttpUserAgent), clientConfig.UserAgent)
 	return &clientService{
 		client: sdkgoauth.NewAPIClient(clientConfig),
 	}, nil

--- a/services/cloudapi-v6/resources/client.go
+++ b/services/cloudapi-v6/resources/client.go
@@ -2,8 +2,11 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/ionos-cloud/ionosctl/internal/config"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/spf13/viper"
 )
 
 type Client struct {
@@ -31,6 +34,7 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 		return nil, errors.New("username, password or token incorrect")
 	}
 	clientConfig := ionoscloud.NewConfiguration(name, pwd, token, hostUrl)
+	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(config.CLIHttpUserAgent), clientConfig.UserAgent)
 	return &clientService{
 		client: ionoscloud.NewAPIClient(clientConfig),
 	}, nil


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Add user agent for each client in CLI. The http user agent has the following format: 
`ionosctl/v<version>_<user-agent-sdk>`

for internal testing of the CLI it will be:
`ionosctl/DEV_<user-agent-sdk>`

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
