### PR TITLE
enhancement: limit flag value to values in specific set

### DIFF
--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/ionos-cloud/ionosctl/commands/cloudapi-v6/query"
 	"os"
+	"strings"
 
 	"github.com/fatih/structs"
 	"github.com/ionos-cloud/ionosctl/commands/cloudapi-v6/completer"
@@ -33,6 +34,10 @@ func LabelCmd() *core.Command {
 	_ = labelCmd.Command.RegisterFlagCompletionFunc(config.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultLabelResourceCols, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	var (
+		allowedValues = []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}
+	)
 
 	/*
 		List Command
@@ -69,10 +74,7 @@ func LabelCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddLabelResourceFlag(cloudapiv6.ArgResourceType, "", "", fmt.Sprintf("Type of the resource to list labels from. Can be one of: %s, %s, %s, %s, %s", cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource))
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
-	})
+	list.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, fmt.Sprintf("Type of the resource to list labels from. Can be one of: %s", strings.Join(allowedValues, ", ")), core.RequiredFlagOption())
 	list.AddBoolFlag(config.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
@@ -120,10 +122,7 @@ func LabelCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddLabelResourceFlag(cloudapiv6.ArgResourceType, "", "", "Type of the resource to get label from", core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
-	})
+	get.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, fmt.Sprintf("Type of the resource to get labels from. Can be one of: %s", strings.Join(allowedValues, ", ")), core.RequiredFlagOption())
 	get.AddBoolFlag(config.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
@@ -182,10 +181,7 @@ func LabelCmd() *core.Command {
 	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	addLabel.AddLabelResourceFlag(cloudapiv6.ArgResourceType, "", "", "Type of the resource to add label to", core.RequiredFlagOption())
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
-	})
+	addLabel.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, fmt.Sprintf("Type of the resource to add label to. Can be one of: %s", strings.Join(allowedValues, ", ")), core.RequiredFlagOption())
 	addLabel.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -224,10 +220,7 @@ func LabelCmd() *core.Command {
 	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	removeLabel.AddLabelResourceFlag(cloudapiv6.ArgResourceType, "", "", "Type of the resource to remove label for", core.RequiredFlagOption())
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}, cobra.ShellCompDirectiveNoFileComp
-	})
+	removeLabel.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, fmt.Sprintf("Type of the resource to remove label from. Can be one of: %s", strings.Join(allowedValues, ", ")), core.RequiredFlagOption())
 	removeLabel.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all Labels.")
 	removeLabel.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
 

--- a/docs/subcommands/compute-engine/label-add.md
+++ b/docs/subcommands/compute-engine/label-add.md
@@ -45,7 +45,7 @@ Required values to run command:
       --label-value string     The unique Label Value (required)
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
-      --resource-type string   Type of the resource to add label to (required)
+      --resource-type string   Type of the resource to add label to. Can be one of: datacenter, volume, server, snapshot, ipblock (required)
       --server-id string       The unique Server Id
       --snapshot-id string     The unique Snapshot Id
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-get.md
+++ b/docs/subcommands/compute-engine/label-get.md
@@ -44,7 +44,7 @@ Required values to run command:
       --no-headers             When using text output, don't print headers
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
-      --resource-type string   Type of the resource to get label from (required)
+      --resource-type string   Type of the resource to get labels from. Can be one of: datacenter, volume, server, snapshot, ipblock (required)
       --server-id string       The unique Server Id
       --snapshot-id string     The unique Snapshot Id
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-list.md
+++ b/docs/subcommands/compute-engine/label-list.md
@@ -45,7 +45,7 @@ Available Filters:
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
-      --resource-type string   Type of the resource to list labels from. Can be one of: datacenter, volume, server, snapshot, ipblock
+      --resource-type string   Type of the resource to list labels from. Can be one of: datacenter, volume, server, snapshot, ipblock (required)
       --server-id string       The unique Server Id
       --snapshot-id string     The unique Snapshot Id
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/compute-engine/label-remove.md
+++ b/docs/subcommands/compute-engine/label-remove.md
@@ -44,7 +44,7 @@ Required values to run command:
       --label-key string       The unique Label Key (required)
   -o, --output string          Desired output format [text|json] (default "text")
   -q, --quiet                  Quiet output
-      --resource-type string   Type of the resource to remove label for (required)
+      --resource-type string   Type of the resource to remove label from. Can be one of: datacenter, volume, server, snapshot, ipblock (required)
       --server-id string       The unique Server Id
       --snapshot-id string     The unique Snapshot Id
   -v, --verbose                Print step-by-step process when running command

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -99,14 +99,18 @@ func (c *Command) AddUUIDFlag(name, shorthand, defaultValue, desc string, option
 	}
 }
 
-func (c *Command) AddLabelResourceFlag(name, shorthand, defaultValue, desc string, optionFunc ...FlagOptionFunc) {
+func (c *Command) AddSetFlag(name, shorthand, defaultValue string, allowed []string, desc string, optionFunc ...FlagOptionFunc) {
 	flags := c.Command.Flags()
 	if shorthand != "" {
-		flags.VarP(newLabelResourceFlag(defaultValue), name, shorthand, desc)
+		flags.VarP(newSetFlag(defaultValue, allowed), name, shorthand, desc)
 	} else {
-		flags.Var(newLabelResourceFlag(defaultValue), name, desc)
+		flags.Var(newSetFlag(defaultValue, allowed), name, desc)
 	}
 	viper.BindPFlag(GetFlagName(c.NS, name), c.Command.Flags().Lookup(name))
+
+	_ = c.Command.RegisterFlagCompletionFunc(name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return allowed, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	// Add Option to Flag
 	for _, option := range optionFunc {

--- a/pkg/core/flag.go
+++ b/pkg/core/flag.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/google/uuid"
-	cloudapiv6 "github.com/ionos-cloud/ionosctl/services/cloudapi-v6"
 	"github.com/spf13/viper"
 	"strings"
 )
@@ -260,19 +259,4 @@ func (a *SetFlag) Type() string {
 
 func (a SetFlag) String() string {
 	return a.Value
-}
-
-// -
-
-// Can only be a string for which there is a corresponding endpoint in cloudapi labels API
-// For example, https://api.ionos.com/cloudapi/v6/datacenters/{datacenterId}/servers/{serverId}/labels
-// As of Sep. 2022, the set of valid strings are "datacenter", "server", "volume", "ipblock", "snapshot".
-func newLabelResourceFlag(defaultValue string) *SetFlag {
-	return newSetFlag(defaultValue, []string{
-		cloudapiv6.DatacenterResource,
-		cloudapiv6.ServerResource,
-		cloudapiv6.VolumeResource,
-		cloudapiv6.IpBlockResource,
-		cloudapiv6.SnapshotResource,
-	})
 }

--- a/pkg/core/flag.go
+++ b/pkg/core/flag.go
@@ -218,30 +218,22 @@ func (u uuidFlag) String() string {
 
 /// -- END UUID FLAG TYPE --
 
-// LabelResourceFlag /
-// Can only be a string for which there is a corresponding endpoint in cloudapi labels API
-// For example, https://api.ionos.com/cloudapi/v6/datacenters/{datacenterId}/servers/{serverId}/labels
-// As of Sep. 2022, the set of valid strings are "datacenter", "server", "volume", "ipblock", "snapshot".
+// SetFlag /
+// Values set for this flag must be part of allowed values
 // NOTE: Track progress of https://github.com/spf13/pflag/issues/236 : Might be implemented in pflag
-type LabelResourceFlag struct {
+type SetFlag struct {
 	Value   string
 	Allowed []string
 }
 
-func newLabelResourceFlag(defaultValue string) *LabelResourceFlag {
-	return &LabelResourceFlag{
-		Value: defaultValue,
-		Allowed: []string{
-			cloudapiv6.DatacenterResource,
-			cloudapiv6.ServerResource,
-			cloudapiv6.VolumeResource,
-			cloudapiv6.IpBlockResource,
-			cloudapiv6.SnapshotResource,
-		},
+func newSetFlag(defaultValue string, Allowed []string) *SetFlag {
+	return &SetFlag{
+		Value:   defaultValue,
+		Allowed: Allowed,
 	}
 }
 
-func (a *LabelResourceFlag) Set(p string) error {
+func (a *SetFlag) Set(p string) error {
 	isIncluded := func(opts []string, val string) bool {
 		for _, opt := range opts {
 			if val == opt {
@@ -252,10 +244,9 @@ func (a *LabelResourceFlag) Set(p string) error {
 	}
 	if !isIncluded(a.Allowed, p) {
 		return fmt.Errorf(
-			"Resource %s does not have a specific Label API endpoint. Please use -%s/--%s instead, or one of these values: %s",
+			"value %s is incompatible with flag %s. Please pick one of these values: %s",
+			a.Value,
 			p,
-			cloudapiv6.ArgFiltersShort,
-			cloudapiv6.ArgFilters,
 			strings.Join(a.Allowed, ","),
 		)
 	}
@@ -263,10 +254,25 @@ func (a *LabelResourceFlag) Set(p string) error {
 	return nil
 }
 
-func (a *LabelResourceFlag) Type() string {
+func (a *SetFlag) Type() string {
 	return "string"
 }
 
-func (a LabelResourceFlag) String() string {
+func (a SetFlag) String() string {
 	return a.Value
+}
+
+// -
+
+// Can only be a string for which there is a corresponding endpoint in cloudapi labels API
+// For example, https://api.ionos.com/cloudapi/v6/datacenters/{datacenterId}/servers/{serverId}/labels
+// As of Sep. 2022, the set of valid strings are "datacenter", "server", "volume", "ipblock", "snapshot".
+func newLabelResourceFlag(defaultValue string) *SetFlag {
+	return newSetFlag(defaultValue, []string{
+		cloudapiv6.DatacenterResource,
+		cloudapiv6.ServerResource,
+		cloudapiv6.VolumeResource,
+		cloudapiv6.IpBlockResource,
+		cloudapiv6.SnapshotResource,
+	})
 }


### PR DESCRIPTION
## What does this fix or implement?

limit flag value to values in specific set. Useful for image upload/patch/delete, label resource, etc.

labelResourceFlag type is now a SetFlag (more general)


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any
- [x] Jira task updated
