### PR TITLE
feat: add --no-headers flag to get commands

### DIFF
--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -76,6 +76,7 @@ func TokenCmd() *core.Command {
 		return completer.TokensIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
 	get.AddIntFlag(authv1.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the token information is displayed")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Generate/Create Command

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -90,6 +90,7 @@ func BackupunitCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get SSO URL Command

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -143,6 +143,7 @@ Required values to run command:
 	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.AttachedCdromsIds(os.Stderr, viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgDataCenterId)), viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	getCdromCmd.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Detach Cdrom Command

--- a/commands/cloudapi-v6/console.go
+++ b/commands/cloudapi-v6/console.go
@@ -50,6 +50,7 @@ func ServerConsoleCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return consoleCmd
 }

--- a/commands/cloudapi-v6/contract.go
+++ b/commands/cloudapi-v6/contract.go
@@ -55,6 +55,7 @@ func ContractCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceLimits, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"CORES", "RAM", "HDD", "SSD", "DAS", "IPS", "K8S", "NLB", "NAT"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return contractCmd
 }

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -90,6 +90,7 @@ You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -122,6 +122,7 @@ func FirewallruleCmd() *core.Command {
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -118,6 +118,7 @@ func FlowlogCmd() *core.Command {
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -88,6 +88,7 @@ func GroupCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -102,6 +102,7 @@ func ImageCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImageIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return imageCmd
 }

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -87,6 +87,7 @@ func IpblockCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -108,6 +108,7 @@ func K8sClusterCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified Cluster to be in ACTIVE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Cluster to be in ACTIVE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/k8s_kubeconfig.go
+++ b/commands/cloudapi-v6/k8s_kubeconfig.go
@@ -43,6 +43,7 @@ func K8sKubeconfigCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sClustersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return k8sCmd
 }

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -108,6 +108,7 @@ func K8sNodeCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified Node to be in ACTIVE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Node to be in ACTIVE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Recreate Command

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -99,6 +99,7 @@ func K8sNodePoolCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified NodePool to be in ACTIVE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for NodePool to be in ACTIVE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -113,6 +113,7 @@ func LabelCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get By Urn Command
@@ -129,6 +130,7 @@ func LabelCmd() *core.Command {
 		InitClient: true,
 	})
 	getByUrn.AddStringFlag(cloudapiv6.ArgLabelUrn, "", "", "URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>]", core.RequiredFlagOption())
+	getByUrn.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Add Command

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -96,6 +96,7 @@ func LanCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LansIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -95,6 +95,7 @@ func LoadBalancerCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LoadbalancersIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/location.go
+++ b/commands/cloudapi-v6/location.go
@@ -84,6 +84,7 @@ func LocationCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocationId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	locationCmd.AddCommand(CpuCmd())
 

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -98,6 +98,7 @@ func NatgatewayCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified NAT Gateway to be in AVAILABLE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, config.DefaultTimeoutSeconds, "Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -105,6 +105,7 @@ func NatgatewayFlowLogCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -106,6 +106,7 @@ func NatgatewayRuleCmd() *core.Command {
 		return completer.NatGatewayRulesIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -98,6 +98,7 @@ func NetworkloadbalancerCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified Network Load Balancer to be in AVAILABLE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -105,6 +105,7 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -106,6 +106,7 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 		return completer.ForwardingRulesIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/nic.go
