### PR TITLE
fix: completions for cert manager

### DIFF
--- a/commands/certmanager/delete.go
+++ b/commands/certmanager/delete.go
@@ -3,12 +3,11 @@ package certmanager
 import (
 	"context"
 	"fmt"
-	"github.com/ionos-cloud/ionosctl/pkg/printer"
-	"github.com/spf13/cobra"
-
 	"github.com/ionos-cloud/ionosctl/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/pkg/core"
+	"github.com/ionos-cloud/ionosctl/pkg/printer"
 	"github.com/ionos-cloud/ionosctl/pkg/utils"
+	"github.com/spf13/cobra"
 )
 
 func CertDeleteCmd() *core.Command {
@@ -26,6 +25,9 @@ func CertDeleteCmd() *core.Command {
 	})
 
 	cmd.AddStringFlag(FlagCertId, constants.FlagIdP, "", "Response delete a single certificate (required)")
+	_ = cmd.Command.RegisterFlagCompletionFunc(FlagCertId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return CertificatesIds(), cobra.ShellCompDirectiveNoFileComp
+	})
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Response delete all certificates")
 
 	cmd.Command.Flags().StringSlice(constants.ArgCols, nil, printer.ColsMessage(allCols))

--- a/commands/certmanager/get.go
+++ b/commands/certmanager/get.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/pkg/printer"
 	sdkgo "github.com/ionos-cloud/sdk-go-cert-manager"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func CertGetCmd() *core.Command {
@@ -26,7 +25,7 @@ func CertGetCmd() *core.Command {
 
 	cmd.AddStringFlag(FlagCertId, "i", "", "Response get a single certificate", core.RequiredFlagOption())
 	_ = cmd.Command.RegisterFlagCompletionFunc(FlagCertId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return CertificatesIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
+		return CertificatesIds(), cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.AddBoolFlag(FlagCert, "", false, "Print the certificate")
 	cmd.AddBoolFlag(FlagCertChain, "", false, "Print the certificate chain")

--- a/commands/certmanager/patch.go
+++ b/commands/certmanager/patch.go
@@ -28,6 +28,9 @@ func CertUpdateCmd() *core.Command {
 	})
 
 	cmd.AddStringFlag(FlagCertId, "i", "", "Provide certificate ID", core.RequiredFlagOption())
+	_ = cmd.Command.RegisterFlagCompletionFunc(FlagCertId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return CertificatesIds(), cobra.ShellCompDirectiveNoFileComp
+	})
 	cmd.AddStringFlag(FlagCertName, "n", "", "Provide new certificate name", core.RequiredFlagOption())
 
 	cmd.Command.Flags().StringSlice(constants.ArgCols, nil, printer.ColsMessage(allCols))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,8 +34,8 @@ func StringSlicesEqual(a, b []string) bool {
 }
 
 // Map applies a function to a slice, and returns the modified slice
-func Map(s []string, f func(int, string) string) []string {
-	sm := make([]string, len(s))
+func Map[V comparable, R any](s []V, f func(int, V) R) []R {
+	sm := make([]R, len(s))
 	for i, v := range s {
 		sm[i] = f(i, v)
 	}


### PR DESCRIPTION
## What does this fix or implement?

Added completions for "ID" flag for some certmanager commands

Updated "Map" util function to Go 1.17 standards using generics
