### PR TITLE
Fix example and docu for ipblock create parameters

### DIFF
--- a/commands/cloudapi-v5/examples.go
+++ b/commands/cloudapi-v5/examples.go
@@ -119,7 +119,7 @@ ionosctl image list --location us/las --type HDD --licence-type LINUX`
 	*/
 	listIpBlockExample     = `ionosctl ipblock list`
 	getIpBlockExample      = `ionosctl ipblock get --ipblock-id IPBLOCK_ID`
-	createIpBlockExample   = `ionosctl ipblock create --ipblock-name NAME --ipblock-location LOCATION_ID --ipblock-size IPBLOCK_SIZE`
+	createIpBlockExample   = `ionosctl ipblock create --name NAME --location LOCATION_ID --size IPBLOCK_SIZE`
 	updateIpBlockExample   = `ionosctl ipblock update --ipblock-id IPBLOCK_ID --ipblock-name NAME`
 	deleteIpBlockExample   = `ionosctl ipblock delete --ipblock-id IPBLOCK_ID --wait-for-request`
 	listIpConsumersExample = `ionosctl ipconsumer list --ipblock-id IPBLOCK_ID`

--- a/docs/subcommands/compute-engine/ipblock-create.md
+++ b/docs/subcommands/compute-engine/ipblock-create.md
@@ -52,6 +52,6 @@ You can wait for the Request to be executed using `--wait-for-request` option.
 ## Examples
 
 ```text
-ionosctl ipblock create --ipblock-name NAME --ipblock-location LOCATION_ID --ipblock-size IPBLOCK_SIZE
+ionosctl ipblock create --name NAME --location LOCATION_ID --size IPBLOCK_SIZE
 ```
 


### PR DESCRIPTION
## What does this fix or implement?

The example and documentation for the command **ionosctl ipblock create** provided outdated parameter naming. The naming was fixed. There are no functional changes.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
