### PR TITLE
feat: add commit hash to dev version

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -38,7 +38,8 @@ var (
 	Version string
 	// Label - If label is not set, the version will be: DEV
 	// If label is set as `release`, it will show the version released
-	Label string
+	Label     string
+	GitCommit string
 
 	IonosctlVersion cliVersion
 )
@@ -144,6 +145,7 @@ func initVersion() {
 	}
 	if Label == "" {
 		IonosctlVersion.label = CLIVersionDev
+		IonosctlVersion.hash = GitCommit
 	} else {
 		IonosctlVersion.label = Label
 	}
@@ -152,11 +154,12 @@ func initVersion() {
 type cliVersion struct {
 	version string
 	label   string
+	hash    string
 }
 
 func (v cliVersion) GetVersion() string {
 	if v.label != "release" {
-		return fmt.Sprintf("%s", v.label)
+		return fmt.Sprintf("%s - %s", v.label, v.hash)
 	} else {
 		return fmt.Sprintf("%s", v.version)
 	}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -6,9 +6,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../"
 OUT_D=${OUT_D:-${DIR}/builds}
 mkdir -p "${OUT_D}"
 
-version="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
+VERSION="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
+GIT_COMMIT="$(git rev-parse --short HEAD)"
 
-ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${version}"
+ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/commands.GitCommit=${GIT_COMMIT}"
 
 (
     export GO111MODULE=on

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -8,6 +8,7 @@ mkdir -p "${OUT_D}"
 
 VERSION="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
 GIT_COMMIT="$(git rev-parse --short HEAD)"
+[[ -n $(git status -s) ]] && echo 'modified and/or untracked diff' && GIT_COMMIT="${GIT_COMMIT}.modified"
 
 ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/commands.GitCommit=${GIT_COMMIT}"
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
-version="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
+VERSION="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
 GIT_COMMIT="$(git rev-parse --short HEAD)"
+[[ -n $(git status -s) ]] && echo 'modified and/or untracked diff' && GIT_COMMIT="${GIT_COMMIT}.modified"
 
-ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${version} -X github.com/ionos-cloud/ionosctl/commands.GitCommit=${GIT_COMMIT}"
+ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/commands.GitCommit=${GIT_COMMIT}"
 
 (
     export GO111MODULE=on

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 version="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
+GIT_COMMIT="$(git rev-parse --short HEAD)"
 
-ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${version}"
+ldflags="-X github.com/ionos-cloud/ionosctl/commands.Version=${version} -X github.com/ionos-cloud/ionosctl/commands.GitCommit=${GIT_COMMIT}"
 
 (
     export GO111MODULE=on


### PR DESCRIPTION
## What does this fix or implement?

add commit hash to `ionosctl version`, as well as way to distinguish if git diff is empty or not

```
 % ./builds/ionosctl_linux_amd64 version
IONOS Cloud CLI version: DEV - dc7bf63
SDK GO version: 6.1.0
SDK GO DBaaS Postgres version: v1.0.3
SDK GO Auth version: 1.0.4
```

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
