### PR TITLE
fix: wrong brew tap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ snap install ionosctl
 You can install `ionosctl` using the [Homebrew](https://brew.sh) package manager:
 
 ```bash
-brew tap ionos-cloud/homebrew-ionosctl-tap
+brew tap ionos-cloud/homebrew-ionos-cloud
 brew install ionosctl
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ snap install ionosctl
 You can install `ionosctl` using the [Homebrew](https://brew.sh) package manager:
 
 ```bash
-brew tap ionos-cloud/homebrew-ionosctl-tap
+brew tap ionos-cloud/homebrew-ionos-cloud
 brew install ionosctl
 ```
 


### PR DESCRIPTION
## What does this fix or implement?

missed this when code reviewing for #181 :disappointed: 

```
brew tap ionos-cloud/homebrew-ionosctl-tap
brew install ionosctl
```

should be

```
brew tap ionos-cloud/homebrew-ionos-cloud
brew install ionosctl
```

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Documentation updated