### PR TITLE
refactor: add ask pkg

### DIFF
--- a/internal/confirm/confirm.go
+++ b/internal/confirm/confirm.go
@@ -1,0 +1,40 @@
+package confirm
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+// Ask uses os.Stdin to ask the user for confirmation.
+// If any of the arguments passed as `overrides` is true, it returns true.
+func Ask(s string, overrides ...bool) bool {
+	return FAsk(s, os.Stdin, overrides...)
+}
+
+// FAsk asks the user for confirmation on any Reader
+// If any of the arguments passed as `overrides` is true, it returns true.
+func FAsk(s string, in io.Reader, overrides ...bool) bool {
+	for _, o := range overrides {
+		if o {
+			return true
+		}
+	}
+	rr := bufio.NewReader(in)
+	fmt.Printf("%s? [y/n]: ", s)
+
+	resp, err := rr.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp = strings.ToLower(strings.TrimSpace(resp))
+
+	if resp == "y" || resp == "yes" {
+		return true
+	}
+	return false
+}

--- a/internal/confirm/confirm_test.go
+++ b/internal/confirm/confirm_test.go
@@ -1,0 +1,68 @@
+package confirm
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFAsk(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		overrides []bool
+		expected  bool
+	}{
+		{
+			name:      "Test empty input",
+			input:     "\n",
+			overrides: []bool{},
+			expected:  false,
+		},
+		{
+			name:      "Test yes input",
+			input:     "yes\n",
+			overrides: []bool{},
+			expected:  true,
+		},
+		{
+			name:      "Test no input",
+			input:     "no\n",
+			overrides: []bool{},
+			expected:  false,
+		},
+		{
+			name:      "Test uppercase yes input",
+			input:     "YES\n",
+			overrides: []bool{},
+			expected:  true,
+		},
+		{
+			name:      "Test uppercase no input",
+			input:     "NO\n",
+			overrides: []bool{},
+			expected:  false,
+		},
+		{
+			name:      "Test override true",
+			input:     "no\n",
+			overrides: []bool{true},
+			expected:  true,
+		},
+		{
+			name:      "Test multiple overrides",
+			input:     "\n",
+			overrides: []bool{false, true, false},
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := bytes.NewBufferString(tt.input)
+			actual := FAsk("Test", in, tt.overrides...)
+			if actual != tt.expected {
+				t.Errorf("FAsk() = %v; want %v", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/confirmation.go
+++ b/pkg/utils/confirmation.go
@@ -31,7 +31,7 @@ func readUserInput(reader io.Reader, writer printer.PrintService, message string
 }
 
 // AskForConfirm parses and verifies user input for confirmation.
-// Checks "--force" or "--quiet", and if these are set, then it skips verification.
+// Checks "--force" or "--quiet" WITHOUT core.GetFlagName. WARNING: if your Force/Quiet flags are bound to viper, they are most likely going to be ignored!
 // DEPRECATED: Use confirm.Ask instead
 func AskForConfirm(reader io.Reader, writer printer.PrintService, message string) error {
 	if viper.GetBool(constants.ArgForce) || viper.GetBool(constants.ArgQuiet) {

--- a/pkg/utils/confirmation.go
+++ b/pkg/utils/confirmation.go
@@ -31,6 +31,8 @@ func readUserInput(reader io.Reader, writer printer.PrintService, message string
 }
 
 // AskForConfirm parses and verifies user input for confirmation.
+// Checks "--force" or "--quiet", and if these are set, then it skips verification.
+// DEPRECATED: Use confirm.Ask instead
 func AskForConfirm(reader io.Reader, writer printer.PrintService, message string) error {
 	if viper.GetBool(constants.ArgForce) || viper.GetBool(constants.ArgQuiet) {
 		return nil


### PR DESCRIPTION
## What does this fix or implement?

the current way of asking for confirmation is pretty verbose and is hard to integrate with the `--force` flag. this provides an easy to use interface for one-line confirm asking