### PR TITLE
fix: add SDK Go DBaaS Postgres info to `version`

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/internal/config"
 	"github.com/ionos-cloud/ionosctl/internal/core"
-	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+	sdkgodbaaspostgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
+	sdkgo "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
 )
 
@@ -42,7 +43,11 @@ func RunVersion(c *core.CommandConfig) error {
 	if err != nil {
 		return err
 	}
-	err = c.Printer.Print("SDK GO version: " + ionoscloud.Version)
+	err = c.Printer.Print("SDK GO version: " + sdkgo.Version)
+	if err != nil {
+		return err
+	}
+	err = c.Printer.Print("SDK GO DBaaS Postgres version: " + sdkgodbaaspostgres.Version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR updates `ionosctl version` command to display also information about SDK Go DBaaS Postgres version.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
