### PR TITLE
feat: Improve string slice printing

### DIFF
--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -180,8 +180,6 @@ func printText(out io.Writer, cols []string, keyValueMap []map[string]interface{
 		for _, col := range cols {
 			v := r[col]
 
-			values = append(values, v)
-
 			switch v.(type) {
 			case string:
 				formats = append(formats, "%s")
@@ -191,9 +189,15 @@ func printText(out io.Writer, cols []string, keyValueMap []map[string]interface{
 				formats = append(formats, "%f")
 			case bool:
 				formats = append(formats, "%v")
+			case []string:
+				formats = append(formats, "%s")
+				v = strings.Join(v.([]string), ",")
 			default:
 				formats = append(formats, "%v")
 			}
+
+			values = append(values, v)
+
 		}
 		format := strings.Join(formats, "\t")
 		_, err := fmt.Fprintf(w, format+"\n", values...)

--- a/pkg/printer/result_test.go
+++ b/pkg/printer/result_test.go
@@ -1,8 +1,10 @@
 package printer
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetHeaders(t *testing.T) {
@@ -74,4 +76,27 @@ func TestGetHeaders(t *testing.T) {
 			assert.Equalf(t, tt.want, GetHeaders(tt.args.allColumns, tt.args.defaultColumns, tt.args.customColumns), "GetHeaders(%v, %v, %v)", tt.args.allColumns, tt.args.defaultColumns, tt.args.customColumns)
 		})
 	}
+}
+
+func TestPrintText(t *testing.T) {
+	buf := new(bytes.Buffer)
+	headers := []string{
+		"String", "Int", "Float64", "Bool", "StringSlice",
+	}
+	kvmap := []map[string]interface{}{
+		{
+			"String":      "string",
+			"Int":         int(1),
+			"Float64":     float64(1.123),
+			"Bool":        true,
+			"StringSlice": []string{"a", "b"},
+		},
+	}
+
+	assert.NoError(t, printText(buf, headers, kvmap, false))
+
+	expectOut := `String   Int   Float64    Bool   StringSlice
+string   1     1.123000   true   a,b
+`
+	assert.Equal(t, expectOut, buf.String())
 }


### PR DESCRIPTION
## What does this fix or implement?

Using the default go representation of string slices is a bit cumbersome to process on the command line.
The text output of read commands should be valid input for writing and `[a, b]` is not a valid string slice input.

Consider the following scenario that this change makes possible (ID flags omitted for brevity):

```sh
ionosctl nic update --ips "$(ionosctl nic get --cols Ips --no-headers | cut -d, -f1)"
```

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
