### PR TITLE
fix: max results

### DIFF
--- a/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
@@ -73,6 +73,7 @@ func AlbRuleHttpRuleCmd() *core.Command {
 			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
 		), cobra.ShellCompDirectiveNoFileComp
 	})
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/cpu.go
+++ b/commands/cloudapi-v6/cpu.go
@@ -58,6 +58,7 @@ func CpuCmd() *core.Command {
 		return completer.LocationIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	return cpuCmd

--- a/commands/cloudapi-v6/ipconsumer.go
+++ b/commands/cloudapi-v6/ipconsumer.go
@@ -54,6 +54,7 @@ func IpconsumerCmd() *core.Command {
 		return completer.IpBlocksIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
 	listResources.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	listResources.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	listResources.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	return resourceCmd

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -63,6 +63,7 @@ func IpfailoverCmd() *core.Command {
 		return completer.LansIds(os.Stderr, viper.GetString(core.GetFlagName(listCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
 	listCmd.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	listCmd.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	listCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -59,6 +59,7 @@ func K8sNodePoolLanCmd() *core.Command {
 		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -72,6 +72,7 @@ func NlbRuleTargetCmd() *core.Command {
 		), cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -60,17 +60,20 @@ func GetListQueryParams(c *core.CommandConfig) (resources.ListQueryParams, error
 			listQueryParams = listQueryParams.SetFilters(filters)
 		}
 	}
-	orderBy, _ := c.Command.Command.Flags().GetString(cloudapiv6.ArgOrderBy)
-	listQueryParams = listQueryParams.SetOrderBy(orderBy)
 
-	maxResults, _ := c.Command.Command.Flags().GetInt32(cloudapiv6.ArgMaxResults)
-	listQueryParams = listQueryParams.SetMaxResults(maxResults)
+	if c.Command.Command.Flags().Changed(cloudapiv6.ArgMaxResults) {
+		orderBy, _ := c.Command.Command.Flags().GetString(cloudapiv6.ArgOrderBy)
+		listQueryParams = listQueryParams.SetOrderBy(orderBy)
+	}
 
+	if c.Command.Command.Flags().Changed(cloudapiv6.ArgMaxResults) {
+		maxResults, _ := c.Command.Command.Flags().GetInt32(cloudapiv6.ArgMaxResults)
+		listQueryParams = listQueryParams.SetMaxResults(maxResults)
+	}
+
+	// No guard against "changed", as we want the pflag imposed defaults
 	depth, _ := c.Command.Command.Flags().GetInt32(cloudapiv6.ArgDepth)
 	listQueryParams = listQueryParams.SetDepth(depth)
-	// Uncomment this when support for Pretty param is added
-	//	pretty := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgPretty))
-	//	queryParams = queryParams.SetPretty(pretty)
 
 	if !structs.IsZero(listQueryParams) || !structs.IsZero(listQueryParams.QueryParams) {
 		c.Printer.Verbose("Query Parameters set: %v, %v", utils.GetPropertiesKVSet(listQueryParams), utils.GetPropertiesKVSet(listQueryParams.QueryParams))

--- a/commands/cloudapi-v6/resource.go
+++ b/commands/cloudapi-v6/resource.go
@@ -51,6 +51,7 @@ func ResourceCmd() *core.Command {
 		InitClient: true,
 	})
 	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -62,6 +62,7 @@ func UserS3keyCmd() *core.Command {
 		return completer.UsersIds(os.Stderr), cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
+	list.AddInt32Flag(cloudapiv6.ArgMaxResults, cloudapiv6.ArgMaxResultsShort, cloudapiv6.DefaultMaxResults, cloudapiv6.ArgMaxResultsDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/internal/pointer/pointer.go
+++ b/internal/pointer/pointer.go
@@ -1,0 +1,7 @@
+package pointer
+
+// From is a helper routine that allocates a new any value
+// to store v and returns a pointer to it.
+func From[T any](v T) *T {
+	return &v
+}

--- a/services/cloudapi-v6/constants.go
+++ b/services/cloudapi-v6/constants.go
@@ -274,7 +274,7 @@ const (
 	DefaultServerCores     = 2
 	DefaultVolumeSize      = 10
 	DefaultNicLanId        = 1
-	DefaultMaxResults      = 0
+	DefaultMaxResults      = int32(0)
 	DefaultServerCPUFamily = "AMD_OPTERON"
 	DefaultListDepth       = int32(1)
 	DefaultGetDepth        = int32(0)

--- a/services/cloudapi-v6/constants.go
+++ b/services/cloudapi-v6/constants.go
@@ -1,8 +1,6 @@
 package cloudapi_v6
 
 import (
-	"math"
-
 	"github.com/ionos-cloud/ionosctl/services/cloudapi-v6/resources"
 )
 
@@ -276,7 +274,7 @@ const (
 	DefaultServerCores     = 2
 	DefaultVolumeSize      = 10
 	DefaultNicLanId        = 1
-	DefaultMaxResults      = int32(math.MaxInt32)
+	DefaultMaxResults      = 0
 	DefaultServerCPUFamily = "AMD_OPTERON"
 	DefaultListDepth       = int32(1)
 	DefaultGetDepth        = int32(0)

--- a/services/cloudapi-v6/resources/query_params.go
+++ b/services/cloudapi-v6/resources/query_params.go
@@ -13,12 +13,16 @@ func (q ListQueryParams) SetFilters(filters map[string]string) ListQueryParams {
 }
 
 func (q ListQueryParams) SetOrderBy(orderBy string) ListQueryParams {
-	q.OrderBy = &orderBy
+	if orderBy != "" {
+		q.OrderBy = &orderBy
+	}
 	return q
 }
 
 func (q ListQueryParams) SetMaxResults(maxResults int32) ListQueryParams {
-	q.MaxResults = &maxResults
+	if maxResults > 0 {
+		q.MaxResults = &maxResults
+	}
 	return q
 }
 
@@ -31,6 +35,9 @@ func (q ListQueryParams) SetPretty(pretty bool) ListQueryParams {
 	q.QueryParams.Pretty = &pretty
 	return q
 }
+
+// TODO: Merge ListQueryParams into QueryParams
+// TODO: Once Compute namespace is added, add all of QueryParam's flags as Global flags, to reduce duplication
 
 type QueryParams struct {
 	Depth  *int32 `json:"Depth,omitempty"`

--- a/services/cloudapi-v6/resources/query_params_test.go
+++ b/services/cloudapi-v6/resources/query_params_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"github.com/ionos-cloud/ionosctl/internal/pointer"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestListQueryParams_SetMaxResults(t *testing.T) {
+	tests := []struct {
+		name string
+		from ListQueryParams
+		with int32
+		want ListQueryParams
+	}{
+		{
+			name: "Empty max results",
+			from: ListQueryParams{},
+			with: 0,
+			want: ListQueryParams{},
+		},
+		{
+			name: "Empty max results, depth set",
+			from: ListQueryParams{QueryParams: QueryParams{Depth: pointer.From(int32(10))}},
+			with: 0,
+			want: ListQueryParams{QueryParams: QueryParams{Depth: pointer.From(int32(10))}},
+		},
+		{
+			name: "Non empty max results",
+			from: ListQueryParams{},
+			with: 10,
+			want: ListQueryParams{MaxResults: pointer.From(int32(10))},
+		},
+		{
+			name: "Non empty max results, depth set",
+			from: ListQueryParams{QueryParams: QueryParams{Depth: pointer.From(int32(10))}},
+			with: 10,
+			want: ListQueryParams{MaxResults: pointer.From(int32(10)), QueryParams: QueryParams{Depth: pointer.From(int32(10))}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := tt.from.SetMaxResults(tt.with)
+			assert.Equalf(t, tt.want, q, "SetMaxResults(%v)", tt.with)
+		})
+	}
+}


### PR DESCRIPTION
## What does this fix or implement?

Add MaxResults to all list commands where it was missing from 
Safeguard that setting MaxResults to 0, or OrderBy to "" would never send these values to the API -- both by using the Setter functions to avoid setting those values, and also by using pflag's `Changed()` function (which returns true only if the flag is set)

**NOTE**: The cloudapi query parameters would no longer be duplicated if we add a `compute` namespace for CloudAPI resources, as we could add them to `GlobalFlags()` of the `compute` namespace. 


## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