+++ b/commands/cloudapi-v6/nic.go
@@ -105,6 +105,7 @@ func NicCmd() *core.Command {
 		return completer.NicsIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -87,6 +87,7 @@ func PccCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -93,6 +93,7 @@ func RequestCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRequestId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Wait Command

--- a/commands/cloudapi-v6/resource.go
+++ b/commands/cloudapi-v6/resource.go
@@ -39,7 +39,7 @@ func ResourceCmd() *core.Command {
 	/*
 		List Command
 	*/
-	core.NewCommand(ctx, resourceCmd, core.CommandBuilder{
+	list := core.NewCommand(ctx, resourceCmd, core.CommandBuilder{
 		Namespace:  "resource",
 		Resource:   "resource",
 		Verb:       "list",
@@ -51,6 +51,7 @@ func ResourceCmd() *core.Command {
 		CmdRun:     RunResourceList,
 		InitClient: true,
 	})
+	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -75,6 +76,7 @@ func ResourceCmd() *core.Command {
 	_ = getRsc.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ResourcesIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	getRsc.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return resourceCmd
 }

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -86,6 +86,7 @@ func UserS3keyCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgS3KeyId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.S3KeyIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgUserId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -104,6 +104,7 @@ func ServerCmd() *core.Command {
 	})
 	get.AddBoolFlag(config.ArgWaitForState, config.ArgWaitForStateShort, config.DefaultWait, "Wait for specified Server to be in AVAILABLE state")
 	get.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, config.DefaultTimeoutSeconds, "Timeout option for waiting for Server to be in AVAILABLE state [seconds]")
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/share.go
+++ b/commands/cloudapi-v6/share.go
@@ -85,6 +85,7 @@ func ShareCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupResourcesIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -87,6 +87,7 @@ func SnapshotCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/template.go
+++ b/commands/cloudapi-v6/template.go
@@ -84,6 +84,7 @@ func TemplateCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTemplateId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.TemplatesIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return templateCmd
 }

--- a/commands/cloudapi-v6/token.go
+++ b/commands/cloudapi-v6/token.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/ionos-cloud/ionosctl/commands/cloudapi-v6/completer"
+	"github.com/ionos-cloud/ionosctl/internal/config"
 	"github.com/ionos-cloud/ionosctl/internal/core"
 	"github.com/ionos-cloud/ionosctl/internal/printer"
 	cloudapiv6 "github.com/ionos-cloud/ionosctl/services/cloudapi-v6"
@@ -49,6 +50,7 @@ func ServerTokenCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return tokenCmd
 }

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -88,6 +88,7 @@ func UserCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -97,6 +97,7 @@ func VolumeCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesIds(os.Stderr, viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/dbaas/postgres/api-version.go
+++ b/commands/dbaas/postgres/api-version.go
@@ -56,7 +56,7 @@ func APIVersionCmd() *core.Command {
 	/*
 		Get Command
 	*/
-	core.NewCommand(ctx, apiversionCmd, core.CommandBuilder{
+	get := core.NewCommand(ctx, apiversionCmd, core.CommandBuilder{
 		Namespace:  "dbaas-postgres",
 		Resource:   "api-version",
 		Verb:       "get",
@@ -68,6 +68,7 @@ func APIVersionCmd() *core.Command {
 		CmdRun:     RunAPIVersionGet,
 		InitClient: true,
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return apiversionCmd
 }

--- a/commands/dbaas/postgres/backup.go
+++ b/commands/dbaas/postgres/backup.go
@@ -74,6 +74,7 @@ func BackupCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return backupCmd
 }

--- a/commands/dbaas/postgres/cluster.go
+++ b/commands/dbaas/postgres/cluster.go
@@ -86,6 +86,7 @@ func ClusterCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/dbaas/postgres/version.go
+++ b/commands/dbaas/postgres/version.go
@@ -72,6 +72,7 @@ func PgsqlVersionCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(dbaaspg.ArgClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return pgsqlcompleter.ClustersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
+	get.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return pgsqlversionCmd
 }

--- a/docs/subcommands/authentication/contract-get.md
+++ b/docs/subcommands/authentication/contract-get.md
@@ -37,6 +37,7 @@ Use this command to get information about the Contract Resources on your account
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
+      --no-headers               When using text output, don't print headers
   -o, --output string            Desired output format [text|json] (default "text")
   -q, --quiet                    Quiet output
       --resource-limits string   Specify Resource Limits to see details about it

--- a/docs/subcommands/authentication/token-get.md
+++ b/docs/subcommands/authentication/token-get.md
@@ -36,6 +36,7 @@ Required values to run command:
       --contract int      Users with multiple contracts must provide the contract number, for which the token information is displayed
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
+      --no-headers        When using text output, don't print headers
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output
   -i, --token-id string   The unique Key ID of a Token (required)

--- a/docs/subcommands/compute-engine/datacenter-get.md
+++ b/docs/subcommands/compute-engine/datacenter-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -i, --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/firewallrule-get.md
+++ b/docs/subcommands/compute-engine/firewallrule-get.md
@@ -47,6 +47,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --nic-id string            The unique NIC Id (required)
+      --no-headers               When using text output, don't print headers
   -o, --output string            Desired output format [text|json] (default "text")
   -q, --quiet                    Quiet output
       --server-id string         The unique Server Id (required)

--- a/docs/subcommands/compute-engine/flowlog-get.md
+++ b/docs/subcommands/compute-engine/flowlog-get.md
@@ -47,6 +47,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --nic-id string          The unique NIC Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/image-get.md
+++ b/docs/subcommands/compute-engine/image-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -i, --image-id string   The unique Image Id (required)
+      --no-headers        When using text output, don't print headers
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output
   -v, --verbose           Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/ipblock-get.md
+++ b/docs/subcommands/compute-engine/ipblock-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -i, --ipblock-id string   The unique IpBlock Id (required)
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-get-by-urn.md
+++ b/docs/subcommands/compute-engine/label-get-by-urn.md
@@ -28,6 +28,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --label-urn string   URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>] (required)
+      --no-headers         When using text output, don't print headers
   -o, --output string      Desired output format [text|json] (default "text")
   -q, --quiet              Quiet output
   -v, --verbose            Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-get.md
+++ b/docs/subcommands/compute-engine/label-get.md
@@ -40,6 +40,7 @@ Required values to run command:
   -h, --help                   Print usage
       --ipblock-id string      The unique IpBlock Id
       --label-key string       The unique Label Key (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
       --resource-type string   Type of the resource to get label from (required)

--- a/docs/subcommands/compute-engine/lan-get.md
+++ b/docs/subcommands/compute-engine/lan-get.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --lan-id string          The unique LAN Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/loadbalancer-get.md
+++ b/docs/subcommands/compute-engine/loadbalancer-get.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
   -i, --loadbalancer-id string   The unique Load Balancer Id (required)
+      --no-headers               When using text output, don't print headers
   -o, --output string            Desired output format [text|json] (default "text")
   -q, --quiet                    Quiet output
   -v, --verbose                  Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/location-get.md
+++ b/docs/subcommands/compute-engine/location-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -i, --location-id string   The unique Location Id (required)
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/nic-get.md
+++ b/docs/subcommands/compute-engine/nic-get.md
@@ -45,6 +45,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --nic-id string          The unique NIC Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/pcc-get.md
+++ b/docs/subcommands/compute-engine/pcc-get.md
@@ -35,6 +35,7 @@ Required values to run command:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -i, --pcc-id string    The unique Private Cross-Connect Id (required)
   -q, --quiet            Quiet output

--- a/docs/subcommands/compute-engine/request-get.md
+++ b/docs/subcommands/compute-engine/request-get.md
@@ -41,6 +41,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -i, --request-id string   The unique Request Id (required)

--- a/docs/subcommands/compute-engine/server-cdrom-get.md
+++ b/docs/subcommands/compute-engine/server-cdrom-get.md
@@ -51,6 +51,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/server-console-get.md
+++ b/docs/subcommands/compute-engine/server-console-get.md
@@ -49,6 +49,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/server-get.md
+++ b/docs/subcommands/compute-engine/server-get.md
@@ -43,6 +43,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/server-token-get.md
+++ b/docs/subcommands/compute-engine/server-token-get.md
@@ -49,6 +49,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/compute-engine/snapshot-get.md
+++ b/docs/subcommands/compute-engine/snapshot-get.md
@@ -41,6 +41,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -i, --snapshot-id string   The unique Snapshot Id (required)

--- a/docs/subcommands/compute-engine/template-get.md
+++ b/docs/subcommands/compute-engine/template-get.md
@@ -41,6 +41,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -i, --template-id string   The unique Template Id (required)

--- a/docs/subcommands/compute-engine/volume-get.md
+++ b/docs/subcommands/compute-engine/volume-get.md
@@ -43,6 +43,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-api-version-get.md
+++ b/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-api-version-get.md
@@ -43,6 +43,7 @@ Use this command to get the current version of DBaaS PostgreSQL API.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-backup-get.md
+++ b/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-backup-get.md
@@ -48,6 +48,7 @@ Required values to run command:
   -c, --config string      Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
+      --no-headers         When using text output, don't print headers
   -o, --output string      Desired output format [text|json] (default "text")
   -q, --quiet              Quiet output
   -v, --verbose            Print step-by-step process when running command

--- a/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-cluster-get.md
+++ b/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-cluster-get.md
@@ -48,6 +48,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for Cluster to be in AVAILABLE state [seconds] (default 1200)

--- a/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-version-get.md
+++ b/docs/subcommands/database-as-a-service/postgres/dbaas-postgres-version-get.md
@@ -48,6 +48,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/managed-backup/backupunit-get.md
+++ b/docs/subcommands/managed-backup/backupunit-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/managed-kubernetes/k8s-cluster-get.md
+++ b/docs/subcommands/managed-kubernetes/k8s-cluster-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for waiting for Cluster to be in ACTIVE state [seconds] (default 600)

--- a/docs/subcommands/managed-kubernetes/k8s-kubeconfig-get.md
+++ b/docs/subcommands/managed-kubernetes/k8s-kubeconfig-get.md
@@ -40,6 +40,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          When using text output, don't print headers
   -o, --output string       Desired output format [text|json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/managed-kubernetes/k8s-node-get.md
+++ b/docs/subcommands/managed-kubernetes/k8s-node-get.md
@@ -44,6 +44,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -i, --node-id string       The unique K8s Node Id (required)
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json] (default "text")

--- a/docs/subcommands/managed-kubernetes/k8s-nodepool-get.md
+++ b/docs/subcommands/managed-kubernetes/k8s-nodepool-get.md
@@ -43,6 +43,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -i, --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/natgateway/natgateway-flowlog-get.md
+++ b/docs/subcommands/natgateway/natgateway-flowlog-get.md
@@ -52,6 +52,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/natgateway/natgateway-get.md
+++ b/docs/subcommands/natgateway/natgateway-get.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds] (default 60)

--- a/docs/subcommands/natgateway/natgateway-rule-get.md
+++ b/docs/subcommands/natgateway/natgateway-rule-get.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
   -i, --rule-id string         The unique Rule Id (required)

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-flowlog-get.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-flowlog-get.md
@@ -52,6 +52,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output
   -v, --verbose                         Print step-by-step process when running command

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-get.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-get.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
   -i, --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output
   -t, --timeout int                     Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds] (default 300)

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-get.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-get.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      When using text output, don't print headers
   -o, --output string                   Desired output format [text|json] (default "text")
   -q, --quiet                           Quiet output
   -i, --rule-id string                  The unique ForwardingRule Id (required)

--- a/docs/subcommands/user-management/contract-get.md
+++ b/docs/subcommands/user-management/contract-get.md
@@ -37,6 +37,7 @@ Use this command to get information about the Contract Resources on your account
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
+      --no-headers               When using text output, don't print headers
   -o, --output string            Desired output format [text|json] (default "text")
   -q, --quiet                    Quiet output
       --resource-limits string   Specify Resource Limits to see details about it

--- a/docs/subcommands/user-management/group-get.md
+++ b/docs/subcommands/user-management/group-get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
   -i, --group-id string   The unique Group Id (required)
   -h, --help              Print usage
+      --no-headers        When using text output, don't print headers
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output
   -v, --verbose           Print step-by-step process when running command

--- a/docs/subcommands/user-management/resource-get.md
+++ b/docs/subcommands/user-management/resource-get.md
@@ -41,6 +41,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The ID of the specific Resource to retrieve information about

--- a/docs/subcommands/user-management/resource-list.md
+++ b/docs/subcommands/user-management/resource-list.md
@@ -37,6 +37,7 @@ Use this command to get a full list of existing Resources. To sort list by Resou
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/user-management/share-get.md
+++ b/docs/subcommands/user-management/share-get.md
@@ -37,6 +37,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
       --group-id string      The unique Group Id (required)
   -h, --help                 Print usage
+      --no-headers           When using text output, don't print headers
   -o, --output string        Desired output format [text|json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The unique Resource Id (required)

--- a/docs/subcommands/user-management/user-get.md
+++ b/docs/subcommands/user-management/user-get.md
@@ -41,6 +41,7 @@ Required values to run command:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json] (default "text")
   -q, --quiet            Quiet output
   -i, --user-id string   The unique User Id (required)

--- a/docs/subcommands/user-management/user-s3key-get.md
+++ b/docs/subcommands/user-management/user-s3key-get.md
@@ -48,6 +48,7 @@ Required values to run command:
   -c, --config string     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
+      --no-headers        When using text output, don't print headers
   -o, --output string     Desired output format [text|json] (default "text")
   -q, --quiet             Quiet output
   -i, --s3key-id string   The unique User S3Key Id (required)


### PR DESCRIPTION
## What does this fix or implement?

Same reasoning as with the list commands. Omitting the headers makes things easier to use in scripts, because the output does not have to be edited by things like `sed` or `cut`.

For example, getting the node count of a node pool:

```sh
NODE_COUNT=$(ionosctl k8s nodepool get --cluster-id abc --nodepool-id xyz --cols NodeCount --no-headers)
```

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
