### PR TITLE
fix: listing of group resources

### DIFF
--- a/commands/cloudapi-v6/resource.go
+++ b/commands/cloudapi-v6/resource.go
@@ -151,6 +151,7 @@ func GroupResourceCmd() *core.Command {
 		CmdRun:     RunGroupResourceList,
 		InitClient: true,
 	})
+	listResources.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	listResources.AddStringSliceFlag(constants.ArgCols, "", defaultResourceCols, printer.ColsMessage(defaultResourceCols))
 	_ = listResources.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultResourceCols, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
## What does this fix or implement?

Fixes the issue that listing of group resources always returned an empty list. (max-results defaulted to 0)

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
