### PR TITLE
fix: stray character in ionosctl version for snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
       export GOPATH=$PWD
       env CGO_ENABLED=0 GOOS=linux \
       go build --ldflags "-s -w \
-        -X github.com/ionos-cloud/ionosctl/commands.Version=$(git describe --tags --abbrev=0)' \
+        -X 'github.com/ionos-cloud/ionosctl/commands.Version=$(git describe --tags --abbrev=0)' \
         -X 'github.com/ionos-cloud/ionosctl/commands.Label=release'" \
         -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/ionosctl
     build-snaps:


### PR DESCRIPTION
snap releases have stray character in output of version command: IONOS Cloud CLI version: v6.3.2'

## What does this fix or implement?

```
~$ ionosctl version
IONOS Cloud CLI version: v6.3.2'
SDK GO version: 6.1.3
SDK GO DBaaS Postgres version: 1.0.4
SDK GO Auth version: 1.0.5
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
