### PR TITLE
add ionosctl as snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: ionosctl # registered name
+summary: IONOS Cloud CLI tool.
+base: core18
+description: |
+  The IONOS Cloud CLI (ionosctl) gives the ability to manage IONOS Cloud infrastructure directly from Command Line.
+
+adopt-info: ionosctl
+grade: stable
+confinement: strict
+architectures:
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+apps:
+  ionosctl:
+    command: bin/ionosctl
+    plugs:
+      - home
+      - network
+      - removable-media
+
+parts:
+  ionosctl:
+    plugin: nil
+    source: https://github.com/ionos-cloud/ionosctl.git
+    source-type: git
+    override-pull: |
+      git clone https://github.com/ionos-cloud/ionosctl.git src/github.com/ionos-cloud/ionosctl
+       cd src/github.com/ionos-cloud/ionosctl
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+      override-build: |
+      export GOPATH=$PWD
+      env CGO_ENABLED=0 GOOS=linux \
+      go build --ldflags "-s -w \
+        -X github.com/ionos-cloud/ionosctl/commands.Version=$(git describe --tags --abbrev=0)' \
+        -X 'github.com/ionos-cloud/ionosctl/commands.Label=release'" \
+        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/ionosctl
+    build-snaps:
+    - go
+    build-packages:
+    - git
+    - sed


### PR DESCRIPTION
## What does this fix or implement?

Allows ionosctl to be built as a snap.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
