### PR TITLE
changed: cols, filters are now case insensitive

### DIFF
--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -113,7 +113,7 @@ func getFilters(args []string, cmd *core.Command) (map[string]string, error) {
 func isValidFilter(filter string, availableFiltersObjs ...[]string) bool {
 	for _, availableFilters := range availableFiltersObjs {
 		for _, availableFilter := range availableFilters {
-			if availableFilter == filter {
+			if strings.ToLower(availableFilter) == strings.ToLower(filter) {
 				return true
 			}
 		}

--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -92,7 +92,7 @@ func getFilters(args []string, cmd *core.Command) (map[string]string, error) {
 	for _, arg := range args {
 		if strings.Contains(arg, FiltersPartitionChar) {
 			kv := strings.Split(arg, FiltersPartitionChar)
-			filtersKV[kv[0]] = kv[1]
+			filtersKV[strings.ToLower(kv[0])] = kv[1]
 		} else {
 			return filtersKV, errors.New(
 				fmt.Sprintf("\"%s --filters\" option set incorrectly.\n\nUsage: %s --filters KEY1%sVALUE1,KEY2%sVALUE2\n\nFor more details, see '%s --help'.",

--- a/commands/cloudapi-v6/volume_test.go
+++ b/commands/cloudapi-v6/volume_test.go
@@ -857,7 +857,7 @@ func TestPreRunServerVolumeListFilters(t *testing.T) {
 		viper.Set(constants.ArgQuiet, false)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdby=%s", testQueryParamVar)})
 		err := PreRunServerVolumeList(cfg)
 		assert.NoError(t, err)
 	})

--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -46,10 +46,14 @@ func GetHeaders(allColumns []string, defaultColumns []string, customColumns []st
 		return defaultColumns
 	}
 
+	allColumnsLowercase := functional.Map(allColumns, func(x string) string {
+		return strings.ToLower(x)
+	})
+
 	var validCustomColumns []string
 	for _, c := range customColumns {
-		if slices.Contains(allColumns, c) {
-			validCustomColumns = append(validCustomColumns, c)
+		if idx := slices.Index(allColumnsLowercase, strings.ToLower(c)); idx != -1 {
+			validCustomColumns = append(validCustomColumns, allColumns[idx])
 		}
 	}
 

--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"golang.org/x/exp/slices"
 	"io"


### PR DESCRIPTION
## What does this fix or implement?

Changed filters and cols to be case insensitive since one was expecting Title case, and one was expecting full lowercase.

```
 % ionosctl server list --all -F namE=dp --cols NAME,TyPe,availabilityZOne --no-headers 
dp-fa0368d9625a36ba65b3-gw4jgwdcnz   ENTERPRISE   AUTO
```
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
