### PR TITLE
feat: Add dynamic completion for --cpu-family

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,9 @@ modules.xml
 
 
 # End of https://www.toptal.com/developers/gitignore/api/go,goland+iml,webstorm+iml,visualstudiocode
+
+# Contains built binaries
+builds/
+
+# direnv config
+.envrc

--- a/commands/cloudapi-v6/completer/properties.go
+++ b/commands/cloudapi-v6/completer/properties.go
@@ -1,0 +1,30 @@
+package completer
+
+import (
+	"context"
+	"io"
+
+	"github.com/ionos-cloud/ionosctl/pkg/utils/clierror"
+	"github.com/ionos-cloud/ionosctl/services/cloudapi-v6/resources"
+)
+
+// DatacenterCPUFamilies returns the list of available CPU families in a given datacenter
+// If the datacenter ID is not provided returns a set of possible default values.
+func DatacenterCPUFamilies(ctx context.Context, outErr io.Writer, datacenterId string) []string {
+	if datacenterId == "" {
+		return []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}
+	}
+	client, err := getClient()
+	clierror.CheckError(err, outErr)
+	dcSvc := resources.NewDataCenterService(client, ctx)
+	dc, _, err := dcSvc.Get(datacenterId, resources.QueryParams{})
+	clierror.CheckError(err, outErr)
+	if dc.Properties == nil || dc.Properties.CpuArchitecture == nil {
+		return nil
+	}
+	result := make([]string, len(*dc.Properties.CpuArchitecture))
+	for i, arch := range *dc.Properties.CpuArchitecture {
+		result[i] = *arch.CpuFamily
+	}
+	return result
+}

--- a/commands/cloudapi-v6/completer/properties_test.go
+++ b/commands/cloudapi-v6/completer/properties_test.go
@@ -1,0 +1,13 @@
+package completer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatacenterCPUFamiliesDefault(t *testing.T) {
+	cpuFamilies := DatacenterCPUFamilies(context.Background(), nil, "")
+	assert.Equal(t, []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}, cpuFamilies)
+}

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -158,8 +158,9 @@ Required values to run a command (for Private Kubernetes Cluster):
 		return []string{"2048MB", "3GB", "4GB", "5GB", "10GB", "50GB", "100GB"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(cloudapiv6.ArgCpuFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Type")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCpuFamily, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}, cobra.ShellCompDirectiveNoFileComp
+	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
+		return completer.DatacenterCPUFamilies(create.Command.Context(), os.Stderr, datacenterId), cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(cloudapiv6.ArgAvailabilityZone, cloudapiv6.ArgAvailabilityZoneShort, "AUTO", "The compute Availability Zone in which the Node should exist")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCpuFamily, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -166,8 +166,9 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 		return []string{"256MB", "512MB", "1024MB", "2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(cloudapiv6.ArgCPUFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Family for the Server. For CUBE Servers, the CPU Family is INTEL_SKYLAKE")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCPUFamily, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}, cobra.ShellCompDirectiveNoFileComp
+	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
+		return completer.DatacenterCPUFamilies(create.Command.Context(), os.Stderr, datacenterId), cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(cloudapiv6.ArgAvailabilityZone, cloudapiv6.ArgAvailabilityZoneShort, "AUTO", "Availability zone of the Server")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -256,8 +256,9 @@ Required values to run command:
 	})
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Server")
 	update.AddStringFlag(cloudapiv6.ArgCPUFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Family of the Server")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCPUFamily, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}, cobra.ShellCompDirectiveNoFileComp
+	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		datacenterId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))
+		return completer.DatacenterCPUFamilies(update.Command.Context(), os.Stderr, datacenterId), cobra.ShellCompDirectiveNoFileComp
 	})
 	update.AddStringFlag(cloudapiv6.ArgAvailabilityZone, cloudapiv6.ArgAvailabilityZoneShort, "", "Availability zone of the Server")
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
## What does this fix or implement?

It's fairly easy to misconfigure a server or k8s node pool by using a CPU family that is not available in the datacenter.
I've added a completer that fetches a datacenter if the corresponding flag was already provided and completes according to what is available.
When `--datacenter-id` is not specified, the default list is returned.

This should make interactive usage of `ionosctl` a bit less error prone.

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
