### PR TITLE
feat: Add --no-headers flag to list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ DATACENTER_ID3   us/las
 
 Note: When using `TAB` in autocompletion, on `--cols` option on a specific resource, the available columns for that resource will be displayed.
 
+* Use the `--no-headers` option
+
+To skip printing the column headers in output format `text`.
+
 * Use the `--verbose` option
 
 You will see step-by-step process when running a command.

--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -54,7 +54,7 @@ func TokenCmd() *core.Command {
 		InitClient: true,
 	})
 	list.AddIntFlag(authv1.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the tokens are listed")
-	list.AddBoolFlag(authv1.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -54,6 +54,7 @@ func TokenCmd() *core.Command {
 		InitClient: true,
 	})
 	list.AddIntFlag(authv1.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the tokens are listed")
+	list.AddBoolFlag(authv1.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -69,7 +69,7 @@ func BackupunitCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -69,6 +69,7 @@ func BackupunitCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -114,6 +114,7 @@ Required values to run command:
 	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	listCdroms.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Cdrom Command

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -114,7 +114,7 @@ Required values to run command:
 	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listCdroms.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	listCdroms.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Cdrom Command

--- a/commands/cloudapi-v6/cpu.go
+++ b/commands/cloudapi-v6/cpu.go
@@ -57,6 +57,7 @@ func CpuCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocationId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return cpuCmd
 }

--- a/commands/cloudapi-v6/cpu.go
+++ b/commands/cloudapi-v6/cpu.go
@@ -57,7 +57,7 @@ func CpuCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocationId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return cpuCmd
 }

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -69,6 +69,7 @@ You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -69,7 +69,7 @@ You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -83,7 +83,7 @@ func FirewallruleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -83,6 +83,7 @@ func FirewallruleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -81,7 +81,7 @@ func FlowlogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -81,6 +81,7 @@ func FlowlogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -67,6 +67,7 @@ func GroupCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -67,7 +67,7 @@ func GroupCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -81,7 +81,7 @@ func ImageCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -81,6 +81,7 @@ func ImageCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -66,7 +66,7 @@ func IpblockCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -66,6 +66,7 @@ func IpblockCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/ipconsumer.go
+++ b/commands/cloudapi-v6/ipconsumer.go
@@ -55,6 +55,7 @@ func IpconsumerCmd() *core.Command {
 	_ = listResources.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	listResources.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return resourceCmd
 }

--- a/commands/cloudapi-v6/ipconsumer.go
+++ b/commands/cloudapi-v6/ipconsumer.go
@@ -55,7 +55,7 @@ func IpconsumerCmd() *core.Command {
 	_ = listResources.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	listResources.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	listResources.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return resourceCmd
 }

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -62,7 +62,7 @@ func IpfailoverCmd() *core.Command {
 	_ = listCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LansIds(os.Stderr, viper.GetString(core.GetFlagName(listCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	listCmd.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	listCmd.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -62,6 +62,7 @@ func IpfailoverCmd() *core.Command {
 	_ = listCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LansIds(os.Stderr, viper.GetString(core.GetFlagName(listCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	listCmd.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -85,6 +85,7 @@ func K8sClusterCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sClustersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -85,7 +85,7 @@ func K8sClusterCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sClustersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -74,7 +74,7 @@ func K8sNodeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -74,6 +74,7 @@ func K8sNodeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -72,7 +72,7 @@ func K8sNodePoolCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -72,6 +72,7 @@ func K8sNodePoolCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -58,7 +58,7 @@ func K8sNodePoolLanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -58,6 +58,7 @@ func K8sNodePoolLanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -71,7 +71,7 @@ func LabelCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -71,6 +71,7 @@ func LabelCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -71,7 +71,7 @@ func LanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -71,6 +71,7 @@ func LanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -70,7 +70,7 @@ func LoadBalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -70,6 +70,7 @@ func LoadBalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/location.go
+++ b/commands/cloudapi-v6/location.go
@@ -63,6 +63,7 @@ func LocationCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/location.go
+++ b/commands/cloudapi-v6/location.go
@@ -63,7 +63,7 @@ func LocationCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -71,7 +71,7 @@ func NatgatewayCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -71,6 +71,7 @@ func NatgatewayCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -71,7 +71,7 @@ func NatgatewayFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -71,6 +71,7 @@ func NatgatewayFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway_lan.go
+++ b/commands/cloudapi-v6/natgateway_lan.go
@@ -64,6 +64,7 @@ Required values to run command:
 	_ = list.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/natgateway_lan.go
+++ b/commands/cloudapi-v6/natgateway_lan.go
@@ -64,7 +64,7 @@ Required values to run command:
 	_ = list.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -76,7 +76,7 @@ func NatgatewayRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -76,6 +76,7 @@ func NatgatewayRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -71,7 +71,7 @@ func NetworkloadbalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -71,6 +71,7 @@ func NetworkloadbalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -71,7 +71,7 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -71,6 +71,7 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -76,6 +76,7 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -76,7 +76,7 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -71,6 +71,7 @@ func NlbRuleTargetCmd() *core.Command {
 			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
 		), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -71,7 +71,7 @@ func NlbRuleTargetCmd() *core.Command {
 			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
 		), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/nic.go
+++ b/commands/cloudapi-v6/nic.go
@@ -75,7 +75,7 @@ func NicCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NICsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/nic.go
+++ b/commands/cloudapi-v6/nic.go
@@ -75,6 +75,7 @@ func NicCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NICsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -66,7 +66,7 @@ func PccCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -410,6 +410,7 @@ func PeersCmd() *core.Command {
 	_ = listPeers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	listPeers.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return peerCmd
 }

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -66,6 +66,7 @@ func PccCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -72,7 +72,7 @@ func RequestCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -72,6 +72,7 @@ func RequestCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -61,7 +61,7 @@ func UserS3keyCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -61,6 +61,7 @@ func UserS3keyCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -77,6 +77,7 @@ func ServerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -77,7 +77,7 @@ func ServerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/share.go
+++ b/commands/cloudapi-v6/share.go
@@ -60,6 +60,7 @@ func ShareCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/share.go
+++ b/commands/cloudapi-v6/share.go
@@ -60,7 +60,7 @@ func ShareCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -66,6 +66,7 @@ func SnapshotCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -66,7 +66,7 @@ func SnapshotCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/template.go
+++ b/commands/cloudapi-v6/template.go
@@ -63,6 +63,7 @@ func TemplateCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.TemplatesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/template.go
+++ b/commands/cloudapi-v6/template.go
@@ -63,7 +63,7 @@ func TemplateCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.TemplatesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -67,7 +67,7 @@ func UserCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -67,6 +67,7 @@ func UserCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -72,6 +72,7 @@ func VolumeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -72,7 +72,7 @@ func VolumeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(cloudapiv6.ArgNoHeaders, "", false, "When using text output, don't print headers")
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -707,6 +707,7 @@ Required values to run command:
 	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
+	listVolumes.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Volume Command

--- a/docs/README.md
+++ b/docs/README.md
@@ -300,6 +300,10 @@ DATACENTER_ID3   us/las
 
 Note: When using `TAB` in autocompletion, on `--cols` option on a specific resource, the available columns for that resource will be displayed.
 
+* Use the `--no-headers` option
+
+To skip printing the column headers in output format `text`.
+
 * Use the `--verbose` option
 
 You will see step-by-step process when running a command.

--- a/docs/subcommands/authentication/token-list.md
+++ b/docs/subcommands/authentication/token-list.md
@@ -32,6 +32,7 @@ Use this command to retrieve a complete list of Tokens under your account, to li
       --contract int     Users with multiple contracts must provide the contract number, for which the tokens are listed
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/datacenter-list.md
+++ b/docs/subcommands/compute-engine/datacenter-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/firewallrule-list.md
+++ b/docs/subcommands/compute-engine/firewallrule-list.md
@@ -52,6 +52,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
       --nic-id string          The unique NIC Id (required)
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/flowlog-list.md
+++ b/docs/subcommands/compute-engine/flowlog-list.md
@@ -52,6 +52,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
       --nic-id string          The unique NIC Id (required)
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/image-list.md
+++ b/docs/subcommands/compute-engine/image-list.md
@@ -48,6 +48,7 @@ Available Filters:
       --licence-type string   The licence type of the Image (deprecated)
   -l, --location string       The location of the Image (deprecated)
   -M, --max-results int       The maximum number of elements to return
+      --no-headers            When using text output, don't print headers
       --order-by string       Limits results to those containing a matching value for a specific property
   -o, --output string         Desired output format [text|json] (default "text")
   -q, --quiet                 Quiet output

--- a/docs/subcommands/compute-engine/ipblock-list.md
+++ b/docs/subcommands/compute-engine/ipblock-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/ipconsumer-list.md
+++ b/docs/subcommands/compute-engine/ipconsumer-list.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --ipblock-id string   The unique IpBlock Id (required)
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/ipfailover-list.md
+++ b/docs/subcommands/compute-engine/ipfailover-list.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --lan-id string          The unique LAN Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-list.md
+++ b/docs/subcommands/compute-engine/label-list.md
@@ -33,6 +33,7 @@ Use this command to list all Labels from all Resources under your account. If yo
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --ipblock-id string      The unique IpBlock Id
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
       --resource-type string   Type of the resource to list labels from

--- a/docs/subcommands/compute-engine/lan-list.md
+++ b/docs/subcommands/compute-engine/lan-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/loadbalancer-list.md
+++ b/docs/subcommands/compute-engine/loadbalancer-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/location-cpu-list.md
+++ b/docs/subcommands/compute-engine/location-cpu-list.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --location-id string   The unique Location Id (required)
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/location-list.md
+++ b/docs/subcommands/compute-engine/location-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/nic-list.md
+++ b/docs/subcommands/compute-engine/nic-list.md
@@ -50,6 +50,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/pcc-list.md
+++ b/docs/subcommands/compute-engine/pcc-list.md
@@ -38,6 +38,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/pcc-peers-list.md
+++ b/docs/subcommands/compute-engine/pcc-peers-list.md
@@ -35,6 +35,7 @@ Required values to run command:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
       --pcc-id string    The unique Private Cross-Connect Id (required)
   -q, --quiet            Quiet output

--- a/docs/subcommands/compute-engine/request-list.md
+++ b/docs/subcommands/compute-engine/request-list.md
@@ -46,6 +46,7 @@ Available Filters:
       --latest int        Show latest N Requests. If it is not set, all Requests will be printed (deprecated)
   -M, --max-results int   The maximum number of elements to return
       --method string     Show only the Requests with this method. E.g CREATE, UPDATE, DELETE (deprecated)
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/server-cdrom-list.md
+++ b/docs/subcommands/compute-engine/server-cdrom-list.md
@@ -56,6 +56,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/server-list.md
+++ b/docs/subcommands/compute-engine/server-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/server-volume-list.md
+++ b/docs/subcommands/compute-engine/server-volume-list.md
@@ -56,6 +56,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/compute-engine/snapshot-list.md
+++ b/docs/subcommands/compute-engine/snapshot-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/template-list.md
+++ b/docs/subcommands/compute-engine/template-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/compute-engine/volume-list.md
+++ b/docs/subcommands/compute-engine/volume-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/managed-backup/backupunit-list.md
+++ b/docs/subcommands/managed-backup/backupunit-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/managed-kubernetes/k8s-cluster-list.md
+++ b/docs/subcommands/managed-kubernetes/k8s-cluster-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/managed-kubernetes/k8s-node-list.md
+++ b/docs/subcommands/managed-kubernetes/k8s-node-list.md
@@ -50,6 +50,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -M, --max-results int      The maximum number of elements to return
+      --no-headers           When using text output, don't print headers
       --nodepool-id string   The unique K8s Node Pool Id (required)
       --order-by string      Limits results to those containing a matching value for a specific property
   -o, --output string        Desired output format [text|json] (default "text")

--- a/docs/subcommands/managed-kubernetes/k8s-nodepool-lan-list.md
+++ b/docs/subcommands/managed-kubernetes/k8s-nodepool-lan-list.md
@@ -43,6 +43,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/managed-kubernetes/k8s-nodepool-list.md
+++ b/docs/subcommands/managed-kubernetes/k8s-nodepool-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int     The maximum number of elements to return
+      --no-headers          When using text output, don't print headers
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/natgateway/natgateway-flowlog-list.md
+++ b/docs/subcommands/natgateway/natgateway-flowlog-list.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/natgateway/natgateway-lan-list.md
+++ b/docs/subcommands/natgateway/natgateway-lan-list.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/natgateway/natgateway-list.md
+++ b/docs/subcommands/natgateway/natgateway-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/natgateway/natgateway-rule-list.md
+++ b/docs/subcommands/natgateway/natgateway-rule-list.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-flowlog-list.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-flowlog-list.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                            Print usage
   -M, --max-results int                 The maximum number of elements to return
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
       --order-by string                 Limits results to those containing a matching value for a specific property
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-list.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-list.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int        The maximum number of elements to return
+      --no-headers             When using text output, don't print headers
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-list.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-list.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                            Print usage
   -M, --max-results int                 The maximum number of elements to return
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
       --order-by string                 Limits results to those containing a matching value for a specific property
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-list.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-list.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output
       --rule-id string                  The unique ForwardingRule Id (required)

--- a/docs/subcommands/user-management/group-list.md
+++ b/docs/subcommands/user-management/group-list.md
@@ -43,6 +43,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/user-management/share-list.md
+++ b/docs/subcommands/user-management/share-list.md
@@ -36,6 +36,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
       --group-id string   The unique Group Id (required)
   -h, --help              Print usage
+      --no-headers        When using text output, don't print headers
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output
   -v, --verbose           Print step-by-step process when running command

--- a/docs/subcommands/user-management/user-list.md
+++ b/docs/subcommands/user-management/user-list.md
@@ -44,6 +44,7 @@ Available Filters:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -M, --max-results int   The maximum number of elements to return
+      --no-headers        When using text output, don't print headers
       --order-by string   Limits results to those containing a matching value for a specific property
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output

--- a/docs/subcommands/user-management/user-s3key-list.md
+++ b/docs/subcommands/user-management/user-s3key-list.md
@@ -47,6 +47,7 @@ Required values to run command:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -q, --quiet            Quiet output
       --user-id string   The unique User Id (required)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -33,6 +33,7 @@ const (
 	ArgUser                = "user"
 	ArgPassword            = "password"
 	ArgPasswordShort       = "p"
+	ArgNoHeaders           = "no-headers"
 
 	DefaultApiURL         = "https://api.ionos.com"
 	DefaultConfigFileName = "/config.json"

--- a/internal/core/command_runner.go
+++ b/internal/core/command_runner.go
@@ -24,7 +24,8 @@ func NewCommand(ctx context.Context, parent *Command, info CommandBuilder) *Comm
 		Example: info.Example,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			// Set Printer in sync with the Output Flag
-			p := getPrinter()
+			noHeaders, _ := cmd.Flags().GetBool(config2.ArgNoHeaders)
+			p := getPrinter(noHeaders)
 			// Set Command to Command Builder
 			// The cmd is passed to the PreCommandCfg
 			info.Command = &Command{Command: cmd}
@@ -35,7 +36,8 @@ func NewCommand(ctx context.Context, parent *Command, info CommandBuilder) *Comm
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			// Set Printer in sync with the Output Flag
-			p := getPrinter()
+			noHeaders, _ := cmd.Flags().GetBool(config2.ArgNoHeaders)
+			p := getPrinter(noHeaders)
 			// Set Buffers
 			cmd.SetIn(os.Stdin)
 			cmd.SetOut(p.GetStdout())
@@ -167,7 +169,7 @@ type CommandConfig struct {
 	Context context.Context
 }
 
-func getPrinter() printer.PrintService {
+func getPrinter(noHeaders bool) printer.PrintService {
 	var out io.Writer
 	if viper.GetBool(config2.ArgQuiet) {
 		var execOut bytes.Buffer
@@ -175,7 +177,7 @@ func getPrinter() printer.PrintService {
 	} else {
 		out = os.Stdout
 	}
-	printReg, err := printer.NewPrinterRegistry(out, os.Stderr)
+	printReg, err := printer.NewPrinterRegistry(out, os.Stderr, noHeaders)
 	clierror.CheckError(err, os.Stderr)
 	return printReg[viper.GetString(config2.ArgOutput)]
 }

--- a/internal/core/test.go
+++ b/internal/core/test.go
@@ -32,7 +32,7 @@ func PreCmdConfigTest(t *testing.T, writer io.Writer, preRunner PreCmdRunTest) {
 	if viper.GetString(config.ArgOutput) == "" {
 		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
 	}
-	p, _ := printer.NewPrinterRegistry(writer, writer)
+	p, _ := printer.NewPrinterRegistry(writer, writer, false)
 	prt := p[viper.GetString(config.ArgOutput)]
 	preCmdCfg := &PreCommandConfig{
 		Command: &Command{
@@ -63,7 +63,7 @@ func CmdConfigTest(t *testing.T, writer io.Writer, runner CmdRunnerTest) {
 	if viper.GetString(config.ArgOutput) == "" {
 		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
 	}
-	printReg, _ := printer.NewPrinterRegistry(writer, writer)
+	printReg, _ := printer.NewPrinterRegistry(writer, writer, false)
 	prt := printReg[viper.GetString(config.ArgOutput)]
 	// Init Test Mock Resources and Services
 	testMocks := initMockResources(ctrl)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -24,7 +24,7 @@ func TestNewPrinterJSON(t *testing.T) {
 	viper.Set(config.ArgOutput, "json")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	_, err := NewPrinterRegistry(w, w)
+	_, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 }
 
@@ -33,7 +33,7 @@ func TestNewPrinterText(t *testing.T) {
 	viper.Set(config.ArgOutput, "text")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	_, err := NewPrinterRegistry(w, w)
+	_, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 }
 
@@ -48,7 +48,7 @@ func TestPrinterPrintResultJson(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -74,7 +74,7 @@ func TestPrinterPrintStandardResultJson(t *testing.T) {
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -101,7 +101,7 @@ func TestPrinterPrintDefaultJson(t *testing.T) {
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -119,7 +119,7 @@ func TestPrinterPrintDefaultQuietJson(t *testing.T) {
 	viper.Set(config.ArgQuiet, true)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -142,7 +142,7 @@ func TestPrinterResultJsonRequestId(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -174,7 +174,7 @@ func TestPrinterResultJsonRequestIdErr(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["json"]
 	p.SetStderr(w)
@@ -200,7 +200,7 @@ func TestPrinterGetStdoutJSON(t *testing.T) {
 	viper.Set(config.ArgOutput, "json")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	out := reg["json"].GetStdout()
 	err = w.Flush()
@@ -213,7 +213,7 @@ func TestPrinterGetStderrJSON(t *testing.T) {
 	viper.Set(config.ArgOutput, "json")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	out := reg["json"].GetStderr()
 
@@ -228,7 +228,7 @@ func TestPrinterPrintResultText(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -251,7 +251,7 @@ func TestPrinterPrintResultTextRequestId(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -280,7 +280,7 @@ func TestPrinterPrintResultTextResource(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -303,7 +303,7 @@ func TestPrinterPrintResultTextWaitResource(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -326,7 +326,7 @@ func TestPrinterPrintResultTextWaitStateResource(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -354,7 +354,7 @@ func TestPrinterPrintResultTextKeyValue(t *testing.T) {
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -378,13 +378,46 @@ func TestPrinterPrintResultTextKeyValue(t *testing.T) {
 	assert.True(t, re.Match(b.Bytes()))
 }
 
+func TestPrinterPrintResultTextKeyValueNoHeaders(t *testing.T) {
+	var (
+		b      bytes.Buffer
+		tabwrt = "123   dummy   true   1.230000\n"
+	)
+	viper.Set(config.ArgOutput, "text")
+	viper.Set(config.ArgQuiet, false)
+	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
+	w := bufio.NewWriter(&b)
+	reg, err := NewPrinterRegistry(w, w, true)
+	assert.NoError(t, err)
+	p := reg["text"]
+	p.SetStderr(w)
+	p.SetStdout(w)
+	keyValueMap := map[string]interface{}{
+		"ID":          123,
+		"Name":        "dummy",
+		"Authorized":  true,
+		"Age[min]":    1.23,
+		"Description": "dummy",
+	}
+	res := Result{
+		Columns:  []string{"ID", "Name", "Authorized", "Age[min]"},
+		KeyValue: []map[string]interface{}{keyValueMap},
+	}
+
+	p.Print(res)
+	err = w.Flush()
+	assert.NoError(t, err)
+	re := regexp.MustCompile(tabwrt)
+	assert.Truef(t, re.Match(b.Bytes()), `"%v" != "%v"`, b.Bytes(), []byte(tabwrt))
+}
+
 func TestPrinterPrintDefaultText(t *testing.T) {
 	var b bytes.Buffer
 	viper.Set(config.ArgOutput, "text")
 	viper.Set(config.ArgQuiet, false)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -402,7 +435,7 @@ func TestPrinterUnknownFormatType(t *testing.T) {
 	viper.Set(config.ArgOutput, "dummy")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	_, err := NewPrinterRegistry(w, w)
+	_, err := NewPrinterRegistry(w, w, false)
 	assert.Error(t, err)
 	assert.True(t, err.Error() == `unknown type format dummy. Hint: use --output json|text`)
 }
@@ -413,7 +446,7 @@ func TestPrinterResultQuiet(t *testing.T) {
 	viper.Set(config.ArgQuiet, true)
 	viper.Set(config.ArgServerUrl, config.DefaultApiURL)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	p := reg["text"]
 	p.SetStderr(w)
@@ -433,7 +466,7 @@ func TestPrinterGetStdoutText(t *testing.T) {
 	viper.Set(config.ArgOutput, "text")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	out := reg["text"].GetStdout()
 	err = w.Flush()
@@ -446,7 +479,7 @@ func TestPrinterGetStderrText(t *testing.T) {
 	viper.Set(config.ArgOutput, "text")
 	viper.Set(config.ArgQuiet, false)
 	w := bufio.NewWriter(&b)
-	reg, err := NewPrinterRegistry(w, w)
+	reg, err := NewPrinterRegistry(w, w, false)
 	assert.NoError(t, err)
 	out := reg["text"].GetStderr()
 	err = w.Flush()

--- a/internal/printer/result.go
+++ b/internal/printer/result.go
@@ -29,7 +29,7 @@ type Result struct {
 	ApiResponse *resources.Response
 }
 
-func (prt *Result) PrintText(out io.Writer) error {
+func (prt *Result) PrintText(out io.Writer, noHeaders bool) error {
 	var resultPrint ResultPrint
 	if prt.Resource != "" && prt.Verb != "" {
 		resultPrint.Message = standardSuccessMsg(prt.Resource, prt.Verb, prt.WaitForRequest, prt.WaitForState)
@@ -44,7 +44,7 @@ func (prt *Result) PrintText(out io.Writer) error {
 		resultPrint.RequestId = requestId
 	}
 	if prt.KeyValue != nil && prt.Columns != nil {
-		err := printText(out, prt.Columns, prt.KeyValue)
+		err := printText(out, prt.Columns, prt.KeyValue, noHeaders)
 		if err != nil {
 			return err
 		}
@@ -118,17 +118,19 @@ func statusMsg(writer io.Writer, msg string, args ...interface{}) {
 	}
 }
 
-func printText(out io.Writer, cols []string, keyValueMap []map[string]interface{}) error {
+func printText(out io.Writer, cols []string, keyValueMap []map[string]interface{}, noHeaders bool) error {
 	w := new(tabwriter.Writer)
 	w.Init(out, 5, 0, 3, ' ', tabwriter.StripEscape)
 
-	var headers []string
-	for _, col := range cols {
-		headers = append(headers, col)
-	}
-	_, err := fmt.Fprintln(w, strings.Join(headers, "\t"))
-	if err != nil {
-		return err
+	if !noHeaders {
+		var headers []string
+		for _, col := range cols {
+			headers = append(headers, col)
+		}
+		_, err := fmt.Fprintln(w, strings.Join(headers, "\t"))
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, r := range keyValueMap {

--- a/services/auth-v1/constants.go
+++ b/services/auth-v1/constants.go
@@ -10,7 +10,6 @@ const (
 	ArgCurrent      = "current"
 	ArgCurrentShort = "C"
 	ArgContractNo   = "contract"
-	ArgNoHeaders    = "no-headers"
 )
 
 const (

--- a/services/auth-v1/constants.go
+++ b/services/auth-v1/constants.go
@@ -10,6 +10,7 @@ const (
 	ArgCurrent      = "current"
 	ArgCurrentShort = "C"
 	ArgContractNo   = "contract"
+	ArgNoHeaders    = "no-headers"
 )
 
 const (

--- a/services/cloudapi-v6/constants.go
+++ b/services/cloudapi-v6/constants.go
@@ -138,6 +138,7 @@ const (
 	ArgOrderBy               = "order-by"
 	ArgMaxResults            = "max-results"
 	ArgMaxResultsShort       = "M"
+	ArgNoHeaders             = "no-headers"
 )
 
 // IDs Flags

--- a/services/cloudapi-v6/constants.go
+++ b/services/cloudapi-v6/constants.go
@@ -138,7 +138,6 @@ const (
 	ArgOrderBy               = "order-by"
 	ArgMaxResults            = "max-results"
 	ArgMaxResultsShort       = "M"
-	ArgNoHeaders             = "no-headers"
 )
 
 // IDs Flags


### PR DESCRIPTION
## What does this fix or implement?

I find myself using the following construct a lot: `ionosctl ... list --cols ... | tail -n +2`. The `tail` removes the first line of the output which are the column headers. I propose to add a flag that does this instead of having to rely on an external binary.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
