### PR TITLE
fix: two vees in version for CLIHttpUserAgent

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -40,8 +40,6 @@ var (
 	// If label is set as `release`, it will show the version released
 	Label     string
 	GitCommit string
-
-	IonosctlVersion cliVersion
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -77,13 +75,12 @@ func init() {
 	rootCmd.Command.SetHelpCommand(helpCommand)
 
 	// Init version
-	initVersion()
-	rootCmd.Command.Version = IonosctlVersion.GetVersion()
-	if rootCmd.Command.Version != CLIVersionDev {
-		viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/v%v", IonosctlVersion.GetVersion()))
+	if Label == "release" {
+		rootCmd.Command.Version = "v" + strings.TrimLeft(Version, "v ")
 	} else {
-		viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", IonosctlVersion.GetVersion()))
+		rootCmd.Command.Version = fmt.Sprintf("%s-%s", CLIVersionDev, GitCommit)
 	}
+	viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", rootCmd.Command.Version))
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -137,32 +134,6 @@ func initConfig() {
 	// IONOS_USERNAME, IONOS_PASSWORD or IONOS_TOKEN
 	// The user can also overwrite the endpoint: IONOS_API_URL
 	viper.AutomaticEnv()
-}
-
-func initVersion() {
-	if Version != "" {
-		IonosctlVersion.version = Version
-	}
-	if Label == "" {
-		IonosctlVersion.label = CLIVersionDev
-		IonosctlVersion.hash = GitCommit
-	} else {
-		IonosctlVersion.label = Label
-	}
-}
-
-type cliVersion struct {
-	version string
-	label   string
-	hash    string
-}
-
-func (v cliVersion) GetVersion() string {
-	if v.label != "release" {
-		return fmt.Sprintf("%s - %s", v.label, v.hash)
-	} else {
-		return fmt.Sprintf("%s", v.version)
-	}
 }
 
 // AddCommands adds sub commands to the base command.


### PR DESCRIPTION
## What does this fix or implement?

double `v` characters in kibana logs. `ionosctl/vv6.3.3_ionos-cloud-sdk-go/v6.1.3`

removed duplicated code (struct cliVersion) 

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
