### PR TITLE
fix: version command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Changed
+- Changed `ionosctl version` behaviour to only display the version of the CLI by default. You can use verbose flag to display SDK versions. e.g.
+     ```bash
+      $ ionosctl version
+      v6.5.0
+     ```
+
 ## [6.5.0] (January 2023)
 
 ### Changed

--- a/commands/version.go
+++ b/commands/version.go
@@ -40,22 +40,13 @@ func VersionCmd() *core.Command {
 }
 
 func RunVersion(c *core.CommandConfig) error {
-	err := c.Printer.Print("IONOS Cloud CLI version: " + rootCmd.Command.Version)
+	err := c.Printer.Print(rootCmd.Command.Version)
 	if err != nil {
 		return err
 	}
-	err = c.Printer.Print("SDK GO version: " + sdkgo.Version)
-	if err != nil {
-		return err
-	}
-	err = c.Printer.Print("SDK GO DBaaS Postgres version: " + sdkgodbaaspostgres.Version)
-	if err != nil {
-		return err
-	}
-	err = c.Printer.Print("SDK GO Auth version: " + sdkgoauth.Version)
-	if err != nil {
-		return err
-	}
+	c.Printer.Verbose("sdk-go " + sdkgo.Version)
+	c.Printer.Verbose("sdk-go-dbaas-postgres " + sdkgodbaaspostgres.Version)
+	c.Printer.Verbose("sdk-go-dbaas-auth " + sdkgoauth.Version)
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgUpdates)) {
 		/*

--- a/commands/version.go
+++ b/commands/version.go
@@ -45,10 +45,10 @@ func RunVersion(c *core.CommandConfig) error {
 	if err != nil {
 		return err
 	}
-	c.Printer.Verbose("sdk-go v" + sdkcompute.Version)
-	c.Printer.Verbose("sdk-go-dbaas-postgres v" + sdkpostgres.Version)
-	c.Printer.Verbose("sdk-go-dbaas-auth v" + sdkauth.Version)
-	c.Printer.Verbose("sdk-go-cert-manager v" + sdkcertmanager.Version)
+	c.Printer.Verbose("sdk-go " + sdkcompute.Version)
+	c.Printer.Verbose("sdk-go-dbaas-postgres " + sdkpostgres.Version)
+	c.Printer.Verbose("sdk-go-auth " + sdkauth.Version)
+	c.Printer.Verbose("sdk-go-cert-manager " + sdkcertmanager.Version)
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgUpdates)) {
 		/*

--- a/commands/version.go
+++ b/commands/version.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/pkg/core"
-	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
-	sdkgodbaaspostgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
-	sdkgo "github.com/ionos-cloud/sdk-go/v6"
+	sdkauth "github.com/ionos-cloud/sdk-go-auth"
+	sdkcertmanager "github.com/ionos-cloud/sdk-go-cert-manager"
+	sdkpostgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
+	sdkcompute "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
 )
 
@@ -44,9 +45,10 @@ func RunVersion(c *core.CommandConfig) error {
 	if err != nil {
 		return err
 	}
-	c.Printer.Verbose("sdk-go " + sdkgo.Version)
-	c.Printer.Verbose("sdk-go-dbaas-postgres " + sdkgodbaaspostgres.Version)
-	c.Printer.Verbose("sdk-go-dbaas-auth " + sdkgoauth.Version)
+	c.Printer.Verbose("sdk-go " + sdkcompute.Version)
+	c.Printer.Verbose("sdk-go-dbaas-postgres " + sdkpostgres.Version)
+	c.Printer.Verbose("sdk-go-dbaas-auth " + sdkauth.Version)
+	c.Printer.Verbose("sdk-go-cert-manager " + sdkcertmanager.Version)
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgUpdates)) {
 		/*

--- a/commands/version.go
+++ b/commands/version.go
@@ -45,10 +45,10 @@ func RunVersion(c *core.CommandConfig) error {
 	if err != nil {
 		return err
 	}
-	c.Printer.Verbose("sdk-go " + sdkcompute.Version)
-	c.Printer.Verbose("sdk-go-dbaas-postgres " + sdkpostgres.Version)
-	c.Printer.Verbose("sdk-go-dbaas-auth " + sdkauth.Version)
-	c.Printer.Verbose("sdk-go-cert-manager " + sdkcertmanager.Version)
+	c.Printer.Verbose("sdk-go v" + sdkcompute.Version)
+	c.Printer.Verbose("sdk-go-dbaas-postgres v" + sdkpostgres.Version)
+	c.Printer.Verbose("sdk-go-dbaas-auth v" + sdkauth.Version)
+	c.Printer.Verbose("sdk-go-cert-manager v" + sdkcertmanager.Version)
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgUpdates)) {
 		/*


### PR DESCRIPTION
## What does this fix or implement?
Makes the version command behave predictably, like that of any other CLI:

```bash
$ npm -v
8.3.1
$ python3 --version
Python 3.10.6
$ javac --version
javac 11.0.17
```
etc...

Before:
```bash
$ ionosctl version
IONOS Cloud CLI version: v6.5.0
SDK GO version: 6.1.3
SDK GO DBaaS Postgres version: 1.0.4
SDK GO Auth version: 1.0.5
```

After:
```bash
$ ionosctl version
v6.5.0
```

```bash
$ ionosctl version -v
v6.5.0
[INFO] sdk-go 6.1.3
[INFO] sdk-go-dbaas-postgres 1.0.4
[INFO] sdk-go-dbaas-auth 1.0.5
[INFO] sdk-go-cert-manager v1.0.0
```


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
