### PR TITLE
fix: improve verbose print when delete/detach/remove --all

### DIFF
--- a/commands/cloudapi-v5/backupunit.go
+++ b/commands/cloudapi-v5/backupunit.go
@@ -360,14 +360,16 @@ func DeleteAllBackupUnits(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if backupUnitsItems, ok := backupUnits.GetItemsOk(); ok && backupUnitsItems != nil {
 		for _, backupUnit := range *backupUnitsItems {
+			toPrint := ""
 			if id, ok := backupUnit.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("BackupUnit Id: " + *id)
+				toPrint += "BackupUnit Id: " + *id
 			}
 			if properties, ok := backupUnit.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" BackupUnit Name: " + *name)
+					toPrint += " BackupUnit Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Backup Units"); err != nil {
@@ -388,6 +390,7 @@ func DeleteAllBackupUnits(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/cdrom.go
+++ b/commands/cloudapi-v5/cdrom.go
@@ -302,14 +302,16 @@ func DetachllCdRoms(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if cdRomsItems, ok := csRoms.GetItemsOk(); ok && cdRomsItems != nil {
 		for _, cdRom := range *cdRomsItems {
+			toPrint := ""
 			if id, ok := cdRom.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("CD-ROM Id: " + *id)
+				toPrint += "CD-ROM Id: " + *id
 			}
 			if properties, ok := cdRom.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" CD-ROM Name: " + *name)
+					toPrint += " CD-ROM Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the CD-ROMS"); err != nil {
@@ -330,6 +332,7 @@ func DetachllCdRoms(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/datacenter.go
+++ b/commands/cloudapi-v5/datacenter.go
@@ -309,14 +309,16 @@ func DeleteAllDatacenters(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if datacentersItems, ok := datacenters.GetItemsOk(); ok && datacentersItems != nil {
 		for _, dc := range *datacentersItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Datacenter Id: " + *id)
+				toPrint += "Datacenter Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Datacenter Name: " + *name)
+					toPrint += " Datacenter Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Datacenters"); err != nil {
@@ -338,6 +340,7 @@ func DeleteAllDatacenters(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/firewallrule.go
+++ b/commands/cloudapi-v5/firewallrule.go
@@ -496,14 +496,16 @@ func DeleteAllFirewallRules(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if firewallrulestems, ok := firewallrules.GetItemsOk(); ok && firewallrulestems != nil {
 		for _, firewall := range *firewallrulestems {
+			toPrint := ""
 			if id, ok := firewall.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Firewallrule Id: " + *id)
+				toPrint += "Firewallrule Id: " + *id
 			}
 			if properties, ok := firewall.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Firewallrule Name: " + *name)
+					toPrint += " Firewallrule Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Firewallrules"); err != nil {
@@ -524,6 +526,7 @@ func DeleteAllFirewallRules(c *core.CommandConfig) (*resources.Response, error) 
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/group.go
+++ b/commands/cloudapi-v5/group.go
@@ -452,14 +452,16 @@ func DeleteAllGroups(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if groupsItems, ok := groups.GetItemsOk(); ok && groupsItems != nil {
 		for _, group := range *groupsItems {
+			toPrint := ""
 			if id, ok := group.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Group Id: " + *id)
+				toPrint += "Group Id: " + *id
 			}
 			if properties, ok := group.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Group Name: " + *name)
+					toPrint += " Group Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Groups"); err != nil {
@@ -481,6 +483,7 @@ func DeleteAllGroups(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/ipblock.go
+++ b/commands/cloudapi-v5/ipblock.go
@@ -300,14 +300,16 @@ func DeleteAllIpBlocks(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if ipBlocksItems, ok := ipBlocks.GetItemsOk(); ok && ipBlocksItems != nil {
 		for _, dc := range *ipBlocksItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("IpBlock Id: " + *id)
+				toPrint += "IpBlock Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" IpBlock Name: " + *name)
+					toPrint += " IpBlock Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the IpBlocks"); err != nil {
@@ -328,6 +330,7 @@ func DeleteAllIpBlocks(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/ipfailover.go
+++ b/commands/cloudapi-v5/ipfailover.go
@@ -296,14 +296,16 @@ func RemoveAllIpFailovers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if ipFailoversItems, ok := ipFailovers.GetItemsOk(); ok && ipFailoversItems != nil {
 		for _, ipFailover := range *ipFailoversItems {
+			toPrint := ""
 			if id, ok := ipFailover.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("IP Failover Id: " + *id)
+				toPrint += "IP Failover Id: " + *id
 			}
 			if properties, ok := ipFailover.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" IP Failover Name: " + *name)
+					toPrint += " IP Failover Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "remove all the IP Failovers"); err != nil {

--- a/commands/cloudapi-v5/k8s_cluster.go
+++ b/commands/cloudapi-v5/k8s_cluster.go
@@ -448,14 +448,16 @@ func DeleteAllK8sClusters(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sClustersItems, ok := k8Clusters.GetItemsOk(); ok && k8sClustersItems != nil {
 		for _, k8sCluster := range *k8sClustersItems {
+			toPrint := ""
 			if id, ok := k8sCluster.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sCluster Id: " + *id)
+				toPrint += "K8sCluster Id: " + *id
 			}
 			if properties, ok := k8sCluster.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" K8sCluster Name: " + *name)
+					toPrint += " K8sCluster Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sClusters"); err != nil {
@@ -477,6 +479,7 @@ func DeleteAllK8sClusters(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/k8s_node.go
+++ b/commands/cloudapi-v5/k8s_node.go
@@ -312,14 +312,16 @@ func DeleteAllK8sNodes(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sNodesItems, ok := k8sNodes.GetItemsOk(); ok && k8sNodesItems != nil {
 		for _, dc := range *k8sNodesItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sNodes Id: " + *id)
+				toPrint += "K8sNodes Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" K8sNodes Name: " + *name)
+					toPrint += " K8sNodes Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sNodes"); err != nil {
@@ -343,6 +345,7 @@ func DeleteAllK8sNodes(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/k8s_nodepool.go
+++ b/commands/cloudapi-v5/k8s_nodepool.go
@@ -556,14 +556,16 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if k8sNodePoolsItems, ok := k8sNodePools.GetItemsOk(); ok && k8sNodePoolsItems != nil {
 		for _, dc := range *k8sNodePoolsItems {
+			toPrint := ""
 			if id, ok := dc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("K8sNodePool Id: " + *id)
+				toPrint += "K8sNodePool Id: " + *id
 			}
 			if properties, ok := dc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print("K8sNodePool Name: " + *name)
+					toPrint += " K8sNodePool Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the K8sNodePools"); err != nil {
@@ -585,6 +587,7 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/labelresource.go
+++ b/commands/cloudapi-v5/labelresource.go
@@ -86,14 +86,16 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, erro
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Datacenter with Id: "+dcId); err != nil {
@@ -116,6 +118,7 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) (*resources.Response, erro
 					}
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -202,14 +205,16 @@ func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Server with Id: "+serverId); err != nil {
@@ -231,8 +236,8 @@ func RemoveAllServerLabels(c *core.CommandConfig) (*resources.Response, error) {
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -318,14 +323,16 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Volume with Id: "+volumeId); err != nil {
@@ -347,8 +354,8 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) (*resources.Response, error) {
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -431,14 +438,16 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from IpBlock with Id: "+ipBlockId); err != nil {
@@ -460,8 +469,8 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) (*resources.Response, error) 
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -540,14 +549,16 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error)
 	}
 	if labelsItems, ok := labels.GetItemsOk(); ok && labelsItems != nil {
 		for _, label := range *labelsItems {
+			toPrint := ""
 			if properties, ok := label.GetPropertiesOk(); ok && properties != nil {
 				if key, ok := properties.GetKeyOk(); ok && key != nil {
-					_ = c.Printer.Print(" Label Key: " + *key)
+					toPrint += "Label Key: " + *key
 				}
 				if value, ok := properties.GetValueOk(); ok && value != nil {
-					_ = c.Printer.Print(" Label Value: " + *value)
+					toPrint += " Label Value: " + *value
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Labels from Snapshot with Id: "+snapshotId); err != nil {
@@ -569,8 +580,8 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) (*resources.Response, error)
 						return nil, err
 					}
 				}
-
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/lan.go
+++ b/commands/cloudapi-v5/lan.go
@@ -375,14 +375,16 @@ func DeleteAllLans(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if lansItems, ok := lans.GetItemsOk(); ok && lansItems != nil {
 		for _, lan := range *lansItems {
+			toPrint := ""
 			if id, ok := lan.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Lan Id: " + *id)
+				toPrint += "Lan Id: " + *id
 			}
 			if properties, ok := lan.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Lan Name: " + *name)
+					toPrint += " Lan Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Lans"); err != nil {
@@ -404,6 +406,7 @@ func DeleteAllLans(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/loadbalancer.go
+++ b/commands/cloudapi-v5/loadbalancer.go
@@ -353,14 +353,16 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) (*resources.Response, error) 
 	}
 	if loadBalancersItems, ok := loadBalancers.GetItemsOk(); ok && loadBalancersItems != nil {
 		for _, lb := range *loadBalancersItems {
+			toPrint := ""
 			if id, ok := lb.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("LoadBalancer Id: " + *id)
+				toPrint += "LoadBalancer Id: " + *id
 			}
 			if properties, ok := lb.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" LoadBalancer Name: " + *name)
+					toPrint += " LoadBalancer Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the LoadBalancers"); err != nil {
@@ -383,6 +385,7 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) (*resources.Response, error) 
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/nic.go
+++ b/commands/cloudapi-v5/nic.go
@@ -408,14 +408,16 @@ func DeleteAllNics(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if nicsItems, ok := nics.GetItemsOk(); ok && nicsItems != nil {
 		for _, nic := range *nicsItems {
+			toPrint := ""
 			if id, ok := nic.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Nic Id: " + *id)
+				toPrint += "Nic Id: " + *id
 			}
 			if properties, ok := nic.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Nic Name: " + *name)
+					toPrint += " Nic Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Nics"); err != nil {
@@ -439,6 +441,7 @@ func DeleteAllNics(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -742,14 +745,16 @@ func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if nicsItems, ok := nics.GetItemsOk(); ok && nicsItems != nil {
 		for _, nic := range *nicsItems {
+			toPrint := ""
 			if id, ok := nic.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Nic Id: " + *id)
+				toPrint += "Nic Id: " + *id
 			}
 			if properties, ok := nic.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Nic Name: " + *name)
+					toPrint += " Nic Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "detach all the Nics"); err != nil {
@@ -770,6 +775,7 @@ func DetachAllNics(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/pcc.go
+++ b/commands/cloudapi-v5/pcc.go
@@ -297,14 +297,16 @@ func DeleteAllPccs(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if pccsItems, ok := pccs.GetItemsOk(); ok && pccsItems != nil {
 		for _, pcc := range *pccsItems {
+			toPrint := ""
 			if id, ok := pcc.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("PrivateCrossConnect Id: " + *id)
+				toPrint += "PrivateCrossConnect Id: " + *id
 			}
 			if properties, ok := pcc.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" PrivateCrossConnect Name: " + *name)
+					toPrint += " PrivateCrossConnect Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the PrivateCrossConnects"); err != nil {
@@ -326,6 +328,7 @@ func DeleteAllPccs(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/s3key.go
+++ b/commands/cloudapi-v5/s3key.go
@@ -324,6 +324,7 @@ func DeleteAllS3Keys(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/server.go
+++ b/commands/cloudapi-v5/server.go
@@ -696,14 +696,16 @@ func DeleteAllServers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if serversItems, ok := servers.GetItemsOk(); ok && serversItems != nil {
 		for _, server := range *serversItems {
+			toPrint := ""
 			if id, ok := server.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Server Id: " + *id)
+				toPrint += "Server Id: " + *id
 			}
 			if properties, ok := server.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Server Name: " + *name)
+					toPrint += " Server Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Servers"); err != nil {
@@ -725,6 +727,7 @@ func DeleteAllServers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/snapshot.go
+++ b/commands/cloudapi-v5/snapshot.go
@@ -448,14 +448,16 @@ func DeleteAllSnapshots(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if snapshotsItems, ok := snapshots.GetItemsOk(); ok && snapshotsItems != nil {
 		for _, snapshot := range *snapshotsItems {
+			toPrint := ""
 			if id, ok := snapshot.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Snapshot Id: " + *id)
+				toPrint += "Snapshot Id: " + *id
 			}
 			if properties, ok := snapshot.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Snapshot Name: " + *name)
+					toPrint += " Snapshot Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Snapshots"); err != nil {
@@ -477,6 +479,7 @@ func DeleteAllSnapshots(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/user.go
+++ b/commands/cloudapi-v5/user.go
@@ -375,17 +375,19 @@ func DeleteAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if usersItems, ok := users.GetItemsOk(); ok && usersItems != nil {
 		for _, user := range *usersItems {
+			toPrint := ""
 			if id, ok := user.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("User Id: " + *id)
+				toPrint += "User Id: " + *id
 			}
 			if properties, ok := user.GetPropertiesOk(); ok && properties != nil {
 				if firstName, ok := properties.GetFirstnameOk(); ok && firstName != nil {
-					_ = c.Printer.Print(" User First Name: " + *firstName)
+					toPrint += " User First Name: " + *firstName
 				}
 				if lastName, ok := properties.GetLastnameOk(); ok && lastName != nil {
-					_ = c.Printer.Print(" User Last Name: " + *lastName)
+					toPrint += " User Last Name: " + *lastName
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Users"); err != nil {
@@ -408,6 +410,7 @@ func DeleteAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil
@@ -582,17 +585,19 @@ func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if usersItems, ok := users.GetItemsOk(); ok && usersItems != nil {
 		for _, user := range *usersItems {
+			toPrint := ""
 			if id, ok := user.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("User Id: " + *id)
+				toPrint += "User Id: " + *id
 			}
 			if properties, ok := user.GetPropertiesOk(); ok && properties != nil {
 				if firstName, ok := properties.GetFirstnameOk(); ok && firstName != nil {
-					_ = c.Printer.Print(" User Name: " + *firstName)
+					toPrint += " User Name: " + *firstName
 				}
 				if lastName, ok := properties.GetLastnameOk(); ok && lastName != nil {
-					_ = c.Printer.Print(" User Name: " + *lastName)
+					toPrint += " User Name: " + *lastName
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "removing all the Users"); err != nil {
@@ -613,6 +618,7 @@ func RemoveAllUsers(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil

--- a/commands/cloudapi-v5/volume.go
+++ b/commands/cloudapi-v5/volume.go
@@ -579,14 +579,16 @@ func DeleteAllVolumes(c *core.CommandConfig) (*resources.Response, error) {
 	}
 	if volumesItems, ok := volumes.GetItemsOk(); ok && volumesItems != nil {
 		for _, volume := range *volumesItems {
+			toPrint := ""
 			if id, ok := volume.GetIdOk(); ok && id != nil {
-				_ = c.Printer.Print("Volume Id: " + *id)
+				toPrint += "Volume Id: " + *id
 			}
 			if properties, ok := volume.GetPropertiesOk(); ok && properties != nil {
 				if name, ok := properties.GetNameOk(); ok && name != nil {
-					_ = c.Printer.Print(" Volume Name: " + *name)
+					toPrint += " Volume Name: " + *name
 				}
 			}
+			_ = c.Printer.Print(toPrint)
 		}
 
 		if err := utils.AskForConfirm(c.Stdin, c.Printer, "delete all the Volumes"); err != nil {
@@ -609,6 +611,7 @@ func DeleteAllVolumes(c *core.CommandConfig) (*resources.Response, error) {
 					return nil, err
 				}
 			}
+			_ = c.Printer.Print("\n")
 		}
 	}
 	return resp, nil


### PR DESCRIPTION
## What does this fix or implement?

The print that is shown when you use a delete/detach/remove operation followed by the --all flag shows now the id and the name of the resource which will be deleted in the same line

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [ ] Sonar Cloud Scan
- [x] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any
- [x] Jira task updated
