### PR TITLE
fix: validate `--since` and `--until` options for logs

### DIFF
--- a/commands/dbaas/postgres/logs.go
+++ b/commands/dbaas/postgres/logs.go
@@ -55,7 +55,7 @@ func LogsCmd() *core.Command {
 		ShortDesc:  "List Logs for a PostgreSQL Cluster",
 		Example:    listLogsExample,
 		LongDesc:   "Use this command to retrieve the Logs of a specified PostgreSQL Cluster. By default, the result will contain all Cluster Logs. You can specify the start time, end time or a limit for sorting Cluster Logs.\n\nRequired values to run command:\n\n* Cluster Id",
-		PreCmdRun:  PreRunClusterId,
+		PreCmdRun:  PreRunClusterLogsList,
 		CmdRun:     RunClusterLogsList,
 		InitClient: true,
 	})
@@ -75,6 +75,22 @@ func LogsCmd() *core.Command {
 	list.AddBoolFlag(config.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return clusterCmd
+}
+
+func PreRunClusterLogsList(c *core.PreCommandConfig) error {
+	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgSince)) {
+		if !strings.HasSuffix(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgSince)), minuteSuffix) &&
+			!strings.HasSuffix(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgSince)), hourSuffix) {
+			return errors.New("--since option must have suffix h(hours) or m(minutes). e.g.: --since 2h")
+		}
+	}
+	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgUntil)) {
+		if !strings.HasSuffix(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgUntil)), minuteSuffix) &&
+			!strings.HasSuffix(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgUntil)), hourSuffix) {
+			return errors.New("--until option must have suffix h(hours) or m(minutes). e.g.: --until 1h")
+		}
+	}
+	return core.CheckRequiredFlags(c.Command, c.NS, dbaaspg.ArgClusterId)
 }
 
 func RunClusterLogsList(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres/logs_test.go
+++ b/commands/dbaas/postgres/logs_test.go
@@ -59,6 +59,51 @@ func TestLogCmd(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPreRunClusterLogsList(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSince), testSinceVar)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgUntil), testUntilVar)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgClusterId), testClusterVar)
+		err := PreRunClusterLogsList(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestPreRunClusterLogsListSinceErr(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSince), "3min")
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgUntil), testUntilVar)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgClusterId), testClusterVar)
+		err := PreRunClusterLogsList(cfg)
+		assert.Error(t, err)
+	})
+}
+
+func TestPreRunClusterLogsListUntilErr(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
+		viper.Reset()
+		viper.Set(config.ArgOutput, config.DefaultOutputFormat)
+		viper.Set(config.ArgQuiet, false)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSince), testUntilVar)
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgUntil), "1min")
+		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgClusterId), testClusterVar)
+		err := PreRunClusterLogsList(cfg)
+		assert.Error(t, err)
+	})
+}
+
 func TestRunClusterLogsGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR adds validation for --since and --until options for `ionosctl dbaas postgres cluster logs list` command.
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Sonar Cloud Scan
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
