### PR TITLE
feat: use multi-level json for the login config file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,17 +14,25 @@ import (
 	"github.com/spf13/viper"
 )
 
-func GetUserData() map[string]string {
-	if viper.GetString(Token) != "" {
-		return map[string]string{
+type UserData struct {
+	Username string `mapstructure:"name,omitempty"`
+	Password string `mapstructure:"password,omitempty"`
+	Token string `mapstructure:"token,omitempty"`
+	ServerUrl string `mapstructure:"api-url"`
+}
+
+type Config struct {
+	Data UserData `mapstructure:"userdata"`
+}
+
+func GetUserData() Config {
+	return Config {
+		Data: UserData {
+			Username:  viper.GetString(Username),
+			Password:  viper.GetString(Password),
 			Token:     viper.GetString(Token),
 			ServerUrl: viper.GetString(ServerUrl),
-		}
-	}
-	return map[string]string{
-		Username:  viper.GetString(Username),
-		Password:  viper.GetString(Password),
-		ServerUrl: viper.GetString(ServerUrl),
+		},
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,14 +96,24 @@ func LoadFile() error {
 		return errors.New("no permission for the config file, expected 600")
 	}
 
-
 	viper.SetConfigFile(viper.GetString(ArgConfig))
 	err := viper.ReadInConfig()
 	if err != nil {
 		return err
 	}
-	return nil
 
+	var cfg Config
+	err = viper.Unmarshal(&cfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Config file is: %+v\n", cfg)
+
+	fmt.Printf("Viper Username: %s\n", viper.GetString("Data.Username"))
+	fmt.Printf("Viper Config.Username: %s\n", viper.GetString("userdata.name"))
+
+	return nil
 }
 
 // Load collects config data from the config file, using environment variables as fallback.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,14 +15,14 @@ import (
 )
 
 type UserData struct {
-	Username  string `mapstructure:"name,omitempty"`
-	Password  string `mapstructure:"password,omitempty"`
-	Token     string `mapstructure:"token,omitempty"`
-	ServerUrl string `mapstructure:"api-url"`
+	Username  string `json:"name,omitempty"`
+	Password  string `json:"password,omitempty"`
+	Token     string `json:"token,omitempty"`
+	ServerUrl string `json:"api-url"`
 }
 
 type Config struct {
-	Data UserData `mapstructure:"userdata"`
+	Data UserData `json:"userdata"`
 }
 
 func GetUserData() Config {
@@ -123,11 +123,13 @@ func WriteFile() error {
 
 	defer f.Close()
 
+	// struct to JSON byte array
 	b, err := json.MarshalIndent(GetUserData(), "", "  ")
 	if err != nil {
 		return errors.New("unable to encode configuration to JSON format")
 	}
 
+	// byte array to file
 	_, err = f.Write(b)
 	if err != nil {
 		return errors.New("unable to write configuration")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,9 +15,9 @@ import (
 )
 
 type UserData struct {
-	Username string `mapstructure:"name,omitempty"`
-	Password string `mapstructure:"password,omitempty"`
-	Token string `mapstructure:"token,omitempty"`
+	Username  string `mapstructure:"name,omitempty"`
+	Password  string `mapstructure:"password,omitempty"`
+	Token     string `mapstructure:"token,omitempty"`
 	ServerUrl string `mapstructure:"api-url"`
 }
 
@@ -26,8 +26,8 @@ type Config struct {
 }
 
 func GetUserData() Config {
-	return Config {
-		Data: UserData {
+	return Config{
+		Data: UserData{
 			Username:  viper.GetString(Username),
 			Password:  viper.GetString(Password),
 			Token:     viper.GetString(Token),
@@ -82,17 +82,11 @@ func LoadFile() error {
 	permNumber, _ := strconv.Atoi(strBase10)
 
 	system := runtime.GOOS
-<<<<<<< HEAD
-	if system == "windows" && permNumber != int(666) {
-		return errors.New("no permission for the config file, expected 666")
-	}	else if permNumber != int(600) {
-=======
 	if system == "windows" {
 		if permNumber != int(666) {
 			return errors.New("no permission for the config file, expected 666")
 		}
 	} else if permNumber != int(600) {
->>>>>>> 6dd0729... fix: windows file perms
 		return errors.New("no permission for the config file, expected 600")
 	}
 
@@ -101,19 +95,8 @@ func LoadFile() error {
 	if err != nil {
 		return err
 	}
-
-	var cfg Config
-	err = viper.Unmarshal(&cfg)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Config file is: %+v\n", cfg)
-
-	fmt.Printf("Viper Username: %s\n", viper.GetString("Data.Username"))
-	fmt.Printf("Viper Config.Username: %s\n", viper.GetString("userdata.name"))
-
 	return nil
+
 }
 
 // Load collects config data from the config file, using environment variables as fallback.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,29 +82,27 @@ func LoadFile() error {
 	permNumber, _ := strconv.Atoi(strBase10)
 
 	system := runtime.GOOS
+<<<<<<< HEAD
+	if system == "windows" && permNumber != int(666) {
+		return errors.New("no permission for the config file, expected 666")
+	}	else if permNumber != int(600) {
+=======
 	if system == "windows" {
-		if permNumber == int(666) {
-			viper.SetConfigFile(viper.GetString(ArgConfig))
-			err := viper.ReadInConfig()
-			if err != nil {
-				return err
-			}
-			return nil
-		} else {
-			return errors.New("no permission for the config file, expected 600")
+		if permNumber != int(666) {
+			return errors.New("no permission for the config file, expected 666")
 		}
-	} else {
-		if permNumber == int(600) {
-			viper.SetConfigFile(viper.GetString(ArgConfig))
-			err := viper.ReadInConfig()
-			if err != nil {
-				return err
-			}
-			return nil
-		} else {
-			return errors.New("no permission for the config file, expected 600")
-		}
+	} else if permNumber != int(600) {
+>>>>>>> 6dd0729... fix: windows file perms
+		return errors.New("no permission for the config file, expected 600")
 	}
+
+
+	viper.SetConfigFile(viper.GetString(ArgConfig))
+	err := viper.ReadInConfig()
+	if err != nil {
+		return err
+	}
+	return nil
 
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -44,9 +44,10 @@ const (
 	DefaultWait           = false
 	DefaultTimeoutSeconds = int(60)
 
-	Username         = "userdata.name"
-	Password         = "userdata.password"
-	Token            = "userdata.token"
-	ServerUrl        = "userdata.api-url"
+	Username         = "name"
+	Password         = "password"
+	Token            = "token"
+	ServerUrl        = "api-url"
+
 	CLIHttpUserAgent = "cli-user-agent"
 )

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -44,10 +44,10 @@ const (
 	DefaultWait           = false
 	DefaultTimeoutSeconds = int(60)
 
-	Username         = "userdata.name"
-	Password         = "userdata.password"
-	Token            = "userdata.token"
-	ServerUrl        = "userdata.api-url"
+	Username  = "userdata.name"
+	Password  = "userdata.password"
+	Token     = "userdata.token"
+	ServerUrl = "userdata.api-url"
 
 	CLIHttpUserAgent = "cli-user-agent"
 )

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -44,10 +44,10 @@ const (
 	DefaultWait           = false
 	DefaultTimeoutSeconds = int(60)
 
-	Username         = "name"
-	Password         = "password"
-	Token            = "token"
-	ServerUrl        = "api-url"
+	Username         = "userdata.name"
+	Password         = "userdata.password"
+	Token            = "userdata.token"
+	ServerUrl        = "userdata.api-url"
 
 	CLIHttpUserAgent = "cli-user-agent"
 )

--- a/pkg/testdata/config.json
+++ b/pkg/testdata/config.json
@@ -1,6 +1,8 @@
 {
-  "userdata.api-url": "https://api.ionos.com",
-  "userdata.name": "test@ionos.com",
-  "userdata.password": "test",
-  "userdata.token": "jwt-token"
+  "userdata": {
+    "api-url": "https://api.ionos.com",
+    "name": "test@ionos.com",
+    "password": "test",
+    "token": "jwt-token"
+  }
 }


### PR DESCRIPTION
## What does this fix or implement?

**Currently**, After logging in, the generated config.json file uses dot-notation to interpret JSON levels:

```
{
  "userdata.api-url": "https://api.ionos.com",
  "userdata.name": "test@ionos.com",
  "userdata.password": "test",
  "userdata.token": "jwt-token"
}
```

**After this PR will be merged**, `api-url`, `name`, `password`, `token` will be nested under `userdata` JSON object:

```
{
  "userdata": {
    "api-url": "https://api.ionos.com",
    "name": "test@ionos.com",
    "password": "test",
    "token": "jwt-token""
  }
}
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Sonar Cloud Scan
- [x] Jira task updated
