### PR TITLE
feat: update after image ftp upload

### DIFF
--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -335,13 +335,8 @@ func DeleteAllNonPublicImages(c *core.CommandConfig) error {
 	return nil
 }
 
-func RunImageUpdate(c *core.CommandConfig) error {
-	listQueryParams, err := query.GetListQueryParams(c)
-	if err != nil {
-		return err
-	}
-	queryParams := listQueryParams.QueryParams
-
+// returns an ImageProperties object which reflects the currently set flags
+func getDesiredImageAfterPatch(c *core.CommandConfig) resources.ImageProperties {
 	input := resources.ImageProperties{}
 	c.Command.Command.Flags().VisitAll(func(flag *pflag.Flag) {
 		val := flag.Value.String()
@@ -398,6 +393,17 @@ func RunImageUpdate(c *core.CommandConfig) error {
 		}
 		c.Printer.Verbose(fmt.Sprintf("Property %s set: %s", flag.Name, flag.Value))
 	})
+	return input
+}
+
+func RunImageUpdate(c *core.CommandConfig) error {
+	listQueryParams, err := query.GetListQueryParams(c)
+	if err != nil {
+		return err
+	}
+	queryParams := listQueryParams.QueryParams
+
+	input := getDesiredImageAfterPatch(c)
 	img, resp, err := c.CloudApiV6Services.Images().Update(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)),
 		input,

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -139,20 +139,24 @@ func ImageCmd() *core.Command {
 	update.AddBoolFlag(config.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Image")
-	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Image")
-	update.AddSetFlag(cloudapiv6.ArgLicenceType, "", "UNKNOWN", []string{"UNKNOWN", "WINDOWS", "WINDOWS2016", "WINDOWS2022", "LINUX", "OTHER"}, "The OS type of this image")
-	update.AddSetFlag("cloud-init", "", "V1", []string{"V1", "NONE"}, "Cloud init compatibility")
-	update.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", true, "'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
-	update.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", true, "'Hot-Plug' RAM")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", true, "'Hot-Plug' NIC")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", true, "'Hot-Plug' Virt-IO drive")
-	update.AddBoolFlag(cloudapiv6.ArgDiscScsiHotPlug, "", true, "'Hot-Plug' SCSI drive")
-	update.AddBoolFlag(cloudapiv6.ArgCpuHotUnplug, "", false, "'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
-	update.AddBoolFlag(cloudapiv6.ArgRamHotUnplug, "", false, "'Hot-Unplug' RAM")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "'Hot-Unplug' NIC")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "'Hot-Unplug' Virt-IO drive")
-	update.AddBoolFlag(cloudapiv6.ArgDiscScsiHotUnplug, "", false, "'Hot-Unplug' SCSI drive")
+	addPropertiesFlags := func(command *core.Command) {
+		command.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Image")
+		command.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Image")
+		command.AddSetFlag(cloudapiv6.ArgLicenceType, "", "UNKNOWN", []string{"UNKNOWN", "WINDOWS", "WINDOWS2016", "WINDOWS2022", "LINUX", "OTHER"}, "The OS type of this image")
+		command.AddSetFlag("cloud-init", "", "V1", []string{"V1", "NONE"}, "Cloud init compatibility")
+		command.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", true, "'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
+		command.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", true, "'Hot-Plug' RAM")
+		command.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", true, "'Hot-Plug' NIC")
+		command.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", true, "'Hot-Plug' Virt-IO drive")
+		command.AddBoolFlag(cloudapiv6.ArgDiscScsiHotPlug, "", true, "'Hot-Plug' SCSI drive")
+		command.AddBoolFlag(cloudapiv6.ArgCpuHotUnplug, "", false, "'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
+		command.AddBoolFlag(cloudapiv6.ArgRamHotUnplug, "", false, "'Hot-Unplug' RAM")
+		command.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "'Hot-Unplug' NIC")
+		command.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "'Hot-Unplug' Virt-IO drive")
+		command.AddBoolFlag(cloudapiv6.ArgDiscScsiHotUnplug, "", false, "'Hot-Unplug' SCSI drive")
+	}
+
+	addPropertiesFlags(update)
 
 	/*
 		Delete Command
@@ -206,6 +210,10 @@ func ImageCmd() *core.Command {
 	upload.AddStringFlag("crt-path", "", "", "(Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.")
 	upload.AddStringSliceFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, nil, "Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path")
 	upload.AddIntFlag("timeout", "", 300, "(seconds) Context Deadline. FTP connection will time out after this many seconds")
+
+	addPropertiesFlags(upload)
+
+	upload.Command.Flags().SortFlags = false // Hot Plugs generate a lot of flags to scroll through, put them at the end
 
 	return imageCmd
 }

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -209,7 +209,7 @@ func ImageCmd() *core.Command {
 	upload.AddBoolFlag("skip-verify", "", false, "Skip verification of server certificate, useful if using a custom ftp-url. WARNING: You can be the target of a man-in-the-middle attack!")
 	upload.AddStringFlag("crt-path", "", "", "(Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.")
 	upload.AddStringSliceFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, nil, "Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path")
-	upload.AddIntFlag("timeout", "", 300, "(seconds) Context Deadline. FTP connection will time out after this many seconds")
+	upload.AddIntFlag(config.ArgTimeout, config.ArgTimeoutShort, 300, "(seconds) Context Deadline. FTP connection will time out after this many seconds")
 
 	addPropertiesFlags(upload)
 
@@ -495,7 +495,7 @@ func RunImageUpload(c *core.CommandConfig) error {
 	aliases := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias))
 	locations := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgLocation))
 	skipVerify := viper.GetBool(core.GetFlagName(c.NS, "skip-verify"))
-	timeout := viper.GetInt(core.GetFlagName(c.NS, "timeout"))
+	timeout := viper.GetInt(core.GetFlagName(c.NS, config.ArgTimeout))
 	var eg errgroup.Group
 	for _, loc := range locations {
 		for imgIdx, img := range images {
@@ -542,7 +542,7 @@ func RunImageUpload(c *core.CommandConfig) error {
 		return err
 	}
 
-	_ = c.Printer.Print("Upload successful!")
+	c.Printer.Verbose("Upload successful in ")
 
 	return nil
 }

--- a/docs/subcommands/compute-engine/image-upload.md
+++ b/docs/subcommands/compute-engine/image-upload.md
@@ -36,22 +36,36 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string        Override default host url (default "https://api.ionos.com")
-      --cols strings          Set of columns to be printed on output 
-                              Available columns: [ImageId Name ImageAliases Location Size LicenceType ImageType Description Public CloudInit CreatedDate CreatedBy CreatedByUserId] (default [ImageId,Name,ImageAliases,Location,LicenceType,ImageType,CloudInit,CreatedDate])
-  -c, --config string         Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
-      --crt-path string       (Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.
-  -f, --force                 Force command to execute without user input
-      --ftp-url string        URL of FTP server, with %s flag if location is embedded into url (default "ftp-%s.ionos.com")
-  -h, --help                  Print usage
-  -i, --image strings         Slice of paths to images, absolute path or relative to ionosctl binary. (required)
-  -a, --image-alias strings   Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path
-  -l, --location strings      Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit (required)
-  -o, --output string         Desired output format [text|json] (default "text")
-  -q, --quiet                 Quiet output
-      --skip-verify           Skip verification of server certificate, useful if using a custom ftp-url. WARNING: You can be the target of a man-in-the-middle attack!
-      --timeout int           (seconds) Context Deadline. FTP connection will time out after this many seconds (default 300)
-  -v, --verbose               Print step-by-step process when running command
+  -u, --api-url string           Override default host url (default "https://api.ionos.com")
+      --cloud-init string        Cloud init compatibility. Can be one of: V1, NONE (default "V1")
+      --cols strings             Set of columns to be printed on output 
+                                 Available columns: [ImageId Name ImageAliases Location Size LicenceType ImageType Description Public CloudInit CreatedDate CreatedBy CreatedByUserId] (default [ImageId,Name,ImageAliases,Location,LicenceType,ImageType,CloudInit,CreatedDate])
+  -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
+      --cpu-hot-plug             'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug (default true)
+      --cpu-hot-unplug           'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug
+      --crt-path string          (Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.
+  -d, --description string       Description of the Image
+      --disc-scsi-hot-plug       'Hot-Plug' SCSI drive (default true)
+      --disc-scsi-hot-unplug     'Hot-Unplug' SCSI drive
+      --disc-virtio-hot-plug     'Hot-Plug' Virt-IO drive (default true)
+      --disc-virtio-hot-unplug   'Hot-Unplug' Virt-IO drive
+  -f, --force                    Force command to execute without user input
+      --ftp-url string           URL of FTP server, with %s flag if location is embedded into url (default "ftp-%s.ionos.com")
+  -h, --help                     Print usage
+  -i, --image strings            Slice of paths to images, absolute path or relative to ionosctl binary. (required)
+  -a, --image-alias strings      Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path
+      --licence-type string      The OS type of this image. Can be one of: UNKNOWN, WINDOWS, WINDOWS2016, WINDOWS2022, LINUX, OTHER (default "UNKNOWN")
+  -l, --location strings         Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit (required)
+  -n, --name string              Name of the Image
+      --nic-hot-plug             'Hot-Plug' NIC (default true)
+      --nic-hot-unplug           'Hot-Unplug' NIC
+  -o, --output string            Desired output format [text|json] (default "text")
+  -q, --quiet                    Quiet output
+      --ram-hot-plug             'Hot-Plug' RAM (default true)
+      --ram-hot-unplug           'Hot-Unplug' RAM
+      --skip-verify              Skip verification of server certificate, useful if using a custom ftp-url. WARNING: You can be the target of a man-in-the-middle attack!
+  -t, --timeout int              (seconds) Context Deadline. FTP connection will time out after this many seconds (default 300)
+  -v, --verbose                  Print step-by-step process when running command
 ```
 
 ## Examples

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,10 +34,10 @@ func StringSlicesEqual(a, b []string) bool {
 }
 
 // Map applies a function to a slice, and returns the modified slice
-func Map(s []string, f func(string) string) []string {
+func Map(s []string, f func(int, string) string) []string {
 	sm := make([]string, len(s))
 	for i, v := range s {
-		sm[i] = f(v)
+		sm[i] = f(i, v)
 	}
 	return sm
 }


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Get uploaded images using a List & filter. For each uploaded image, run an image update on it

NOTES: https://jira.sso.ionos.cloud/browse/SDK-1163. Currently can't filter over a single key with multiple values (i.e. `image list` with filter `locations=fra,fkb,txl` is not possible yet).

Scenario - error is thrown: User uploads `kolibri.iso` to `fra` and `txl`. What if another image with same alias, `kolibri.iso` already exists at different location, `fkb`? The `diff`-finding `image list` would also register `kolibri.iso` at `fkb` as a newly uploaded image.    The solution is to limit the `diff`-finding `image list` to `location=fra,txl` (aka Filter by Location key with multiple values), however this is impossible right now until SDK-1163. As a temporary workaround, an error is thrown


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
