### PR TITLE
fix: Postgres backupid flag type

### DIFF
--- a/commands/dbaas/postgres/backup.go
+++ b/commands/dbaas/postgres/backup.go
@@ -70,7 +70,7 @@ func BackupCmd() *core.Command {
 		CmdRun:     RunBackupGet,
 		InitClient: true,
 	})
-	get.AddUUIDFlag(dbaaspg.ArgBackupId, dbaaspg.ArgIdShort, "", dbaaspg.BackupId, core.RequiredFlagOption())
+	get.AddStringFlag(dbaaspg.ArgBackupId, dbaaspg.ArgIdShort, "", dbaaspg.BackupId, core.RequiredFlagOption())
 	_ = get.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/commands/dbaas/postgres/cluster.go
+++ b/commands/dbaas/postgres/cluster.go
@@ -255,7 +255,7 @@ Required values to run command:
 	_ = restoreCmd.Command.RegisterFlagCompletionFunc(dbaaspg.ArgClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ClustersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
-	restoreCmd.AddUUIDFlag(dbaaspg.ArgBackupId, "", "", "The unique ID of the backup you want to restore", core.RequiredFlagOption())
+	restoreCmd.AddStringFlag(dbaaspg.ArgBackupId, "", "", "The unique ID of the backup you want to restore", core.RequiredFlagOption())
 	_ = restoreCmd.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupsIdsForCluster(os.Stderr, viper.GetString(core.GetFlagName(restoreCmd.NS, dbaaspg.ArgClusterId))), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/commands/dbaas/postgres/cluster.go
+++ b/commands/dbaas/postgres/cluster.go
@@ -152,7 +152,7 @@ Required values to run command:
 		return cloudapiv6completer.LansIds(os.Stderr, viper.GetString(core.GetFlagName(create.NS, dbaaspg.ArgDatacenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(dbaaspg.ArgCidr, dbaaspg.ArgCidrShort, "", "The IP and subnet for the cluster. Note the following unavailable IP ranges: 10.233.64.0/18, 10.233.0.0/18, 10.233.114.0/24. e.g.: 192.168.1.100/24", core.RequiredFlagOption())
-	create.AddUUIDFlag(dbaaspg.ArgBackupId, dbaaspg.ArgBackupIdShort, "", "The unique ID of the backup you want to restore")
+	create.AddStringFlag(dbaaspg.ArgBackupId, dbaaspg.ArgBackupIdShort, "", "The unique ID of the backup you want to restore")
 	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupsIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/pkg/core/command_runner.go
+++ b/pkg/core/command_runner.go
@@ -179,6 +179,11 @@ type CommandConfig struct {
 	Context context.Context
 }
 
+// TODO: Seems like there's no better way to Verbose print outside of 'commands' pkg, other than instantiating a PrintService as so. PrintService merits a refactor. It seems like without this exported func, I can only make Verbose prints if I am inside of a `commands` command object.
+func GetPrinter(noHeaders bool) printer.PrintService {
+	return getPrinter(noHeaders)
+}
+
 func getPrinter(noHeaders bool) printer.PrintService {
 	var out io.Writer
 	if viper.GetBool(constants.ArgQuiet) {

--- a/pkg/core/flag.go
+++ b/pkg/core/flag.go
@@ -200,7 +200,8 @@ func (u *uuidFlag) Set(p string) error {
 	}
 
 	if !IsValidUUID(p) {
-		return fmt.Errorf("%s does not match UUID-4 format", p)
+		//return fmt.Errorf("%s does not match UUID-4 format", p)
+		_ = getPrinter(true).Warn(fmt.Sprintf("WARNING: %s does not match UUID-4 format", p))
 	}
 
 	// Valid UUID if passed above check


### PR DESCRIPTION
## What does this fix or implement?

Similar to https://github.com/ionos-cloud/ionosctl/pull/220, I found another. Despite the name, the backupID is actually not a UUID, instead it looks like `7aaf0e1b-fdd0-11ec-b738-828eb1aea7fe-4oymiqu-13`.

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [x] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any
- [x] Jira task updated
