### PR TITLE
fix: improve verbose print when delete/detach/remove --all

### DIFF
--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -362,14 +362,16 @@ func DeleteAllBackupUnits(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if backupUnitsItems, ok := backupUnits.GetItemsOk(); ok && backupUnitsItems != nil {
 		for _, backupUnit := range *backupUnitsItems {
+			toPrint := ""
 			if id, ok := backupUnit.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("BackupUnit Id: " + *id)
+				toPrint += "BackupUnit Id: " + *id
 			}
 			if properties, ok := backupUnit.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("BackupUnit Name: " + *name)
+					toPrint += " BackupUnit Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Backup Units"); err != nil {
@@ -391,6 +393,7 @@ func DeleteAllBackupUnits(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -302,15 +302,17 @@ func DetachAllCdRoms(c *core.CommandConfig) (*resources.Response, error) {
 		return nil, err
 	}
 	if cdRomsItems, ok := cdRoms.GetItemsOk(); ok && cdRomsItems != nil {
+		toPrint := ""
 		for _, cdRom := range *cdRomsItems {
 			if id, ok := cdRom.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("CD-ROM Id: " + *id)
+				toPrint += "CD-ROM Id: " + *id
 			}
 			if properties, ok := cdRom.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" CD-ROM Name: " + *name)
+					toPrint += " CD-ROM Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the CD-ROMS"); err != nil {
@@ -332,6 +334,7 @@ func DetachAllCdRoms(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -313,14 +313,16 @@ func DeleteAllDatacenters(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if datacentersItems, ok := datacenters.GetItemsOk(); ok && datacentersItems != nil {
 		for _, dc := range *datacentersItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Datacenter Id: " + *id)
+				toPrint += "Datacenter Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Datacenter Name: " + *name)
+					toPrint += " Datacenter Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Datacenters"); err != nil {
 			return nil, err
@@ -342,6 +344,7 @@ func DeleteAllDatacenters(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -517,14 +517,16 @@ func DeleteAllFirewallRuses(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if firewallrulestems, ok := firewallrules.GetItemsOk(); ok && firewallrulestems != nil {
 		for _, firewall := range *firewallrulestems {
+			toPrint := ""
 			if id, ok := firewall.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Firewallrule Id: " + *id)
+				toPrint += "Firewallrule Id: " + *id
 			}
 			if properties, ok := firewall.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Firewallrule Name: " + *name)
+					toPrint += " Firewallrule Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Firewallrules"); err != nil {
@@ -546,6 +548,7 @@ func DeleteAllFirewallRuses(c *core.CommandConfig) (*resources.Response, error) 
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -399,14 +399,16 @@ func DeleteAllFlowlogs(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if flowlogsItems, ok := flowlogs.GetItemsOk(); ok && flowlogsItems != nil {
 		for _, backupUnit := range *flowlogsItems {
+			toPrint := ""
 			if id, ok := backupUnit.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Flowlog Id: " + *id)
+				toPrint += "Flowlog Id: " + *id
 			}
 			if properties, ok := backupUnit.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Flowlog Name: " + *name)
+					toPrint += " Flowlog Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the flow log"); err != nil {
@@ -428,6 +430,7 @@ func DeleteAllFlowlogs(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -492,14 +492,16 @@ func DeleteAllGroups(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if groupsItems, ok := groups.GetItemsOk(); ok && groupsItems != nil {
 		for _, group := range *groupsItems {
+			toPrint := ""
 			if id, ok := group.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Group Id: " + *id)
+				toPrint += "Group Id: " + *id
 			}
 			if properties, ok := group.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Group Name: " + *name)
+					toPrint += " Group Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Groups"); err != nil {
@@ -522,6 +524,7 @@ func DeleteAllGroups(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -117,7 +117,7 @@ func PreRunImageId(c *core.PreCommandConfig) error {
 }
 
 func RunImageList(c *core.CommandConfig) error {
-	c.Printer.Print("WARNING: The following flags are deprecated:" + c.Command.GetAnnotationsByKey(core.DeprecatedFlagsAnnotation) + ". Use --filters --order-by --max-results options instead!")
+	_ = c.Printer.Print("WARNING: The following flags are deprecated:" + c.Command.GetAnnotationsByKey(core.DeprecatedFlagsAnnotation) + ". Use --filters --order-by --max-results options instead!")
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
 	if err != nil {

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -303,14 +303,16 @@ func DeleteAllIpBlocks(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if ipBlocksItems, ok := ipBlocks.GetItemsOk(); ok && ipBlocksItems != nil {
 		for _, dc := range *ipBlocksItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("IpBlock Id: " + *id)
+				toPrint += "IpBlock Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("IpBlock Name: " + *name)
+					toPrint += " IpBlock Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the IpBlocks"); err != nil {
@@ -332,6 +334,7 @@ func DeleteAllIpBlocks(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -295,14 +295,16 @@ func RemoveAllIpFailovers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if ipFailoversItems, ok := ipFailovers.GetItemsOk(); ok && ipFailoversItems != nil {
 		for _, ipFailover := range *ipFailoversItems {
+			toPrint := ""
 			if id, ok := ipFailover.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("IP Failover Id: " + *id)
+				toPrint += "IP Failover Id: " + *id
 			}
 			if properties, ok := ipFailover.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" IP Failover Name: " + *name)
+					toPrint += " IP Failover Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "remove all the IP Failovers"); err != nil {
 			return nil, err

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -451,14 +451,16 @@ func DeleteAllK8sClusters(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sClustersItems, ok := k8Clusters.GetItemsOk(); ok && k8sClustersItems != nil {
 		for _, k8sCluster := range *k8sClustersItems {
+			toPrint := ""
 			if id, ok := k8sCluster.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sCluster Id: " + *id)
+				toPrint += "K8sCluster Id: " + *id
 			}
 			if properties, ok := k8sCluster.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("K8sCluster Name: " + *name)
+					toPrint += " K8sCluster Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sClusters"); err != nil {
@@ -481,6 +483,7 @@ func DeleteAllK8sClusters(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -312,14 +312,16 @@ func DelteAllK8sNodes(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sNodesItems, ok := k8sNodes.GetItemsOk(); ok && k8sNodesItems != nil {
 		for _, dc := range *k8sNodesItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sNodes Id: " + *id)
+				toPrint += "K8sNodes Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("K8sNodes Name: " + *name)
+					toPrint += " K8sNodes Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sNodes"); err != nil {
 			return nil, err
@@ -343,6 +345,7 @@ func DelteAllK8sNodes(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -582,14 +582,16 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sNodePoolsItems, ok := k8sNodePools.GetItemsOk(); ok && k8sNodePoolsItems != nil {
 		for _, dc := range *k8sNodePoolsItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sNodePool Id: " + *id)
+				toPrint += "K8sNodePool Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" K8sNodePool Name: " + *name)
+					toPrint += " K8sNodePool Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sNodePools"); err != nil {
@@ -612,6 +614,7 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/labelresource.go
+++ b/commands/cloudapi-v6/labelresource.go
@@ -84,14 +84,16 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, erro
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Datacenter with Id: "+dcId); err != nil {
@@ -115,6 +117,7 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, erro
 					}
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -165,6 +168,31 @@ func RunServerLabelAdd(c *core.CommandConfig) error {
 	return c.Printer.Print(getLabelResourcePrint(c, getLabelResource(labelDc)))
 }
 
+func RunServerLabelRemove(c *core.CommandConfig) error {
+	var resp *resources.Response
+	var err error
+	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll))
+	if allFlag {
+		resp, err = RemoveAllServerLabels(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
+		serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
+		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
+		c.Printer.Verbose("Removing label with key: %v for Server with id: %v...", labelKey, serverId)
+		resp, err = c.CloudApiV6Services.Labels().ServerDelete(dcId, serverId, labelKey)
+		if resp != nil {
+			c.Printer.Verbose(cloudapiv6.RequestTimeMessage, resp.RequestTime)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return c.Printer.Print(getLabelResourcePrint(c, nil))
+}
+
 func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
@@ -175,14 +203,16 @@ func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Server with Id: "+serverId); err != nil {
@@ -207,34 +237,10 @@ func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 				}
 
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
-}
-
-func RunServerLabelRemove(c *core.CommandConfig) error {
-	var resp *resources.Response
-	var err error
-	allFlag := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll))
-	if allFlag {
-		resp, err = RemoveAllServerLabels(c)
-		if err != nil {
-			return err
-		}
-	} else {
-		dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
-		serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
-		labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
-		c.Printer.Verbose("Removing label with key: %v for Server with id: %v...", labelKey, serverId)
-		resp, err = c.CloudApiV6Services.Labels().ServerDelete(dcId, serverId, labelKey)
-		if resp != nil {
-			c.Printer.Verbose(cloudapiv6.RequestTimeMessage, resp.RequestTime)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return c.Printer.Print(getLabelResourcePrint(c, nil))
 }
 
 func RunVolumeLabelsList(c *core.CommandConfig) error {
@@ -317,14 +323,16 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Volume with Id: "+volumeId); err != nil {
@@ -349,6 +357,7 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
 				}
 
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -427,14 +436,16 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from IpBlock with Id: "+ipBlockId); err != nil {
@@ -457,8 +468,8 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) 
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -538,14 +549,16 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error)
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Snapshot with Id: "+snapshotId); err != nil {
@@ -568,8 +581,8 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error)
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -375,14 +375,16 @@ func DeleteAllLans(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if lansItems, ok := lans.GetItemsOk(); ok && lansItems != nil {
 		for _, lan := range *lansItems {
+			toPrint := ""
 			if id, ok := lan.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Lan Id: " + *id)
+				toPrint += "Lan Id: " + *id
 			}
 			if properties, ok := lan.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Lan Name: " + *name)
+					toPrint += " Lan Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Lans"); err != nil {
 			return nil, err
@@ -404,6 +406,7 @@ func DeleteAllLans(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -347,14 +347,16 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if loadBalancersItems, ok := loadBalancers.GetItemsOk(); ok && loadBalancersItems != nil {
 		for _, lb := range *loadBalancersItems {
+			toPrint := ""
 			if id, ok := lb.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("LoadBalancer Id: " + *id)
+				toPrint += "LoadBalancer Id: " + *id
 			}
 			if properties, ok := lb.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" LoadBalancer Name: " + *name)
+					toPrint += " LoadBalancer Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the LoadBalancers"); err != nil {
 			return nil, err
@@ -377,6 +379,7 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) (*resources.Response, error) 
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -365,14 +365,16 @@ func DeleteAllNatgateways(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if natGatewayItems, ok := natGateways.GetItemsOk(); ok && natGatewayItems != nil {
 		for _, natGateway := range *natGatewayItems {
+			toPrint := ""
 			if id, ok := natGateway.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NatGateway Id: " + *id)
+				toPrint += "NatGateway Id: " + *id
 			}
 			if properties, ok := natGateway.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" NatGateway Name: " + *name)
+					toPrint += " NatGateway Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the NatGateways"); err != nil {
@@ -394,6 +396,7 @@ func DeleteAllNatgateways(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -398,14 +398,16 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) (*resources.Response, er
 	}
 	if natgatewaysItems, ok := flowlogs.GetItemsOk(); ok && natgatewaysItems != nil {
 		for _, natgateway := range *natgatewaysItems {
+			toPrint := ""
 			if id, ok := natgateway.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NatGatewayFlowLog Id: " + *id)
+				toPrint += "NatGatewayFlowLog Id: " + *id
 			}
 			if properties, ok := natgateway.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("NatGatewayFlowLog Name: " + *name)
+					toPrint += " NatGatewayFlowLog Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all theNatGatewayFlowLogs"); err != nil {
@@ -427,6 +429,7 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) (*resources.Response, er
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -439,14 +439,16 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) (*resources.Response, error
 	}
 	if natGatewayRuleItems, ok := natGatewayRules.GetItemsOk(); ok && natGatewayRuleItems != nil {
 		for _, natGateway := range *natGatewayRuleItems {
+			toPrint := ""
 			if id, ok := natGateway.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NatGatewayRule Id: " + *id)
+				toPrint += "NatGatewayRule Id: " + *id
 			}
 			if properties, ok := natGateway.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("NatGatewayRule Name: " + *name)
+					toPrint += " NatGatewayRule Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the NatGatewayRules"); err != nil {
@@ -468,6 +470,7 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) (*resources.Response, error
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -387,14 +387,16 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) (*resources.Response, 
 	}
 	if nlbItems, ok := networkLoadBalancers.GetItemsOk(); ok && nlbItems != nil {
 		for _, networkLoadBalancer := range *nlbItems {
+			toPrint := ""
 			if id, ok := networkLoadBalancer.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NetworkLoadBalancer Id: " + *id)
+				toPrint += "NetworkLoadBalancer Id: " + *id
 			}
 			if properties, ok := networkLoadBalancer.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" NetworkLoadBalancer Name: " + *name)
+					toPrint += " NetworkLoadBalancer Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Backup Units"); err != nil {
@@ -416,6 +418,7 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) (*resources.Response, 
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -397,14 +397,16 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) (*resources.Res
 	}
 	if flowLogsItems, ok := flowLogs.GetItemsOk(); ok && flowLogsItems != nil {
 		for _, flowLog := range *flowLogsItems {
+			toPrint := ""
 			if id, ok := flowLog.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NetworkLoadBalancerFlowLog Id: " + *id)
+				toPrint += "NetworkLoadBalancerFlowLog Id: " + *id
 			}
 			if properties, ok := flowLog.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("NetworkLoadBalancerFlowLog Name: " + *name)
+					toPrint += " NetworkLoadBalancerFlowLog Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the NetworkLoadBalancerFlowLogs"); err != nil {
@@ -426,6 +428,7 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) (*resources.Res
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -457,14 +457,16 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) (*resour
 	}
 	if nlbForwardingRulesItems, ok := nlbForwardingRules.GetItemsOk(); ok && nlbForwardingRulesItems != nil {
 		for _, nlbForwardingRule := range *nlbForwardingRulesItems {
+			toPrint := ""
 			if id, ok := nlbForwardingRule.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("NetworkLoadBalancerForwardingRule Id: " + *id)
+				toPrint += "NetworkLoadBalancerForwardingRule Id: " + *id
 			}
 			if properties, ok := nlbForwardingRule.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("NetworkLoadBalancerForwardingRule Name: " + *name)
+					toPrint += " NetworkLoadBalancerForwardingRule Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Backup Units"); err != nil {
@@ -486,6 +488,7 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) (*resour
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -300,14 +300,16 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if forwardingRulesItems, ok := forwardingRules.GetItemsOk(); ok && forwardingRulesItems != nil {
 		for _, forwardingRule := range *forwardingRulesItems {
+			toPrint := ""
 			if id, ok := forwardingRule.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Forwarding Rule Target Id: " + *id)
+				toPrint += "Forwarding Rule Target Id: " + *id
 			}
 			if properties, ok := forwardingRule.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Forwarding Rule Target Name: " + *name)
+					toPrint += " Forwarding Rule Target Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err = utils.AskForConfirm(c.Stdin, c.Printer, "remove all the Forwarding Rule Targets"); err != nil {

--- a/commands/cloudapi-v6/nic.go
+++ b/commands/cloudapi-v6/nic.go
@@ -434,14 +434,16 @@ func DeleteAllNics(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if nicsItems, ok := nics.GetItemsOk(); ok && nicsItems != nil {
 		for _, nic := range *nicsItems {
+			toPrint := ""
 			if id, ok := nic.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Nic Id: " + *id)
+				toPrint += "Nic Id: " + *id
 			}
 			if properties, ok := nic.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Nic Name: " + *name)
+					toPrint += " Nic Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Nics"); err != nil {
@@ -466,6 +468,7 @@ func DeleteAllNics(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -754,14 +757,16 @@ func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if nicsItems, ok := nics.GetItemsOk(); ok && nicsItems != nil {
 		for _, nic := range *nicsItems {
+			toPrint := ""
 			if id, ok := nic.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Nic Id: " + *id)
+				toPrint += "Nic Id: " + *id
 			}
 			if properties, ok := nic.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Nic Name: " + *name)
+					toPrint += " Nic Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the Nics"); err != nil {
 			return nil, err
@@ -782,6 +787,7 @@ func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -324,14 +324,16 @@ func DeleteAllPccs(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if pccsItems, ok := pccs.GetItemsOk(); ok && pccsItems != nil {
 		for _, pcc := range *pccsItems {
+			toPrint := ""
 			if id, ok := pcc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("PrivateCrossConnect Id: " + *id)
+				toPrint += "PrivateCrossConnect Id: " + *id
 			}
 			if properties, ok := pcc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("PrivateCrossConnect Name: " + *name)
+					toPrint += " PrivateCrossConnect Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the PrivateCrossConnects"); err != nil {
 			return nil, err
@@ -353,6 +355,7 @@ func DeleteAllPccs(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -325,6 +325,7 @@ func DeleteAllS3keys(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -949,14 +949,16 @@ func DeleteAllServers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if serversItems, ok := servers.GetItemsOk(); ok && serversItems != nil {
 		for _, server := range *serversItems {
+			toPrint := ""
 			if id, ok := server.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Server Id: " + *id)
+				toPrint += "Server Id: " + *id
 			}
 			if properties, ok := server.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("Server Name: " + *name)
+					toPrint += " Server Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Servers"); err != nil {
 			return nil, err
@@ -977,6 +979,7 @@ func DeleteAllServers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -453,14 +453,16 @@ func DeleteAllSnapshots(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if snapshotsItems, ok := snapshots.GetItemsOk(); ok && snapshotsItems != nil {
 		for _, snapshot := range *snapshotsItems {
+			toPrint := ""
 			if id, ok := snapshot.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Snapshot Id: " + *id)
+				toPrint += "Snapshot Id: " + *id
 			}
 			if properties, ok := snapshot.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Snapshot Name: " + *name)
+					toPrint += " Snapshot Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Snapshots"); err != nil {
@@ -483,6 +485,7 @@ func DeleteAllSnapshots(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -372,17 +372,19 @@ func DeleteAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if usersItems, ok := users.GetItemsOk(); ok && usersItems != nil {
 		for _, user := range *usersItems {
+			toPrint := ""
 			if id, ok := user.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("User Id: " + *id)
+				toPrint += "User Id: " + *id
 			}
 			if properties, ok := user.GetPropertiesOk(); ok && properties != nil {
 				if firstName, ok := properties.GetFirstnameOk(); ok && firstName != nil {
-					_ = c.Printer.Print("User First Name: " + *firstName)
+					toPrint += " User First Name: " + *firstName
 				}
 				if lastName, ok := properties.GetLastnameOk(); ok && lastName != nil {
-					_ = c.Printer.Print("User Last Name: " + *lastName)
+					toPrint += " User Last Name: " + *lastName
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Users"); err != nil {
@@ -405,6 +407,7 @@ func DeleteAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -579,17 +582,19 @@ func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if usersItems, ok := users.GetItemsOk(); ok && usersItems != nil {
 		for _, user := range *usersItems {
+			toPrint := ""
 			if id, ok := user.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("User Id: " + *id)
+				toPrint += "User Id: " + *id
 			}
 			if properties, ok := user.GetPropertiesOk(); ok && properties != nil {
 				if firstName, ok := properties.GetFirstnameOk(); ok && firstName != nil {
-					_ = c.Printer.Print(" User Name: " + *firstName)
+					toPrint += " User First Name: " + *firstName
 				}
 				if lastName, ok := properties.GetLastnameOk(); ok && lastName != nil {
-					_ = c.Printer.Print(" User Name: " + *lastName)
+					toPrint += " User Last Name: " + *lastName
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "removing all the Users"); err != nil {
@@ -611,6 +616,7 @@ func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -897,14 +897,16 @@ func DetachAllServers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if volumesItems, ok := volumes.GetItemsOk(); ok && volumesItems != nil {
 		for _, volume := range *volumesItems {
+			toPrint := ""
 			if id, ok := volume.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Volume Id: " + *id)
+				toPrint += "Volume Id: " + *id
 			}
 			if properties, ok := volume.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Volume Name: " + *name)
+					toPrint += " Volume Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the Volumes"); err != nil {
 			return nil, err
@@ -925,6 +927,7 @@ func DetachAllServers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil


### PR DESCRIPTION
## What does this fix or implement?

The print that is shown when you use a delete/detach/remove operation followed by the --all flag  shows now the id and the name of the resource which will be deleted in the same line

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] Tests added or updated
- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Documentation updated
- [ ] Sonar Cloud Scan
- [x] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any
- [ ] Jira task updated
