### PR TITLE
changed pollTime

### DIFF
--- a/pkg/utils/wait.go
+++ b/pkg/utils/wait.go
@@ -14,7 +14,7 @@ import (
 const (
 	failed   = "FAILED"
 	done     = "DONE"
-	pollTime = 10
+	pollTime = time.Second
 )
 
 const (

--- a/pkg/utils/watch.go
+++ b/pkg/utils/watch.go
@@ -143,6 +143,7 @@ func WatchDeletionProgress(ctx context.Context, c *core.CommandConfig, interroga
 		defer close(errChan)
 		defer close(progressChan)
 		ticker := time.NewTicker(pollTime)
+		defer ticker.Stop()
 		sendingProgress := func(p int) {
 			select {
 			case progressChan <- p:

--- a/pkg/utils/watch.go
+++ b/pkg/utils/watch.go
@@ -31,6 +31,7 @@ func WatchStateProgress(ctx context.Context, c *core.CommandConfig, interrogator
 		defer close(errChan)
 		defer close(progressChan)
 		ticker := time.NewTicker(pollTime)
+		defer ticker.Stop()
 		sendingProgress := func(p int) {
 			select {
 			case progressChan <- p:
@@ -88,6 +89,7 @@ func WatchRequestProgress(ctx context.Context, c *core.CommandConfig, interrogat
 		defer close(errChan)
 		defer close(progressChan)
 		ticker := time.NewTicker(pollTime)
+		defer ticker.Stop()
 		sendingProgress := func(p int) {
 			select {
 			case progressChan <- p:


### PR DESCRIPTION
## What does this fix or implement?

ionosctl was checking for response from server every 10 nanoseconds consuming a lot of cpu resources. Now it waits one second.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
