### PR TITLE
refactor: get client or die if err

### DIFF
--- a/commands/auth-v1/completer/ids.go
+++ b/commands/auth-v1/completer/ids.go
@@ -2,8 +2,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"

--- a/commands/auth-v1/completer/ids.go
+++ b/commands/auth-v1/completer/ids.go
@@ -2,15 +2,15 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"
 )
 
 func TokensIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	tokenSvc := resources.NewTokenService(client, context.TODO())
 	tokens, _, err := tokenSvc.List(0)

--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/ionos-cloud/ionosctl/v6/commands/auth-v1/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -239,7 +238,7 @@ func RunTokenDeleteExpired(c *core.CommandConfig) error {
 
 func RunTokenDeleteCurrent(c *core.CommandConfig) error {
 	c.Printer.Verbose("Note: This operation is based on Authorization Header for Bearer Token")
-	if viper.GetString(config.Token) == "" {
+	if viper.GetString(constants.Token) == "" {
 		return errors.New(fmt.Sprintf("no token found. Please make sure you have exported the %s environment variable or you have token set in the config file",
 			sdkgoauth.IonosTokenEnvVar))
 	}

--- a/commands/auth-v1/token_test.go
+++ b/commands/auth-v1/token_test.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
@@ -295,7 +294,7 @@ func TestRunTokenDeleteCriteriaCurrent(t *testing.T) {
 		viper.Set(constants.ArgForce, true)
 		viper.Set(constants.ArgVerbose, false)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgCurrent), true)
-		viper.Set(config.Token, testTokenVar)
+		viper.Set(constants.Token, testTokenVar)
 		rm.AuthV1Mocks.Token.EXPECT().DeleteByCriteria("CURRENT", int32(0)).Return(&testDeleteResponse, nil, nil)
 		err := RunTokenDelete(cfg)
 		assert.NoError(t, err)
@@ -460,7 +459,7 @@ func TestRunTokenDeleteCurrent(t *testing.T) {
 		viper.Set(constants.ArgForce, true)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgCurrent), true)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgContractNo), testTokenContractNo)
-		viper.Set(config.Token, testTokenVar)
+		viper.Set(constants.Token, testTokenVar)
 		rm.AuthV1Mocks.Token.EXPECT().DeleteByCriteria("CURRENT", testTokenContractNo).Return(&testDeleteResponse, nil, nil)
 		err := RunTokenDeleteCurrent(cfg)
 		assert.NoError(t, err)
@@ -491,7 +490,7 @@ func TestRunTokenDeleteCurrentErr(t *testing.T) {
 		viper.Set(constants.ArgQuiet, false)
 		viper.Set(constants.ArgForce, true)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgCurrent), true)
-		viper.Set(config.Token, testTokenVar)
+		viper.Set(constants.Token, testTokenVar)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgContractNo), testTokenContractNo)
 		rm.AuthV1Mocks.Token.EXPECT().DeleteByCriteria("CURRENT", testTokenContractNo).Return(&testDeleteResponse, nil, testTokenErr)
 		err := RunTokenDeleteCurrent(cfg)
@@ -540,7 +539,7 @@ func TestRunTokenDeleteCurrentAskForConfirmErr(t *testing.T) {
 		viper.Set(constants.ArgQuiet, false)
 		viper.Set(constants.ArgForce, false)
 		viper.Set(core.GetFlagName(cfg.NS, authv1.ArgCurrent), true)
-		viper.Set(config.Token, testTokenVar)
+		viper.Set(constants.Token, testTokenVar)
 		cfg.Stdin = os.Stdin
 		err := RunTokenDeleteCurrent(cfg)
 		assert.Error(t, err)

--- a/commands/certmanager/certificates.go
+++ b/commands/certmanager/certificates.go
@@ -2,6 +2,7 @@ package certmanager
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"

--- a/commands/certmanager/certificates.go
+++ b/commands/certmanager/certificates.go
@@ -2,11 +2,11 @@ package certmanager
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 
 	"github.com/fatih/structs"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -96,7 +96,7 @@ func getCertRows(certs *[]ionoscloud.CertificateDto) []map[string]interface{} {
 var allCols = structs.Names(CertPrint{})
 
 func CertificatesIds() []string {
-	client, _ := config.GetClient()
+	client, _ := client2.Get()
 	svc := resources.NewCertsService(client, context.Background())
 	certs, _, _ := svc.List()
 	return functional.Map(*certs.GetItems(), func(dto ionoscloud.CertificateDto) string {

--- a/commands/certmanager/certmanager_test.go
+++ b/commands/certmanager/certmanager_test.go
@@ -9,12 +9,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"

--- a/commands/certmanager/certmanager_test.go
+++ b/commands/certmanager/certmanager_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -18,7 +19,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 )
@@ -131,7 +131,7 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			assert.NoError(t, err)
 
 			// var id string
-			svc, err := config.GetClient()
+			svc, err := client.Get()
 			certs, _, err := svc.CertManagerClient.CertificatesApi.CertificatesGet(context.Background()).Execute()
 			assert.NoError(t, err)
 
@@ -203,7 +203,7 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			assert.NoError(t, err)
 
 			// var id string
-			svc, err := config.GetClient()
+			svc, err := client.Get()
 			certs, _, err := svc.CertManagerClient.CertificatesApi.CertificatesGet(context.Background()).
 				Execute()
 			assert.NoError(t, err)

--- a/commands/cloudapi-v6/completer/custom_ids.go
+++ b/commands/cloudapi-v6/completer/custom_ids.go
@@ -6,8 +6,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"

--- a/commands/cloudapi-v6/completer/custom_ids.go
+++ b/commands/cloudapi-v6/completer/custom_ids.go
@@ -6,16 +6,15 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 )
 
 func ImagesIdsCustom(outErr io.Writer, params resources.ListQueryParams) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	imageSvc := resources.NewImageService(client, context.TODO())
 	images, _, err := imageSvc.List(params)
@@ -34,7 +33,7 @@ func ImagesIdsCustom(outErr io.Writer, params resources.ListQueryParams) []strin
 }
 
 func ServersIdsCustom(outErr io.Writer, datacenterId string, params resources.ListQueryParams) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	serverSvc := resources.NewServerService(client, context.TODO())
 	servers, _, err := serverSvc.List(datacenterId, params)

--- a/commands/cloudapi-v6/completer/ids.go
+++ b/commands/cloudapi-v6/completer/ids.go
@@ -6,8 +6,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"

--- a/commands/cloudapi-v6/completer/ids.go
+++ b/commands/cloudapi-v6/completer/ids.go
@@ -6,15 +6,15 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 )
 
 func BackupUnitsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	backupUnitSvc := resources.NewBackupUnitService(client, context.TODO())
 	backupUnits, _, err := backupUnitSvc.List(resources.ListQueryParams{})
@@ -33,7 +33,7 @@ func BackupUnitsIds(outErr io.Writer) []string {
 }
 
 func AttachedCdromsIds(outErr io.Writer, datacenterId, serverId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	serverSvc := resources.NewServerService(client, context.TODO())
 	cdroms, _, err := serverSvc.ListCdroms(datacenterId, serverId, resources.ListQueryParams{})
@@ -52,7 +52,7 @@ func AttachedCdromsIds(outErr io.Writer, datacenterId, serverId string) []string
 }
 
 func DataCentersIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	datacenterSvc := resources.NewDataCenterService(client, context.TODO())
 	datacenters, _, err := datacenterSvc.List(resources.ListQueryParams{})
@@ -72,7 +72,7 @@ func DataCentersIds(outErr io.Writer) []string {
 }
 
 func FirewallRulesIds(outErr io.Writer, datacenterId, serverId, nicId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	firewallRuleSvc := resources.NewFirewallRuleService(client, context.TODO())
 	firewallRules, _, err := firewallRuleSvc.List(datacenterId, serverId, nicId, resources.ListQueryParams{})
@@ -91,7 +91,7 @@ func FirewallRulesIds(outErr io.Writer, datacenterId, serverId, nicId string) []
 }
 
 func FlowLogsIds(outErr io.Writer, datacenterId, serverId, nicId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	flowLogSvc := resources.NewFlowLogService(client, context.TODO())
 	flowLogs, _, err := flowLogSvc.List(datacenterId, serverId, nicId, resources.ListQueryParams{})
@@ -110,7 +110,7 @@ func FlowLogsIds(outErr io.Writer, datacenterId, serverId, nicId string) []strin
 }
 
 func GroupsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	groupSvc := resources.NewGroupService(client, context.TODO())
 	groups, _, err := groupSvc.List(resources.ListQueryParams{})
@@ -129,7 +129,7 @@ func GroupsIds(outErr io.Writer) []string {
 }
 
 func ImageIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	imageSvc := resources.NewImageService(client, context.TODO())
 	images, _, err := imageSvc.List(resources.ListQueryParams{})
@@ -148,7 +148,7 @@ func ImageIds(outErr io.Writer) []string {
 }
 
 func IpBlocksIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	ipBlockSvc := resources.NewIpBlockService(client, context.TODO())
 	ipBlocks, _, err := ipBlockSvc.List(resources.ListQueryParams{})
@@ -167,7 +167,7 @@ func IpBlocksIds(outErr io.Writer) []string {
 }
 
 func K8sClustersIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.TODO())
 	k8ss, _, err := k8sSvc.ListClusters(resources.ListQueryParams{})
@@ -186,7 +186,7 @@ func K8sClustersIds(outErr io.Writer) []string {
 }
 
 func K8sVersionsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.TODO())
 	k8ss, _, err := k8sSvc.ListVersions()
@@ -195,7 +195,7 @@ func K8sVersionsIds(outErr io.Writer) []string {
 }
 
 func K8sNodesIds(outErr io.Writer, clusterId, nodepoolId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.TODO())
 	k8ss, _, err := k8sSvc.ListNodes(clusterId, nodepoolId, resources.ListQueryParams{})
@@ -214,7 +214,7 @@ func K8sNodesIds(outErr io.Writer, clusterId, nodepoolId string) []string {
 }
 
 func K8sNodePoolsIds(outErr io.Writer, clusterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.TODO())
 	k8ss, _, err := k8sSvc.ListNodePools(clusterId, resources.ListQueryParams{})
@@ -233,7 +233,7 @@ func K8sNodePoolsIds(outErr io.Writer, clusterId string) []string {
 }
 
 func LansIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	lanSvc := resources.NewLanService(client, context.TODO())
 	lans, _, err := lanSvc.List(datacenterId, resources.ListQueryParams{})
@@ -252,7 +252,7 @@ func LansIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func LoadbalancersIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	loadbalancerSvc := resources.NewLoadbalancerService(client, context.TODO())
 	loadbalancers, _, err := loadbalancerSvc.List(datacenterId, resources.ListQueryParams{})
@@ -271,7 +271,7 @@ func LoadbalancersIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func LocationIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	locationSvc := resources.NewLocationService(client, context.TODO())
 	locations, _, err := locationSvc.List(resources.ListQueryParams{})
@@ -290,7 +290,7 @@ func LocationIds(outErr io.Writer) []string {
 }
 
 func NatGatewaysIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	natgatewaySvc := resources.NewNatGatewayService(client, context.TODO())
 	natgateways, _, err := natgatewaySvc.List(datacenterId, resources.ListQueryParams{})
@@ -309,7 +309,7 @@ func NatGatewaysIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func NatGatewayFlowLogsIds(outErr io.Writer, datacenterId, natgatewayId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	natgatewaySvc := resources.NewNatGatewayService(client, context.TODO())
 	natFlowLogs, _, err := natgatewaySvc.ListFlowLogs(datacenterId, natgatewayId, resources.ListQueryParams{})
@@ -328,7 +328,7 @@ func NatGatewayFlowLogsIds(outErr io.Writer, datacenterId, natgatewayId string) 
 }
 
 func NatGatewayRulesIds(outErr io.Writer, datacenterId, natgatewayId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	natgatewaySvc := resources.NewNatGatewayService(client, context.TODO())
 	natgateways, _, err := natgatewaySvc.ListRules(datacenterId, natgatewayId, resources.ListQueryParams{})
@@ -347,7 +347,7 @@ func NatGatewayRulesIds(outErr io.Writer, datacenterId, natgatewayId string) []s
 }
 
 func NetworkLoadBalancersIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	networkloadbalancerSvc := resources.NewNetworkLoadBalancerService(client, context.TODO())
 	networkloadbalancers, _, err := networkloadbalancerSvc.List(datacenterId, resources.ListQueryParams{})
@@ -366,7 +366,7 @@ func NetworkLoadBalancersIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func NetworkLoadBalancerFlowLogsIds(outErr io.Writer, datacenterId, networkloadbalancerId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	networkloadbalancerSvc := resources.NewNetworkLoadBalancerService(client, context.TODO())
 	natFlowLogs, _, err := networkloadbalancerSvc.ListFlowLogs(datacenterId, networkloadbalancerId, resources.ListQueryParams{})
@@ -385,7 +385,7 @@ func NetworkLoadBalancerFlowLogsIds(outErr io.Writer, datacenterId, networkloadb
 }
 
 func ForwardingRulesIds(outErr io.Writer, datacenterId, nlbId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	nlbSvc := resources.NewNetworkLoadBalancerService(client, context.TODO())
 	natForwardingRules, _, err := nlbSvc.ListForwardingRules(datacenterId, nlbId, resources.ListQueryParams{})
@@ -404,7 +404,7 @@ func ForwardingRulesIds(outErr io.Writer, datacenterId, nlbId string) []string {
 }
 
 func NicsIds(outErr io.Writer, datacenterId, serverId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	nicSvc := resources.NewNicService(client, context.TODO())
 	nics, _, err := nicSvc.List(datacenterId, serverId, resources.ListQueryParams{})
@@ -423,7 +423,7 @@ func NicsIds(outErr io.Writer, datacenterId, serverId string) []string {
 }
 
 func AttachedNicsIds(outErr io.Writer, datacenterId, loadbalancerId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	nicSvc := resources.NewLoadbalancerService(client, context.TODO())
 	nics, _, err := nicSvc.ListNics(datacenterId, loadbalancerId, resources.ListQueryParams{})
@@ -442,7 +442,7 @@ func AttachedNicsIds(outErr io.Writer, datacenterId, loadbalancerId string) []st
 }
 
 func PccsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	pccSvc := resources.NewPrivateCrossConnectService(client, context.TODO())
 	pccs, _, err := pccSvc.List(resources.ListQueryParams{})
@@ -461,7 +461,7 @@ func PccsIds(outErr io.Writer) []string {
 }
 
 func RequestsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	reqSvc := resources.NewRequestService(client, context.TODO())
 	requests, _, err := reqSvc.List(resources.ListQueryParams{})
@@ -480,7 +480,7 @@ func RequestsIds(outErr io.Writer) []string {
 }
 
 func ResourcesIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	userSvc := resources.NewUserService(client, context.TODO())
 	res, _, err := userSvc.ListResources()
@@ -499,7 +499,7 @@ func ResourcesIds(outErr io.Writer) []string {
 }
 
 func S3KeyIds(outErr io.Writer, userId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	S3KeySvc := resources.NewS3KeyService(client, context.TODO())
 	S3Keys, _, err := S3KeySvc.List(userId, resources.ListQueryParams{})
@@ -518,7 +518,7 @@ func S3KeyIds(outErr io.Writer, userId string) []string {
 }
 
 func ServersIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	serverSvc := resources.NewServerService(client, context.TODO())
 	servers, _, err := serverSvc.List(datacenterId, resources.ListQueryParams{})
@@ -537,7 +537,7 @@ func ServersIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func GroupResourcesIds(outErr io.Writer, groupId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	groupSvc := resources.NewGroupService(client, context.TODO())
 	res, _, err := groupSvc.ListResources(groupId, resources.ListQueryParams{})
@@ -556,7 +556,7 @@ func GroupResourcesIds(outErr io.Writer, groupId string) []string {
 }
 
 func SnapshotIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	snapshotSvc := resources.NewSnapshotService(client, context.TODO())
 	snapshots, _, err := snapshotSvc.List(resources.ListQueryParams{})
@@ -575,7 +575,7 @@ func SnapshotIds(outErr io.Writer) []string {
 }
 
 func TemplatesIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	tplSvc := resources.NewTemplateService(client, context.TODO())
 	tpls, _, err := tplSvc.List(resources.ListQueryParams{})
@@ -594,7 +594,7 @@ func TemplatesIds(outErr io.Writer) []string {
 }
 
 func UsersIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	userSvc := resources.NewUserService(client, context.TODO())
 	users, _, err := userSvc.List(resources.ListQueryParams{})
@@ -613,7 +613,7 @@ func UsersIds(outErr io.Writer) []string {
 }
 
 func GroupUsersIds(outErr io.Writer, groupId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	groupSvc := resources.NewGroupService(client, context.TODO())
 	users, _, err := groupSvc.ListUsers(groupId, resources.ListQueryParams{})
@@ -632,7 +632,7 @@ func GroupUsersIds(outErr io.Writer, groupId string) []string {
 }
 
 func VolumesIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	volumeSvc := resources.NewVolumeService(client, context.TODO())
 	volumes, _, err := volumeSvc.List(datacenterId, resources.ListQueryParams{})
@@ -651,7 +651,7 @@ func VolumesIds(outErr io.Writer, datacenterId string) []string {
 }
 
 func AttachedVolumesIds(outErr io.Writer, datacenterId, serverId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	serverSvc := resources.NewServerService(client, context.TODO())
 	volumes, _, err := serverSvc.ListVolumes(datacenterId, serverId, resources.ListQueryParams{})
@@ -670,7 +670,7 @@ func AttachedVolumesIds(outErr io.Writer, datacenterId, serverId string) []strin
 }
 
 func ApplicationLoadBalancersIds(outErr io.Writer, datacenterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	applicationloadbalancerSvc := resources.NewApplicationLoadBalancerService(client, context.TODO())
 	applicationloadbalancers, _, err := applicationloadbalancerSvc.List(datacenterId, resources.ListQueryParams{})
@@ -689,7 +689,7 @@ func ApplicationLoadBalancersIds(outErr io.Writer, datacenterId string) []string
 }
 
 func ApplicationLoadBalancerFlowLogsIds(outErr io.Writer, datacenterId, applicationloadbalancerId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	applicationloadbalancerSvc := resources.NewApplicationLoadBalancerService(client, context.TODO())
 	natFlowLogs, _, err := applicationloadbalancerSvc.ListFlowLogs(datacenterId, applicationloadbalancerId, resources.ListQueryParams{})
@@ -708,7 +708,7 @@ func ApplicationLoadBalancerFlowLogsIds(outErr io.Writer, datacenterId, applicat
 }
 
 func AlbForwardingRulesIds(outErr io.Writer, datacenterId, albId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	albSvc := resources.NewApplicationLoadBalancerService(client, context.TODO())
 	natForwardingRules, _, err := albSvc.ListForwardingRules(datacenterId, albId, resources.ListQueryParams{})
@@ -727,7 +727,7 @@ func AlbForwardingRulesIds(outErr io.Writer, datacenterId, albId string) []strin
 }
 
 func TargetGroupIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	targetGroupSvc := resources.NewTargetGroupService(client, context.TODO())
 	targetGroups, _, err := targetGroupSvc.List(resources.ListQueryParams{})

--- a/commands/cloudapi-v6/completer/properties.go
+++ b/commands/cloudapi-v6/completer/properties.go
@@ -2,9 +2,8 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
@@ -16,7 +15,7 @@ func DatacenterCPUFamilies(ctx context.Context, outErr io.Writer, datacenterId s
 	if datacenterId == "" {
 		return []string{"AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE"}
 	}
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	dcSvc := resources.NewDataCenterService(client, ctx)
 	dc, _, err := dcSvc.Get(datacenterId, resources.QueryParams{})

--- a/commands/cloudapi-v6/completer/properties.go
+++ b/commands/cloudapi-v6/completer/properties.go
@@ -2,8 +2,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"

--- a/commands/cloudapi-v6/completer/versions.go
+++ b/commands/cloudapi-v6/completer/versions.go
@@ -2,16 +2,15 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 )
 
 func K8sClusterUpgradeVersions(outErr io.Writer, clusterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.Background())
 	cluster, _, err := k8sSvc.GetCluster(clusterId, resources.QueryParams{})
@@ -23,7 +22,7 @@ func K8sClusterUpgradeVersions(outErr io.Writer, clusterId string) []string {
 }
 
 func K8sNodePoolUpgradeVersions(outErr io.Writer, clusterId, nodepoolId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	k8sSvc := resources.NewK8sService(client, context.Background())
 	nodepool, _, err := k8sSvc.GetNodePool(clusterId, nodepoolId, resources.QueryParams{})

--- a/commands/cloudapi-v6/completer/versions.go
+++ b/commands/cloudapi-v6/completer/versions.go
@@ -2,8 +2,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"

--- a/commands/container-registry/registry/post.go
+++ b/commands/container-registry/registry/post.go
@@ -2,8 +2,8 @@ package registry
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -120,8 +120,7 @@ func CmdPost(c *core.CommandConfig) error {
 
 func getLocForAutoComplete() []string {
 	var locations []string
-	svc, _ := config.GetClient()
-	locs, _, _ := svc.RegistryClient.LocationsApi.LocationsGet(context.Background()).Execute()
+	locs, _, _ := client.Must().RegistryClient.LocationsApi.LocationsGet(context.Background()).Execute()
 	list := locs.GetItems()
 
 	for _, item := range *list {

--- a/commands/container-registry/registry/registries.go
+++ b/commands/container-registry/registry/registries.go
@@ -3,8 +3,8 @@ package registry
 import (
 	"context"
 	"github.com/fatih/structs"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -121,8 +121,8 @@ func getRegRows(regs *[]ionoscloud.RegistryResponse) []map[string]interface{} {
 var allCols = structs.Names(RegPrint{})
 
 func RegsIds() []string {
-	client, _ := config.GetClient()
-	svc := resources.NewRegistriesService(client, context.Background())
+	//client, _ := config.GetClient()
+	svc := resources.NewRegistriesService(client.Must(), context.Background())
 	regs, _, _ := svc.List("")
 	return functional.Map(
 		*regs.GetItems(), func(reg ionoscloud.RegistryResponse) string {

--- a/commands/container-registry/registry/registry_test.go
+++ b/commands/container-registry/registry/registry_test.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	ionoscloud "github.com/ionos-cloud/sdk-go-container-registry"
 	"github.com/lucasjones/reggen"
@@ -28,8 +28,7 @@ func TestRegistryService(t *testing.T) {
 		err = c.Command.Execute()
 		assert.NoError(t, err)
 
-		svc, err := config.GetClient()
-		registries, _, err := svc.RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
+		registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
 		assert.NoError(t, err)
 
 		var newRegistry *ionoscloud.RegistryResponse
@@ -54,7 +53,7 @@ func TestRegistryService(t *testing.T) {
 		err = patch.Command.Execute()
 		assert.NoError(t, err)
 
-		checkRegistry, _, err := svc.RegistryClient.RegistriesApi.RegistriesFindById(context.Background(), *newRegistry.GetId()).Execute()
+		checkRegistry, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesFindById(context.Background(), *newRegistry.GetId()).Execute()
 		assert.NoError(t, err)
 		assert.Equal(t, []ionoscloud.Day([]ionoscloud.Day{"Tuesday"}), *checkRegistry.GetProperties().GetGarbageCollectionSchedule().GetDays())
 

--- a/commands/container-registry/token/scopes/scopes.go
+++ b/commands/container-registry/token/scopes/scopes.go
@@ -2,8 +2,8 @@ package scopes
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/services/container-registry/resources"
 	"strconv"
 
@@ -96,8 +96,7 @@ func getTokensScopeRows(token *sdkgo.TokenResponse) []map[string]interface{} {
 var allColsScopes = structs.Names(TokenScopePrint{})
 
 func TokensIds(regId string) []string {
-	client, _ := config.GetClient()
-	svcToken := resources.NewTokenService(client, context.Background())
+	svcToken := resources.NewTokenService(client.Must(), context.Background())
 	var allTokens []sdkgo.TokenResponse
 
 	if regId != "" {
@@ -113,7 +112,7 @@ func TokensIds(regId string) []string {
 		)
 	}
 
-	svc := resources.NewRegistriesService(client, context.Background())
+	svc := resources.NewRegistriesService(client.Must(), context.Background())
 	regs, _, _ := svc.List("")
 	regsIDs := *regs.GetItems()
 

--- a/commands/container-registry/token/token_test.go
+++ b/commands/container-registry/token/token_test.go
@@ -2,12 +2,12 @@ package token
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
 	"time"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/container-registry/registry"
 	"github.com/ionos-cloud/ionosctl/v6/commands/container-registry/token/scopes"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	ionoscloud "github.com/ionos-cloud/sdk-go-container-registry"
 	"github.com/lucasjones/reggen"
@@ -35,9 +35,8 @@ func TestTokenService(t *testing.T) {
 		time.Sleep(3 * time.Second)
 
 		// get registry
-		svc, err := config.GetClient()
 		assert.NoError(t, err)
-		registries, _, err := svc.RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
+		registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
 		assert.NoError(t, err)
 
 		var newReg *ionoscloud.RegistryResponse
@@ -60,7 +59,7 @@ func TestTokenService(t *testing.T) {
 
 		time.Sleep(3 * time.Second)
 		// get token
-		tokens, _, err := svc.RegistryClient.TokensApi.RegistriesTokensGet(context.Background(), *newReg.GetId()).Execute()
+		tokens, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensGet(context.Background(), *newReg.GetId()).Execute()
 		assert.NoError(t, err)
 
 		var newToken *ionoscloud.TokenResponse
@@ -122,7 +121,7 @@ func TestTokenService(t *testing.T) {
 		assert.NoError(t, err)
 		time.Sleep(3 * time.Second)
 
-		checkProp, _, err := svc.RegistryClient.TokensApi.RegistriesTokensFindById(context.Background(), *newReg.GetId(), *newToken.GetId()).Execute()
+		checkProp, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensFindById(context.Background(), *newReg.GetId(), *newToken.GetId()).Execute()
 		assert.NoError(t, err)
 		assert.Equal(t, "disabled", *checkProp.GetProperties().GetStatus())
 		time.Sleep(3 * time.Second)

--- a/commands/container-registry/token/tokens.go
+++ b/commands/container-registry/token/tokens.go
@@ -3,6 +3,7 @@ package token
 import (
 	"context"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"strconv"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/fatih/structs"
 	scope "github.com/ionos-cloud/ionosctl/v6/commands/container-registry/token/scopes"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -129,8 +129,7 @@ func getTokensRows(tokens *[]ionoscloud.TokenResponse) []map[string]interface{} 
 var allCols = structs.Names(TokenPrint{})
 
 func TokensIds(regId string) []string {
-	client, _ := config.GetClient()
-	svcToken := resources.NewTokenService(client, context.Background())
+	svcToken := resources.NewTokenService(client.Must(), context.Background())
 	var allTokens []ionoscloud.TokenResponse
 
 	if regId != "" {
@@ -146,8 +145,7 @@ func TokensIds(regId string) []string {
 		)
 	}
 
-	svc := resources.NewRegistriesService(client, context.Background())
-	regs, _, _ := svc.List("")
+	regs, _, _ := resources.NewRegistriesService(client.Must(), context.Background()).List("")
 	regsIDs := *regs.GetItems()
 
 	for _, regID := range regsIDs {

--- a/commands/dataplatform/cluster/create.go
+++ b/commands/dataplatform/cluster/create.go
@@ -2,11 +2,11 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"
 	"github.com/cjrd/allocate"
 	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	sdkdataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
@@ -52,7 +52,7 @@ func ClusterCreateCmd() *core.Command {
 			input := sdkdataplatform.CreateClusterRequest{}
 			input.SetProperties(createProperties)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/cluster/create.go
+++ b/commands/dataplatform/cluster/create.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"

--- a/commands/dataplatform/cluster/delete.go
+++ b/commands/dataplatform/cluster/delete.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/confirm"

--- a/commands/dataplatform/cluster/delete.go
+++ b/commands/dataplatform/cluster/delete.go
@@ -3,13 +3,13 @@ package cluster
 import (
 	"context"
 	"fmt"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dataplatform"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils"
@@ -39,7 +39,7 @@ func ClusterDeleteCmd() *core.Command {
 				return err
 			}
 			c.Printer.Verbose("Deleting cluster: %s", clusterId)
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			_, _, err = client.DataplatformClient.DataPlatformClusterApi.DeleteCluster(c.Context, clusterId).Execute()
 			if err != nil {
 				return err
@@ -62,7 +62,7 @@ func ClusterDeleteCmd() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/dataplatform/cluster/get.go
+++ b/commands/dataplatform/cluster/get.go
@@ -2,9 +2,9 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	sdkdataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
@@ -27,7 +27,7 @@ func ClusterGetCmd() *core.Command {
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
 			c.Printer.Verbose("Getting Cluster by id: %s", clusterId)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/cluster/get.go
+++ b/commands/dataplatform/cluster/get.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/cluster/kubeconfig.go
+++ b/commands/dataplatform/cluster/kubeconfig.go
@@ -2,9 +2,9 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/spf13/cobra"
@@ -26,7 +26,7 @@ func ClustersKubeConfigCmd() *core.Command {
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
 			c.Printer.Verbose("Getting Cluster by id: %s", clusterId)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/cluster/kubeconfig.go
+++ b/commands/dataplatform/cluster/kubeconfig.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/cluster/list.go
+++ b/commands/dataplatform/cluster/list.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"

--- a/commands/dataplatform/cluster/list.go
+++ b/commands/dataplatform/cluster/list.go
@@ -2,8 +2,8 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/spf13/viper"
@@ -22,7 +22,7 @@ func ClusterListCmd() *core.Command {
 			c.Printer.Verbose("Getting Clusters...")
 			name := viper.GetString(core.GetFlagName(c.NS, constants.FlagName))
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/cluster/update.go
+++ b/commands/dataplatform/cluster/update.go
@@ -2,11 +2,11 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
 
 	"github.com/cilium/fake"
 	cloudapiv6completer "github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/spf13/viper"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
@@ -49,7 +49,7 @@ func ClusterUpdateCmd() *core.Command {
 				updateProperties.SetMaintenanceWindow(maintenanceWindow)
 			}
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/cluster/update.go
+++ b/commands/dataplatform/cluster/update.go
@@ -2,8 +2,9 @@ package cluster
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"
 	cloudapiv6completer "github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"

--- a/commands/dataplatform/completer/ids.go
+++ b/commands/dataplatform/completer/ids.go
@@ -2,14 +2,14 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgo "github.com/ionos-cloud/sdk-go-dataplatform"
 )
 
 func DataplatformClusterIds() []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return nil
 	}
@@ -23,7 +23,7 @@ func DataplatformClusterIds() []string {
 }
 
 func DataplatformNodepoolsIds(clusterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return nil
 	}

--- a/commands/dataplatform/completer/ids.go
+++ b/commands/dataplatform/completer/ids.go
@@ -2,6 +2,7 @@ package completer
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"

--- a/commands/dataplatform/dataplatform_e2e_test.go
+++ b/commands/dataplatform/dataplatform_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/nodepool"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dataplatform"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/cluster"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	sdkcompute "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
@@ -20,7 +20,7 @@ import (
 
 var (
 	uniqueResourceName = "ionosctl-dataplatform-cluster-test-" + fake.AlphaNum(8)
-	client             *config.Client
+	client             *client2.Client
 	createdClusterId   string
 	createdDcId        string
 )
@@ -28,7 +28,7 @@ var (
 // If your test is failing because your credentials env var seem empty, try running with `godotenv -f <config-file> go test <test>`
 func TestDataplatformCmd(t *testing.T) {
 	var err error
-	client, err = config.GetClient()
+	client, err = client2.Get()
 	assert.NoError(t, err)
 	go testClusterIdentifyRequiredNotSet(t)
 	if setup() != nil {

--- a/commands/dataplatform/dataplatform_e2e_test.go
+++ b/commands/dataplatform/dataplatform_e2e_test.go
@@ -3,12 +3,13 @@ package dataplatform
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/nodepool"
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dataplatform"
-	"testing"
-	"time"
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/cluster"

--- a/commands/dataplatform/nodepool/create.go
+++ b/commands/dataplatform/nodepool/create.go
@@ -2,10 +2,10 @@ package nodepool
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	sdkdataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
@@ -89,7 +89,7 @@ func NodepoolCreateCmd() *core.Command {
 			input := sdkdataplatform.CreateNodePoolRequest{}
 			input.SetProperties(createProperties)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/nodepool/create.go
+++ b/commands/dataplatform/nodepool/create.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"

--- a/commands/dataplatform/nodepool/delete.go
+++ b/commands/dataplatform/nodepool/delete.go
@@ -3,10 +3,10 @@ package nodepool
 import (
 	"context"
 	"fmt"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils"
@@ -38,7 +38,7 @@ func NodepoolDeleteCmd() *core.Command {
 				return err
 			}
 			c.Printer.Verbose("Deleting nodepool: %s", nodepoolId)
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			_, _, err = client.DataplatformClient.DataPlatformNodePoolApi.DeleteClusterNodepool(c.Context, clusterId, nodepoolId).Execute()
 			if err != nil {
 				return err
@@ -78,7 +78,7 @@ func deleteAll(c *core.CommandConfig, clusterId string) error {
 	}
 	// Only --all is provided, so delete all nodepools
 
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func deleteAll(c *core.CommandConfig, clusterId string) error {
 }
 
 func deleteNodePools(clusterId string) error {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/dataplatform/nodepool/delete.go
+++ b/commands/dataplatform/nodepool/delete.go
@@ -3,6 +3,7 @@ package nodepool
 import (
 	"context"
 	"fmt"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/nodepool/get.go
+++ b/commands/dataplatform/nodepool/get.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/nodepool/get.go
+++ b/commands/dataplatform/nodepool/get.go
@@ -2,9 +2,9 @@ package nodepool
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dataplatform"
@@ -33,7 +33,7 @@ func NodepoolGetCmd() *core.Command {
 			npId := viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))
 			c.Printer.Verbose("Getting Nodepool %s...", npId)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dataplatform/nodepool/list.go
+++ b/commands/dataplatform/nodepool/list.go
@@ -2,12 +2,12 @@ package nodepool
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dataplatform"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/spf13/cobra"
@@ -32,7 +32,7 @@ func NodepoolListCmd() *core.Command {
 			c.Printer.Verbose("Getting Nodepools...")
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func NodepoolListCmd() *core.Command {
 func listAll(c *core.CommandConfig) error {
 	c.Printer.Verbose("Getting all nodepools...")
 
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/dataplatform/nodepool/list.go
+++ b/commands/dataplatform/nodepool/list.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"

--- a/commands/dataplatform/nodepool/update.go
+++ b/commands/dataplatform/nodepool/update.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/nodepool/update.go
+++ b/commands/dataplatform/nodepool/update.go
@@ -2,9 +2,9 @@ package nodepool
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	sdkdataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
@@ -65,7 +65,7 @@ func NodepoolUpdateCmd() *core.Command {
 			input := sdkdataplatform.PatchNodePoolRequest{}
 			input.SetProperties(updateProperties)
 
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/commands/dbaas/mongo/cluster/create.go
+++ b/commands/dbaas/mongo/cluster/create.go
@@ -2,8 +2,9 @@ package cluster
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/spf13/viper"
 

--- a/commands/dbaas/mongo/cluster/create.go
+++ b/commands/dbaas/mongo/cluster/create.go
@@ -2,9 +2,9 @@ package cluster
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/spf13/viper"
 
 	"github.com/cjrd/allocate"
@@ -97,7 +97,7 @@ func ClusterCreateCmd() *core.Command {
 			if *input.Properties.Location == "" {
 				// If location isn't set to Datacenter's Location, Mongo API throws an error. Location property is also marked as required
 				// To improve user experience we mark it as optional and now we set it to the datacenter's location implicitly (via connections datacenterID).
-				client, err := config.GetClient()
+				client, err := client2.Get()
 				if err != nil {
 					return err
 				}

--- a/commands/dbaas/mongo/cluster/delete.go
+++ b/commands/dbaas/mongo/cluster/delete.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/completer"

--- a/commands/dbaas/mongo/cluster/delete.go
+++ b/commands/dbaas/mongo/cluster/delete.go
@@ -3,11 +3,11 @@ package cluster
 import (
 	"context"
 	"fmt"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
@@ -62,7 +62,7 @@ func ClusterDeleteCmd() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/dbaas/mongo/completer/ids.go
+++ b/commands/dbaas/mongo/completer/ids.go
@@ -2,14 +2,14 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )
 
 func MongoClusterIds() []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return nil
 	}
@@ -23,7 +23,7 @@ func MongoClusterIds() []string {
 }
 
 func MongoSnapshots(clusterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return nil
 	}
@@ -37,7 +37,7 @@ func MongoSnapshots(clusterId string) []string {
 }
 
 func MongoTemplateIds() []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return nil
 	}

--- a/commands/dbaas/mongo/completer/ids.go
+++ b/commands/dbaas/mongo/completer/ids.go
@@ -2,6 +2,7 @@ package completer
 
 import (
 	"context"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"

--- a/commands/dbaas/mongo/mongo_e2e_test.go
+++ b/commands/dbaas/mongo/mongo_e2e_test.go
@@ -3,9 +3,10 @@ package mongo
 import (
 	"context"
 	"fmt"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
 	"time"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/cluster"

--- a/commands/dbaas/mongo/mongo_e2e_test.go
+++ b/commands/dbaas/mongo/mongo_e2e_test.go
@@ -3,13 +3,13 @@ package mongo
 import (
 	"context"
 	"fmt"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
 	"time"
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/cluster"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/user"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	sdkcompute "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
@@ -19,7 +19,7 @@ import (
 var (
 	uniqueResourceName = "ionosctl-mongo-cluster-test-" + fake.AlphaNum(8)
 	cidr               = fake.IP(fake.WithIPv4(), fake.WithIPCIDR("192.168.0.0/16")) + "/24"
-	client             *config.Client
+	client             *client2.Client
 	createdClusterId   string
 	createdDcId        string
 )
@@ -27,7 +27,7 @@ var (
 // If your test is failing because your credentials env var seem empty, try running with `godotenv -f <config-file> go test <test>`
 func TestMongoCommands(t *testing.T) {
 	var err error
-	client, err = config.GetClient()
+	client, err = client2.Get()
 	assert.NoError(t, err)
 	go testMongoClusterCreateIdentifyRequiredNotSet(t)
 	dcId, lanId, err := setupTestMongoCommands()
@@ -171,7 +171,7 @@ func teardownTestMongoCommands() {
 func getPlaygroundTemplateUuid() string {
 	const fallbackUuid = "33457e53-1f8b-4ed2-8a12-2d42355aa759"
 
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return fallbackUuid
 	}

--- a/commands/dbaas/mongo/user/delete.go
+++ b/commands/dbaas/mongo/user/delete.go
@@ -3,11 +3,11 @@ package user
 import (
 	"context"
 	"fmt"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
@@ -56,7 +56,7 @@ func UserDeleteCmd() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig, clusterId string) error {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/dbaas/mongo/user/delete.go
+++ b/commands/dbaas/mongo/user/delete.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"fmt"
+
 	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/completer"

--- a/commands/dbaas/postgres/completer/ids.go
+++ b/commands/dbaas/postgres/completer/ids.go
@@ -2,15 +2,15 @@ package completer
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-postgres/resources"
 )
 
 func BackupsIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	clustersService := resources.NewBackupsService(client, context.TODO())
 	backupList, _, err := clustersService.List()
@@ -29,7 +29,7 @@ func BackupsIds(outErr io.Writer) []string {
 }
 
 func BackupsIdsForCluster(outErr io.Writer, clusterId string) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	clustersService := resources.NewBackupsService(client, context.TODO())
 	backupList, _, err := clustersService.ListBackups(clusterId)
@@ -48,7 +48,7 @@ func BackupsIdsForCluster(outErr io.Writer, clusterId string) []string {
 }
 
 func ClustersIds(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	clustersService := resources.NewClustersService(client, context.TODO())
 	clusterList, _, err := clustersService.List("")
@@ -67,7 +67,7 @@ func ClustersIds(outErr io.Writer) []string {
 }
 
 func PostgresVersions(outErr io.Writer) []string {
-	client, err := config.GetClient()
+	client, err := client2.Get()
 	clierror.CheckError(err, outErr)
 	versionsService := resources.NewVersionsService(client, context.TODO())
 	versionList, _, err := versionsService.List()

--- a/commands/dbaas/postgres/completer/ids.go
+++ b/commands/dbaas/postgres/completer/ids.go
@@ -2,8 +2,9 @@ package completer
 
 import (
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-postgres/resources"

--- a/commands/login.go
+++ b/commands/login.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
 	"strings"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"

--- a/commands/login.go
+++ b/commands/login.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
 	"strings"
 
@@ -80,7 +81,7 @@ func RunLoginUser(c *core.CommandConfig) error {
 
 	if token != "" {
 		// If token is set, use only token
-		viper.Set(config.Token, token)
+		viper.Set(constants.Token, token)
 		c.Printer.Verbose("Token is set.")
 	} else {
 		// If token and username are not set, display messages
@@ -107,14 +108,14 @@ func RunLoginUser(c *core.CommandConfig) error {
 			}
 			pwd = string(bytesPwd)
 		}
-		viper.Set(config.Username, username)
-		c.Printer.Verbose("Username is set %s", viper.GetString(config.Username))
-		viper.Set(config.Password, pwd)
+		viper.Set(constants.Username, username)
+		c.Printer.Verbose("Username is set %s", viper.GetString(constants.Username))
+		viper.Set(constants.Password, pwd)
 		c.Printer.Verbose("Password is set.")
 	}
 	c.Printer.Verbose("ServerUrl: %s", config.GetServerUrl())
-	viper.Set(config.ServerUrl, viper.GetString(constants.ArgServerUrl))
-	client, err := config.GetClient()
+	viper.Set(constants.ServerUrl, viper.GetString(constants.ArgServerUrl))
+	client, err := client2.Get()
 	if err != nil {
 		return err
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -84,7 +84,7 @@ func init() {
 	} else {
 		rootCmd.Command.Version = fmt.Sprintf("%s-%s", CLIVersionDev, GitCommit)
 	}
-	viper.Set(config.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", rootCmd.Command.Version))
+	viper.Set(constants.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", rootCmd.Command.Version))
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"errors"
 	"fmt"
+	"sync"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/die"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
@@ -13,7 +15,6 @@ import (
 	postgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 	cloudv6 "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
-	"sync"
 )
 
 type Client struct {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/internal/die"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
+	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
+	certmanager "github.com/ionos-cloud/sdk-go-cert-manager"
+	dataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
+	mongo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
+	postgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
+	cloudv6 "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/spf13/viper"
+	"sync"
+)
+
+type Client struct {
+	CloudClient        *cloudv6.APIClient
+	AuthClient         *sdkgoauth.APIClient
+	CertManagerClient  *certmanager.APIClient
+	PostgresClient     *postgres.APIClient
+	MongoClient        *mongo.APIClient
+	DataplatformClient *dataplatform.APIClient
+}
+
+func appendUserAgent(userAgent string) string {
+	return fmt.Sprintf("%v_%v", viper.GetString(constants.CLIHttpUserAgent), userAgent)
+}
+
+func newClient(name, pwd, token, hostUrl string) (*Client, error) {
+	if token == "" && (name == "" || pwd == "") {
+		return nil, errors.New("username, password or token incorrect")
+	}
+
+	clientConfig := cloudv6.NewConfiguration(name, pwd, token, hostUrl)
+	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(constants.CLIHttpUserAgent), clientConfig.UserAgent)
+	// Set Depth Query Parameter globally
+	clientConfig.SetDepth(1)
+
+	authConfig := sdkgoauth.NewConfiguration(name, pwd, token, hostUrl)
+	authConfig.UserAgent = appendUserAgent(authConfig.UserAgent)
+
+	certManagerConfig := certmanager.NewConfiguration(name, pwd, token, hostUrl)
+	certManagerConfig.UserAgent = appendUserAgent(certManagerConfig.UserAgent)
+
+	postgresConfig := postgres.NewConfiguration(name, pwd, token, hostUrl)
+	postgresConfig.UserAgent = appendUserAgent(postgresConfig.UserAgent)
+
+	mongoConfig := mongo.NewConfiguration(name, pwd, token, hostUrl)
+	mongoConfig.UserAgent = appendUserAgent(mongoConfig.UserAgent)
+
+	dpConfig := dataplatform.NewConfiguration(name, pwd, token, hostUrl)
+	dpConfig.UserAgent = appendUserAgent(dpConfig.UserAgent)
+
+	return &Client{
+			CloudClient:        cloudv6.NewAPIClient(clientConfig),
+			AuthClient:         sdkgoauth.NewAPIClient(authConfig),
+			CertManagerClient:  certmanager.NewAPIClient(certManagerConfig),
+			PostgresClient:     postgres.NewAPIClient(postgresConfig),
+			MongoClient:        mongo.NewAPIClient(mongoConfig),
+			DataplatformClient: dataplatform.NewAPIClient(dpConfig),
+		},
+		nil
+}
+
+var once sync.Once
+var instance *Client
+
+// Get a client and possibly fail
+func Get() (*Client, error) {
+	var err error
+	once.Do(func() {
+		err = config.Load()
+		instance, err = newClient(viper.GetString(constants.Username), viper.GetString(constants.Password), viper.GetString(constants.Token), config.GetServerUrl())
+	})
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}
+
+// Must gets the client obj or fatally dies
+func Must() *Client {
+	client, err := Get()
+	if err != nil {
+		die.Die(fmt.Errorf("failed getting client: %w", err).Error())
+	}
+	return client
+}
+
+// NewTestClient - function used only for tests.
+// Bypasses the singleton check, not recommended for normal use.
+// TO BE REMOVED ONCE TESTS ARE REFACTORED
+func NewTestClient(name, pwd, token, hostUrl string) (*Client, error) {
+	return newClient(name, pwd, token, hostUrl)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 	certmanager "github.com/ionos-cloud/sdk-go-cert-manager"
+	registry "github.com/ionos-cloud/sdk-go-container-registry"
 	dataplatform "github.com/ionos-cloud/sdk-go-dataplatform"
 	mongo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 	postgres "github.com/ionos-cloud/sdk-go-dbaas-postgres"
@@ -24,6 +25,7 @@ type Client struct {
 	PostgresClient     *postgres.APIClient
 	MongoClient        *mongo.APIClient
 	DataplatformClient *dataplatform.APIClient
+	RegistryClient     *registry.APIClient
 }
 
 func appendUserAgent(userAgent string) string {
@@ -55,6 +57,9 @@ func newClient(name, pwd, token, hostUrl string) (*Client, error) {
 	dpConfig := dataplatform.NewConfiguration(name, pwd, token, hostUrl)
 	dpConfig.UserAgent = appendUserAgent(dpConfig.UserAgent)
 
+	registryConfig := registry.NewConfiguration(name, pwd, token, hostUrl)
+	registryConfig.UserAgent = appendUserAgent(registryConfig.UserAgent)
+
 	return &Client{
 			CloudClient:        cloudv6.NewAPIClient(clientConfig),
 			AuthClient:         sdkgoauth.NewAPIClient(authConfig),
@@ -62,6 +67,7 @@ func newClient(name, pwd, token, hostUrl string) (*Client, error) {
 			PostgresClient:     postgres.NewAPIClient(postgresConfig),
 			MongoClient:        mongo.NewAPIClient(mongoConfig),
 			DataplatformClient: dataplatform.NewAPIClient(dpConfig),
+			RegistryClient:     registry.NewAPIClient(registryConfig),
 		},
 		nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	sdk "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGetClient(t *testing.T) {
+	type args struct {
+		name    string
+		pwd     string
+		token   string
+		hostUrl string
+	}
+	tests := []struct {
+		name    string
+		runs    int
+		args    args
+		want    *Client
+		wantErr bool
+	}{
+		{"MissingCredentials", 1, args{"", "", "", ""}, nil, true},
+		{"MultipleGetClients", 4, args{"user", "pass", "token", "url"}, instance, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			viper.Reset()
+
+			assert.NoError(t, os.Setenv(sdk.IonosUsernameEnvVar, tt.args.name))
+			assert.NoError(t, os.Setenv(sdk.IonosPasswordEnvVar, tt.args.pwd))
+			assert.NoError(t, os.Setenv(sdk.IonosTokenEnvVar, tt.args.token))
+			assert.NoError(t, os.Setenv(sdk.IonosApiUrlEnvVar, tt.args.hostUrl))
+
+			for i := 0; i < tt.runs; i++ {
+				client, err := Get()
+				if !tt.wantErr && err != nil {
+					t.Errorf("Did not expect error: %v", err)
+				}
+				assert.Equalf(t, tt.want, client, "newClient(%v, %v, %v, %v)", tt.args.name, tt.args.pwd, tt.args.token, tt.args.hostUrl)
+			}
+		})
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,11 +1,12 @@
 package client
 
 import (
+	"os"
+	"testing"
+
 	sdk "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestGetClient(t *testing.T) {

--- a/internal/die/die.go
+++ b/internal/die/die.go
@@ -1,0 +1,11 @@
+package die
+
+import (
+	"fmt"
+	"os"
+)
+
+func Die(x string) {
+	fmt.Fprintf(os.Stderr, x)
+	os.Exit(1)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+
+	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 
 	cloudv6 "github.com/ionos-cloud/sdk-go/v6"
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,10 +22,10 @@ func TestUsingJustTokenEnvVar(t *testing.T) {
 
 	assert.NoError(t, os.Setenv(sdk.IonosTokenEnvVar, "tok"))
 	assert.NoError(t, Load())
-	assert.Equal(t, "tok", viper.GetString(Token))
-	assert.Equal(t, "", viper.GetString(Username))
-	assert.Equal(t, "", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "tok", viper.GetString(constants.Token))
+	assert.Equal(t, "", viper.GetString(constants.Username))
+	assert.Equal(t, "", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestTokEnvWithUserPassConfigBackup(t *testing.T) {
@@ -40,10 +40,10 @@ func TestTokEnvWithUserPassConfigBackup(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0600))
 	assert.NoError(t, Load())
 
-	assert.Equal(t, "tok", viper.GetString(Token))
-	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
-	assert.Equal(t, "test", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "tok", viper.GetString(constants.Token))
+	assert.Equal(t, "test@ionos.com", viper.GetString(constants.Username))
+	assert.Equal(t, "test", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestTokEnvWithFullConfig(t *testing.T) {
@@ -58,10 +58,10 @@ func TestTokEnvWithFullConfig(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0600))
 	assert.NoError(t, Load())
 
-	assert.Equal(t, "tok", viper.GetString(Token))
-	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
-	assert.Equal(t, "test", viper.GetString(Password))
-	assert.Equal(t, "https://api.ionos.com", viper.GetString(ServerUrl))
+	assert.Equal(t, "tok", viper.GetString(constants.Token))
+	assert.Equal(t, "test@ionos.com", viper.GetString(constants.Username))
+	assert.Equal(t, "test", viper.GetString(constants.Password))
+	assert.Equal(t, "https://api.ionos.com", viper.GetString(constants.ServerUrl))
 }
 
 func TestEnvVarsHavePriority(t *testing.T) {
@@ -79,10 +79,10 @@ func TestEnvVarsHavePriority(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0600))
 	assert.NoError(t, Load())
 
-	assert.Equal(t, "env_tok", viper.GetString(Token))
-	assert.Equal(t, "env_user", viper.GetString(Username))
-	assert.Equal(t, "env_pass", viper.GetString(Password))
-	assert.Equal(t, "env_url", viper.GetString(ServerUrl))
+	assert.Equal(t, "env_tok", viper.GetString(constants.Token))
+	assert.Equal(t, "env_user", viper.GetString(constants.Username))
+	assert.Equal(t, "env_pass", viper.GetString(constants.Password))
+	assert.Equal(t, "env_url", viper.GetString(constants.ServerUrl))
 }
 
 func TestAuthErr(t *testing.T) {
@@ -97,8 +97,8 @@ func TestAuthErr(t *testing.T) {
 
 	assert.Error(t, Load()) // Need password or token
 
-	assert.Equal(t, "env_user", viper.GetString(Username))
-	assert.Equal(t, "env_url", viper.GetString(ServerUrl))
+	assert.Equal(t, "env_user", viper.GetString(constants.Username))
+	assert.Equal(t, "env_url", viper.GetString(constants.ServerUrl))
 }
 
 func TestUsingJustUsernameAndPasswordEnvVar(t *testing.T) {
@@ -111,10 +111,10 @@ func TestUsingJustUsernameAndPasswordEnvVar(t *testing.T) {
 	assert.NoError(t, os.Setenv(sdk.IonosUsernameEnvVar, "user"))
 	assert.NoError(t, os.Setenv(sdk.IonosPasswordEnvVar, "pass"))
 	assert.NoError(t, Load())
-	assert.Equal(t, "", viper.GetString(Token))
-	assert.Equal(t, "user", viper.GetString(Username))
-	assert.Equal(t, "pass", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "", viper.GetString(constants.Token))
+	assert.Equal(t, "user", viper.GetString(constants.Username))
+	assert.Equal(t, "pass", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestBadConfigPerms(t *testing.T) {
@@ -127,10 +127,10 @@ func TestBadConfigPerms(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0000)) // no read perms
 	assert.Error(t, Load())
 
-	assert.Equal(t, "", viper.GetString(Token))
-	assert.Equal(t, "", viper.GetString(Username))
-	assert.Equal(t, "", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "", viper.GetString(constants.Token))
+	assert.Equal(t, "", viper.GetString(constants.Username))
+	assert.Equal(t, "", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestUsingJustTokenConfig(t *testing.T) {
@@ -143,10 +143,10 @@ func TestUsingJustTokenConfig(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0600))
 	assert.NoError(t, Load())
 
-	assert.Equal(t, "tok", viper.GetString(Token))
-	assert.Equal(t, "", viper.GetString(Username))
-	assert.Equal(t, "", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "tok", viper.GetString(constants.Token))
+	assert.Equal(t, "", viper.GetString(constants.Username))
+	assert.Equal(t, "", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestUsingJustUsernameAndPasswordConfig(t *testing.T) {
@@ -159,10 +159,10 @@ func TestUsingJustUsernameAndPasswordConfig(t *testing.T) {
 	assert.NoError(t, os.Chmod(path, 0600))
 	assert.NoError(t, Load())
 
-	assert.Equal(t, "", viper.GetString(Token))
-	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
-	assert.Equal(t, "test", viper.GetString(Password))
-	assert.Equal(t, "", viper.GetString(ServerUrl))
+	assert.Equal(t, "", viper.GetString(constants.Token))
+	assert.Equal(t, "test@ionos.com", viper.GetString(constants.Username))
+	assert.Equal(t, "test", viper.GetString(constants.Password))
+	assert.Equal(t, "", viper.GetString(constants.ServerUrl))
 }
 
 func TestGetServerUrl(t *testing.T) {
@@ -173,7 +173,7 @@ func TestGetServerUrl(t *testing.T) {
 	assert.NoError(t, os.Setenv(sdk.IonosApiUrlEnvVar, "url"))
 	err := Load()
 	assert.Error(t, err) // Error because neither token nor user & pass set
-	assert.Equal(t, "url", viper.GetString(ServerUrl))
+	assert.Equal(t, "url", viper.GetString(constants.ServerUrl))
 
 	// from config
 	os.Clearenv()
@@ -202,10 +202,10 @@ func TestLoadFile(t *testing.T) {
 	viper.Set(constants.ArgConfig, filepath.Join("..", "testdata", "config.json"))
 	assert.NoError(t, os.Chmod(filepath.Join("..", "testdata", "config.json"), 0600))
 	assert.NoError(t, LoadFile())
-	assert.Equal(t, "test@ionos.com", viper.GetString(Username))
-	assert.Equal(t, "test", viper.GetString(Password))
-	assert.Equal(t, "jwt-token", viper.GetString(Token))
-	assert.Equal(t, "https://api.ionos.com", viper.GetString(ServerUrl))
+	assert.Equal(t, "test@ionos.com", viper.GetString(constants.Username))
+	assert.Equal(t, "test", viper.GetString(constants.Password))
+	assert.Equal(t, "jwt-token", viper.GetString(constants.Token))
+	assert.Equal(t, "https://api.ionos.com", viper.GetString(constants.ServerUrl))
 }
 
 func TestLoadEnvFallback(t *testing.T) {
@@ -219,46 +219,8 @@ func TestLoadEnvFallback(t *testing.T) {
 	assert.NoError(t, os.Setenv(sdk.IonosTokenEnvVar, "token"))
 	assert.NoError(t, os.Setenv(sdk.IonosApiUrlEnvVar, "url"))
 	assert.NoError(t, Load())
-	assert.Equal(t, "user", viper.GetString(Username))
-	assert.Equal(t, "pass", viper.GetString(Password))
-	assert.Equal(t, "token", viper.GetString(Token))
-	assert.Equal(t, "url", viper.GetString(ServerUrl))
-}
-
-func TestGetClient(t *testing.T) {
-	type args struct {
-		name    string
-		pwd     string
-		token   string
-		hostUrl string
-	}
-	tests := []struct {
-		name    string
-		runs    int
-		args    args
-		want    *Client
-		wantErr bool
-	}{
-		{"MissingCredentials", 1, args{"", "", "", ""}, nil, true},
-		{"MultipleGetClients", 4, args{"user", "pass", "token", "url"}, instance, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
-			viper.Reset()
-
-			assert.NoError(t, os.Setenv(sdk.IonosUsernameEnvVar, tt.args.name))
-			assert.NoError(t, os.Setenv(sdk.IonosPasswordEnvVar, tt.args.pwd))
-			assert.NoError(t, os.Setenv(sdk.IonosTokenEnvVar, tt.args.token))
-			assert.NoError(t, os.Setenv(sdk.IonosApiUrlEnvVar, tt.args.hostUrl))
-
-			for i := 0; i < tt.runs; i++ {
-				client, err := GetClient()
-				if !tt.wantErr && err != nil {
-					t.Errorf("Did not expect error: %v", err)
-				}
-				assert.Equalf(t, tt.want, client, "newClient(%v, %v, %v, %v)", tt.args.name, tt.args.pwd, tt.args.token, tt.args.hostUrl)
-			}
-		})
-	}
+	assert.Equal(t, "user", viper.GetString(constants.Username))
+	assert.Equal(t, "pass", viper.GetString(constants.Password))
+	assert.Equal(t, "token", viper.GetString(constants.Token))
+	assert.Equal(t, "url", viper.GetString(constants.ServerUrl))
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,9 +1,0 @@
-package config
-
-const (
-	Username         = "userdata.name"
-	Password         = "userdata.password"
-	Token            = "userdata.token"
-	ServerUrl        = "userdata.api-url"
-	CLIHttpUserAgent = "cli-user-agent"
-)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -103,3 +103,11 @@ const (
 	ErrDeleteAll     = "error occurred removing %v with ID: %v. error: %w"
 	ErrWaitDeleteAll = "error occurred waiting on removing %v with ID: %v. error: %w" // TODO: cleanup constant. reduce duplication
 )
+
+const (
+	Username         = "userdata.name"
+	Password         = "userdata.password"
+	Token            = "userdata.token"
+	ServerUrl        = "userdata.api-url"
+	CLIHttpUserAgent = "cli-user-agent"
+)

--- a/pkg/core/command_runner.go
+++ b/pkg/core/command_runner.go
@@ -3,12 +3,12 @@ package core
 import (
 	"bytes"
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
 	"os"
 
 	dbaas_mongo "github.com/ionos-cloud/ionosctl/v6/services/dbaas-mongo"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
@@ -119,7 +119,7 @@ func NewCommandCfg(ctx context.Context, in io.Reader, p printer.PrintService, in
 		// Define cmd Command Config function for Command
 		initCfg: func(c *CommandConfig) error {
 			// Init Clients and Services
-			client, err := config.GetClient()
+			client, err := client2.Get()
 			if err != nil {
 				return err
 			}

--- a/pkg/core/command_runner.go
+++ b/pkg/core/command_runner.go
@@ -3,9 +3,10 @@ package core
 import (
 	"bytes"
 	"context"
-	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"io"
 	"os"
+
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	dbaas_mongo "github.com/ionos-cloud/ionosctl/v6/services/dbaas-mongo"
 

--- a/services/auth-v1/resources/client.go
+++ b/services/auth-v1/resources/client.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 	"github.com/spf13/viper"
 )
@@ -34,7 +34,7 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 		return nil, errors.New("username, password or token incorrect")
 	}
 	clientConfig := sdkgoauth.NewConfiguration(name, pwd, token, hostUrl)
-	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(config.CLIHttpUserAgent), clientConfig.UserAgent)
+	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(constants.CLIHttpUserAgent), clientConfig.UserAgent)
 	return &clientService{
 		client: sdkgoauth.NewAPIClient(clientConfig),
 	}, nil

--- a/services/auth-v1/resources/client.go
+++ b/services/auth-v1/resources/client.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"

--- a/services/auth-v1/resources/client_test.go
+++ b/services/auth-v1/resources/client_test.go
@@ -1,9 +1,8 @@
 package resources
 
 import (
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -36,8 +35,8 @@ func TestNewClientService(t *testing.T) {
 	})
 }
 
-func getTestClient(t *testing.T) *config.Client {
-	svc, err := config.NewTestClient("user", "pass", "", constants.DefaultApiURL)
+func getTestClient(t *testing.T) *client.Client {
+	svc, err := client.NewTestClient("user", "pass", "", constants.DefaultApiURL)
 	assert.NotNil(t, svc)
 	assert.NoError(t, err)
 	assert.Equal(t, "user", svc.AuthClient.GetConfig().Username)

--- a/services/auth-v1/resources/client_test.go
+++ b/services/auth-v1/resources/client_test.go
@@ -1,8 +1,9 @@
 package resources
 
 import (
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"

--- a/services/auth-v1/resources/token.go
+++ b/services/auth-v1/resources/token.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"

--- a/services/auth-v1/resources/token.go
+++ b/services/auth-v1/resources/token.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 )
@@ -44,7 +43,7 @@ type tokensService struct {
 
 var _ TokensService = &tokensService{}
 
-func NewTokenService(client *config.Client, ctx context.Context) TokensService {
+func NewTokenService(client *client.Client, ctx context.Context) TokensService {
 	return &tokensService{
 		client:  client.AuthClient,
 		context: ctx,

--- a/services/auth-v1/services.go
+++ b/services/auth-v1/services.go
@@ -2,8 +2,7 @@ package auth_v1
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"
 )
@@ -17,7 +16,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client.Client) error {
 	c.Tokens = func() resources.TokensService { return resources.NewTokenService(client, c.Context) }
 	return nil
 }

--- a/services/auth-v1/services.go
+++ b/services/auth-v1/services.go
@@ -2,6 +2,7 @@ package auth_v1
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"

--- a/services/certmanager/resources/certificates.go
+++ b/services/certmanager/resources/certificates.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-cert-manager"

--- a/services/certmanager/resources/certificates.go
+++ b/services/certmanager/resources/certificates.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-cert-manager"
 )
@@ -29,7 +28,7 @@ type certsService struct {
 
 var _ CertsService = &certsService{}
 
-func NewCertsService(client *config.Client, ctx context.Context) CertsService {
+func NewCertsService(client *client.Client, ctx context.Context) CertsService {
 	return &certsService{
 		client:  client.CertManagerClient,
 		context: ctx,

--- a/services/certmanager/resources/client.go
+++ b/services/certmanager/resources/client.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgo "github.com/ionos-cloud/sdk-go-cert-manager"
 	"github.com/spf13/viper"
 )
@@ -34,7 +34,7 @@ func NewClientService(name, pwd, token, hostUrl string) (ClientService, error) {
 		return nil, errors.New("username, password or token incorrect")
 	}
 	clientConfig := sdkgo.NewConfiguration(name, pwd, token, hostUrl)
-	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(config.CLIHttpUserAgent), clientConfig.UserAgent)
+	clientConfig.UserAgent = fmt.Sprintf("%v_%v", viper.GetString(constants.CLIHttpUserAgent), clientConfig.UserAgent)
 	return &clientService{
 		client: sdkgo.NewAPIClient(clientConfig),
 	}, nil

--- a/services/certmanager/resources/client.go
+++ b/services/certmanager/resources/client.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-cert-manager"

--- a/services/certmanager/services.go
+++ b/services/certmanager/services.go
@@ -2,8 +2,8 @@ package certmanager
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/services/certmanager/resources"
 )
 
@@ -14,7 +14,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client.Client) error {
 	c.Certs = func() resources.CertsService { return resources.NewCertsService(client, c.Context) }
 	return nil
 }

--- a/services/certmanager/services.go
+++ b/services/certmanager/services.go
@@ -2,6 +2,7 @@ package certmanager
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/certmanager/resources"

--- a/services/cloudapi-v6/resources/applicationloadbalancer.go
+++ b/services/cloudapi-v6/resources/applicationloadbalancer.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 
@@ -72,7 +71,7 @@ type applicationLoadBalancersService struct {
 
 var _ ApplicationLoadBalancersService = &applicationLoadBalancersService{}
 
-func NewApplicationLoadBalancerService(client *config.Client, ctx context.Context) ApplicationLoadBalancersService {
+func NewApplicationLoadBalancerService(client *client.Client, ctx context.Context) ApplicationLoadBalancersService {
 	return &applicationLoadBalancersService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/applicationloadbalancer.go
+++ b/services/cloudapi-v6/resources/applicationloadbalancer.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/backupunit.go
+++ b/services/cloudapi-v6/resources/backupunit.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -42,7 +41,7 @@ type backupUnitsService struct {
 
 var _ BackupUnitsService = &backupUnitsService{}
 
-func NewBackupUnitService(client *config.Client, ctx context.Context) BackupUnitsService {
+func NewBackupUnitService(client *client.Client, ctx context.Context) BackupUnitsService {
 	return &backupUnitsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/backupunit.go
+++ b/services/cloudapi-v6/resources/backupunit.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/client_test.go
+++ b/services/cloudapi-v6/resources/client_test.go
@@ -1,33 +1,32 @@
 package resources
 
 import (
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewClientService(t *testing.T) {
 	t.Run("no credentials", func(t *testing.T) {
-		svc, err := config.NewTestClient("needspassword", "", "", "url")
+		svc, err := client.NewTestClient("needspassword", "", "", "url")
 		assert.Nil(t, svc)
 		assert.EqualError(t, err, "username, password or token incorrect")
 	})
 
 	t.Run("success", func(t *testing.T) {
-		svc, err := config.NewTestClient("", "", "token", "url")
+		svc, err := client.NewTestClient("", "", "token", "url")
 		assert.NotNil(t, svc)
 		assert.NoError(t, err)
 		assert.Equal(t, "token", svc.CloudClient.GetConfig().Token)
 
-		svc, err = config.NewTestClient("user", "pass", "", "url")
+		svc, err = client.NewTestClient("user", "pass", "", "url")
 		assert.NotNil(t, svc)
 		assert.NoError(t, err)
 		assert.Equal(t, "user", svc.CloudClient.GetConfig().Username)
 		assert.Equal(t, "pass", svc.CloudClient.GetConfig().Password)
 
-		svc, err = config.NewTestClient("user", "pass", "", "")
+		svc, err = client.NewTestClient("user", "pass", "", "")
 		assert.NotNil(t, svc)
 		assert.NoError(t, err)
 		assert.Equal(t, "user", svc.CloudClient.GetConfig().Username)

--- a/services/cloudapi-v6/resources/client_test.go
+++ b/services/cloudapi-v6/resources/client_test.go
@@ -1,8 +1,9 @@
 package resources
 
 import (
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/services/cloudapi-v6/resources/contract.go
+++ b/services/cloudapi-v6/resources/contract.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 
@@ -30,7 +29,7 @@ type contractsService struct {
 
 var _ ContractsService = &contractsService{}
 
-func NewContractService(client *config.Client, ctx context.Context) ContractsService {
+func NewContractService(client *client.Client, ctx context.Context) ContractsService {
 	return &contractsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/contract.go
+++ b/services/cloudapi-v6/resources/contract.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/datacenter.go
+++ b/services/cloudapi-v6/resources/datacenter.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
@@ -40,7 +40,7 @@ type dataCentersService struct {
 
 var _ DatacentersService = &dataCentersService{}
 
-func NewDataCenterService(client *config.Client, ctx context.Context) DatacentersService {
+func NewDataCenterService(client *client.Client, ctx context.Context) DatacentersService {
 	return &dataCentersService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/datacenter.go
+++ b/services/cloudapi-v6/resources/datacenter.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/datacenter.go
+++ b/services/cloudapi-v6/resources/datacenter.go
@@ -48,7 +48,7 @@ func NewDataCenterService(client *client.Client, ctx context.Context) Datacenter
 	}
 }
 
-//func NewDataCenterServices(client *config.Client, ctx context.Context) DatacentersService {
+//func NewDataCenterServices(client *client2.Client, ctx context.Context) DatacentersService {
 //	return &dataCentersService{
 //		client:  client,
 //		context: ctx,

--- a/services/cloudapi-v6/resources/firewallrule.go
+++ b/services/cloudapi-v6/resources/firewallrule.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/firewallrule.go
+++ b/services/cloudapi-v6/resources/firewallrule.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -37,7 +36,7 @@ type firewallRulesService struct {
 
 var _ FirewallRulesService = &firewallRulesService{}
 
-func NewFirewallRuleService(client *config.Client, ctx context.Context) FirewallRulesService {
+func NewFirewallRuleService(client *client.Client, ctx context.Context) FirewallRulesService {
 	return &firewallRulesService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/flowlog.go
+++ b/services/cloudapi-v6/resources/flowlog.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/flowlog.go
+++ b/services/cloudapi-v6/resources/flowlog.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -41,7 +40,7 @@ type flowLogsService struct {
 
 var _ FlowLogsService = &flowLogsService{}
 
-func NewFlowLogService(client *config.Client, ctx context.Context) FlowLogsService {
+func NewFlowLogService(client *client.Client, ctx context.Context) FlowLogsService {
 	return &flowLogsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/group.go
+++ b/services/cloudapi-v6/resources/group.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/group.go
+++ b/services/cloudapi-v6/resources/group.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
@@ -65,7 +65,7 @@ type groupsService struct {
 
 var _ GroupsService = &groupsService{}
 
-func NewGroupService(client *config.Client, ctx context.Context) GroupsService {
+func NewGroupService(client *client.Client, ctx context.Context) GroupsService {
 	return &groupsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/image.go
+++ b/services/cloudapi-v6/resources/image.go
@@ -6,10 +6,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"path/filepath"
 	"time"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -62,7 +61,7 @@ type imagesService struct {
 
 var _ ImagesService = &imagesService{}
 
-func NewImageService(client *config.Client, ctx context.Context) ImagesService {
+func NewImageService(client *client.Client, ctx context.Context) ImagesService {
 	return &imagesService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/image.go
+++ b/services/cloudapi-v6/resources/image.go
@@ -6,9 +6,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"path/filepath"
 	"time"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"

--- a/services/cloudapi-v6/resources/ipblock.go
+++ b/services/cloudapi-v6/resources/ipblock.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -41,7 +40,7 @@ type ipBlocksService struct {
 
 var _ IpBlocksService = &ipBlocksService{}
 
-func NewIpBlockService(client *config.Client, ctx context.Context) IpBlocksService {
+func NewIpBlockService(client *client.Client, ctx context.Context) IpBlocksService {
 	return &ipBlocksService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/ipblock.go
+++ b/services/cloudapi-v6/resources/ipblock.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/k8s.go
+++ b/services/cloudapi-v6/resources/k8s.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -114,7 +113,7 @@ type k8sService struct {
 
 var _ K8sService = &k8sService{}
 
-func NewK8sService(client *config.Client, ctx context.Context) K8sService {
+func NewK8sService(client *client.Client, ctx context.Context) K8sService {
 	return &k8sService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/k8s.go
+++ b/services/cloudapi-v6/resources/k8s.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/label.go
+++ b/services/cloudapi-v6/resources/label.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 
@@ -59,7 +58,7 @@ type labelResourcesService struct {
 
 var _ LabelResourcesService = &labelResourcesService{}
 
-func NewLabelResourceService(client *config.Client, ctx context.Context) LabelResourcesService {
+func NewLabelResourceService(client *client.Client, ctx context.Context) LabelResourcesService {
 	return &labelResourcesService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/label.go
+++ b/services/cloudapi-v6/resources/label.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/label_test.go
+++ b/services/cloudapi-v6/resources/label_test.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -150,8 +149,8 @@ func TestNewLabelResourceService(t *testing.T) {
 	})
 }
 
-func getTestClient(t *testing.T) *config.Client {
-	svc, err := config.NewTestClient("user", "pass", "", constants.DefaultApiURL)
+func getTestClient(t *testing.T) *client.Client {
+	svc, err := client.NewTestClient("user", "pass", "", constants.DefaultApiURL)
 	assert.NotNil(t, svc)
 	assert.NoError(t, err)
 	assert.Equal(t, "user", svc.CloudClient.GetConfig().Username)

--- a/services/cloudapi-v6/resources/label_test.go
+++ b/services/cloudapi-v6/resources/label_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"

--- a/services/cloudapi-v6/resources/lan.go
+++ b/services/cloudapi-v6/resources/lan.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/lan.go
+++ b/services/cloudapi-v6/resources/lan.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -45,7 +44,7 @@ type lansService struct {
 
 var _ LansService = &lansService{}
 
-func NewLanService(client *config.Client, ctx context.Context) LansService {
+func NewLanService(client *client.Client, ctx context.Context) LansService {
 	return &lansService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/loadbalancer.go
+++ b/services/cloudapi-v6/resources/loadbalancer.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -41,7 +40,7 @@ type loadbalancersService struct {
 
 var _ LoadbalancersService = &loadbalancersService{}
 
-func NewLoadbalancerService(client *config.Client, ctx context.Context) LoadbalancersService {
+func NewLoadbalancerService(client *client.Client, ctx context.Context) LoadbalancersService {
 	return &loadbalancersService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/loadbalancer.go
+++ b/services/cloudapi-v6/resources/loadbalancer.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/location.go
+++ b/services/cloudapi-v6/resources/location.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -35,7 +34,7 @@ type locationsService struct {
 
 var _ LocationsService = &locationsService{}
 
-func NewLocationService(client *config.Client, ctx context.Context) LocationsService {
+func NewLocationService(client *client.Client, ctx context.Context) LocationsService {
 	return &locationsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/location.go
+++ b/services/cloudapi-v6/resources/location.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/mocks/ClientService.go
+++ b/services/cloudapi-v6/resources/mocks/ClientService.go
@@ -5,9 +5,8 @@
 package mock_resources
 
 import (
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	reflect "reflect"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,10 +35,10 @@ func (m *MockClientService) EXPECT() *MockClientServiceMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockClientService) Get() *config.Client {
+func (m *MockClientService) Get() *client.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get")
-	ret0, _ := ret[0].(*config.Client)
+	ret0, _ := ret[0].(*client.Client)
 	return ret0
 }
 

--- a/services/cloudapi-v6/resources/mocks/ClientService.go
+++ b/services/cloudapi-v6/resources/mocks/ClientService.go
@@ -5,8 +5,9 @@
 package mock_resources
 
 import (
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	reflect "reflect"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	gomock "github.com/golang/mock/gomock"
 )

--- a/services/cloudapi-v6/resources/natgateway.go
+++ b/services/cloudapi-v6/resources/natgateway.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/natgateway.go
+++ b/services/cloudapi-v6/resources/natgateway.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
@@ -62,7 +62,7 @@ type natGatewaysService struct {
 
 var _ NatGatewaysService = &natGatewaysService{}
 
-func NewNatGatewayService(client *config.Client, ctx context.Context) NatGatewaysService {
+func NewNatGatewayService(client *client.Client, ctx context.Context) NatGatewaysService {
 	return &natGatewaysService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/networkloadbalancer.go
+++ b/services/cloudapi-v6/resources/networkloadbalancer.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/networkloadbalancer.go
+++ b/services/cloudapi-v6/resources/networkloadbalancer.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -75,7 +74,7 @@ type networkLoadBalancersService struct {
 
 var _ NetworkLoadBalancersService = &networkLoadBalancersService{}
 
-func NewNetworkLoadBalancerService(client *config.Client, ctx context.Context) NetworkLoadBalancersService {
+func NewNetworkLoadBalancerService(client *client.Client, ctx context.Context) NetworkLoadBalancersService {
 	return &networkLoadBalancersService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/nic.go
+++ b/services/cloudapi-v6/resources/nic.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/nic.go
+++ b/services/cloudapi-v6/resources/nic.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -45,7 +44,7 @@ type nicsService struct {
 
 var _ NicsService = &nicsService{}
 
-func NewNicService(client *config.Client, ctx context.Context) NicsService {
+func NewNicService(client *client.Client, ctx context.Context) NicsService {
 	return &nicsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/pcc.go
+++ b/services/cloudapi-v6/resources/pcc.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/pcc.go
+++ b/services/cloudapi-v6/resources/pcc.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -42,7 +41,7 @@ type pccsService struct {
 
 var _ PccsService = &pccsService{}
 
-func NewPrivateCrossConnectService(client *config.Client, ctx context.Context) PccsService {
+func NewPrivateCrossConnectService(client *client.Client, ctx context.Context) PccsService {
 	return &pccsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/request.go
+++ b/services/cloudapi-v6/resources/request.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/request.go
+++ b/services/cloudapi-v6/resources/request.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -36,7 +35,7 @@ type requestsService struct {
 
 var _ RequestsService = &requestsService{}
 
-func NewRequestService(client *config.Client, ctx context.Context) RequestsService {
+func NewRequestService(client *client.Client, ctx context.Context) RequestsService {
 	return &requestsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/s3key.go
+++ b/services/cloudapi-v6/resources/s3key.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/s3key.go
+++ b/services/cloudapi-v6/resources/s3key.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 
@@ -34,7 +33,7 @@ type s3KeysService struct {
 
 var _ S3KeysService = &s3KeysService{}
 
-func NewS3KeyService(client *config.Client, ctx context.Context) S3KeysService {
+func NewS3KeyService(client *client.Client, ctx context.Context) S3KeysService {
 	return &s3KeysService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/server.go
+++ b/services/cloudapi-v6/resources/server.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/server.go
+++ b/services/cloudapi-v6/resources/server.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -64,7 +63,7 @@ type serversService struct {
 
 var _ ServersService = &serversService{}
 
-func NewServerService(client *config.Client, ctx context.Context) ServersService {
+func NewServerService(client *client.Client, ctx context.Context) ServersService {
 	return &serversService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/snapshot.go
+++ b/services/cloudapi-v6/resources/snapshot.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/snapshot.go
+++ b/services/cloudapi-v6/resources/snapshot.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -38,7 +37,7 @@ type snapshotsService struct {
 
 var _ SnapshotsService = &snapshotsService{}
 
-func NewSnapshotService(client *config.Client, ctx context.Context) SnapshotsService {
+func NewSnapshotService(client *client.Client, ctx context.Context) SnapshotsService {
 	return &snapshotsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/targetgroup.go
+++ b/services/cloudapi-v6/resources/targetgroup.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/targetgroup.go
+++ b/services/cloudapi-v6/resources/targetgroup.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 
@@ -50,7 +49,7 @@ type targetGroupsService struct {
 
 var _ TargetGroupsService = &targetGroupsService{}
 
-func NewTargetGroupService(client *config.Client, ctx context.Context) TargetGroupsService {
+func NewTargetGroupService(client *client.Client, ctx context.Context) TargetGroupsService {
 	return &targetGroupsService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/template.go
+++ b/services/cloudapi-v6/resources/template.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/template.go
+++ b/services/cloudapi-v6/resources/template.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -34,7 +33,7 @@ type templatesService struct {
 
 var _ TemplatesService = &templatesService{}
 
-func NewTemplateService(client *config.Client, ctx context.Context) TemplatesService {
+func NewTemplateService(client *client.Client, ctx context.Context) TemplatesService {
 	return &templatesService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/user.go
+++ b/services/cloudapi-v6/resources/user.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/resources/user.go
+++ b/services/cloudapi-v6/resources/user.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -64,7 +63,7 @@ type usersService struct {
 
 var _ UsersService = &usersService{}
 
-func NewUserService(client *config.Client, ctx context.Context) UsersService {
+func NewUserService(client *client.Client, ctx context.Context) UsersService {
 	return &usersService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/volume.go
+++ b/services/cloudapi-v6/resources/volume.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -40,7 +39,7 @@ type volumesService struct {
 
 var _ VolumesService = &volumesService{}
 
-func NewVolumeService(client *config.Client, ctx context.Context) VolumesService {
+func NewVolumeService(client *client.Client, ctx context.Context) VolumesService {
 	return &volumesService{
 		client:  client.CloudClient,
 		context: ctx,

--- a/services/cloudapi-v6/resources/volume.go
+++ b/services/cloudapi-v6/resources/volume.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/fatih/structs"

--- a/services/cloudapi-v6/services.go
+++ b/services/cloudapi-v6/services.go
@@ -2,6 +2,7 @@ package cloudapi_v6
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"

--- a/services/cloudapi-v6/services.go
+++ b/services/cloudapi-v6/services.go
@@ -2,8 +2,8 @@ package cloudapi_v6
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 )
 
@@ -40,7 +40,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client.Client) error {
 	c.Locations = func() resources.LocationsService { return resources.NewLocationService(client, c.Context) }
 	c.DataCenters = func() resources.DatacentersService {
 		return resources.NewDataCenterService(client, c.Context)

--- a/services/container-registry/resources/location.go
+++ b/services/container-registry/resources/location.go
@@ -2,7 +2,7 @@ package resources
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	sdkgo "github.com/ionos-cloud/sdk-go-container-registry"
 )
 
@@ -17,7 +17,7 @@ type locationsService struct {
 
 var _ LocationsService = &locationsService{}
 
-func NewLocationsService(client *config.Client, ctx context.Context) LocationsService {
+func NewLocationsService(client *client2.Client, ctx context.Context) LocationsService {
 	return &locationsService{
 		client:  client.RegistryClient,
 		context: ctx,

--- a/services/container-registry/resources/name.go
+++ b/services/container-registry/resources/name.go
@@ -2,8 +2,8 @@ package resources
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgo "github.com/ionos-cloud/sdk-go-container-registry"
 )
 
@@ -21,7 +21,7 @@ type nameService struct {
 var _ NameService = &nameService{}
 
 // NewNameService returns a new NameService.
-func NewNameService(client *config.Client, ctx context.Context) NameService {
+func NewNameService(client *client2.Client, ctx context.Context) NameService {
 	return &nameService{
 		client:  client.RegistryClient,
 		context: ctx,

--- a/services/container-registry/resources/registry.go
+++ b/services/container-registry/resources/registry.go
@@ -2,7 +2,7 @@ package resources
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	sdkgo "github.com/ionos-cloud/sdk-go-container-registry"
 )
 
@@ -23,7 +23,7 @@ type registriesService struct {
 
 var _ RegistriesService = &registriesService{}
 
-func NewRegistriesService(client *config.Client, ctx context.Context) RegistriesService {
+func NewRegistriesService(client *client2.Client, ctx context.Context) RegistriesService {
 	return &registriesService{
 		client:  client.RegistryClient,
 		context: ctx,

--- a/services/container-registry/resources/repository.go
+++ b/services/container-registry/resources/repository.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
-
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	sdkgo "github.com/ionos-cloud/sdk-go-container-registry"
 )
 
@@ -18,7 +17,7 @@ type repositoryService struct {
 
 var _ RepositoryService = &repositoryService{}
 
-func NewRepositoryService(client *config.Client, ctx context.Context) RepositoryService {
+func NewRepositoryService(client *client2.Client, ctx context.Context) RepositoryService {
 	return &repositoryService{
 		client:  client.RegistryClient,
 		context: ctx,

--- a/services/container-registry/resources/token.go
+++ b/services/container-registry/resources/token.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	sdkgo "github.com/ionos-cloud/sdk-go-container-registry"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 )
 
 // TokenService is a wrapper around ionoscloud.Registry
@@ -24,7 +23,7 @@ type tokenService struct {
 
 var _ TokenService = &tokenService{}
 
-func NewTokenService(client *config.Client, ctx context.Context) TokenService {
+func NewTokenService(client *client2.Client, ctx context.Context) TokenService {
 	return &tokenService{
 		client:  client.RegistryClient,
 		context: ctx,

--- a/services/container-registry/services.go
+++ b/services/container-registry/services.go
@@ -2,7 +2,7 @@ package container_registry
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	client2 "github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/services/container-registry/resources"
 )
 
@@ -18,7 +18,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client2.Client) error {
 	c.Registry = func() resources.RegistriesService {
 		return resources.NewRegistriesService(client, c.Context)
 	}

--- a/services/dbaas-mongo/resources/apiversion.go
+++ b/services/dbaas-mongo/resources/apiversion.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"

--- a/services/dbaas-mongo/resources/apiversion.go
+++ b/services/dbaas-mongo/resources/apiversion.go
@@ -2,8 +2,8 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )
 
@@ -18,7 +18,7 @@ type apiMetadataService struct {
 
 var _ ApiMetadataService = &apiMetadataService{}
 
-func NewApiMetadataService(client *config.Client, ctx context.Context) ApiMetadataService {
+func NewApiMetadataService(client *client.Client, ctx context.Context) ApiMetadataService {
 	return &apiMetadataService{
 		client:  client.MongoClient,
 		context: ctx,

--- a/services/dbaas-mongo/resources/cluster.go
+++ b/services/dbaas-mongo/resources/cluster.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"time"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )

--- a/services/dbaas-mongo/resources/cluster.go
+++ b/services/dbaas-mongo/resources/cluster.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"time"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )
@@ -36,7 +35,7 @@ type clustersService struct {
 
 var _ ClustersService = &clustersService{}
 
-func NewClustersService(client *config.Client, ctx context.Context) ClustersService {
+func NewClustersService(client *client.Client, ctx context.Context) ClustersService {
 	return &clustersService{
 		client:  client.MongoClient,
 		context: ctx,

--- a/services/dbaas-mongo/resources/templates.go
+++ b/services/dbaas-mongo/resources/templates.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"

--- a/services/dbaas-mongo/resources/templates.go
+++ b/services/dbaas-mongo/resources/templates.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )
@@ -19,7 +18,7 @@ type templatesService struct {
 
 var _ TemplatesService = &templatesService{}
 
-func NewTemplatesService(client *config.Client, ctx context.Context) TemplatesService {
+func NewTemplatesService(client *client.Client, ctx context.Context) TemplatesService {
 	return &templatesService{
 		client:  client.MongoClient,
 		context: ctx,

--- a/services/dbaas-mongo/resources/user.go
+++ b/services/dbaas-mongo/resources/user.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"

--- a/services/dbaas-mongo/resources/user.go
+++ b/services/dbaas-mongo/resources/user.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-mongo"
 )
@@ -23,7 +22,7 @@ type usersService struct {
 
 var _ UsersService = &usersService{}
 
-func NewUsersService(client *config.Client, ctx context.Context) UsersService {
+func NewUsersService(client *client.Client, ctx context.Context) UsersService {
 	return &usersService{
 		client:  client.MongoClient,
 		context: ctx,

--- a/services/dbaas-mongo/services.go
+++ b/services/dbaas-mongo/services.go
@@ -2,6 +2,7 @@ package dbaas_mongo
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-mongo/resources"

--- a/services/dbaas-mongo/services.go
+++ b/services/dbaas-mongo/services.go
@@ -2,8 +2,8 @@ package dbaas_mongo
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-mongo/resources"
 )
 
@@ -17,7 +17,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client.Client) error {
 	c.Clusters = func() resources.ClustersService { return resources.NewClustersService(client, c.Context) }
 	c.Templates = func() resources.TemplatesService { return resources.NewTemplatesService(client, c.Context) }
 	c.Users = func() resources.UsersService { return resources.NewUsersService(client, c.Context) }

--- a/services/dbaas-postgres/resources/backup.go
+++ b/services/dbaas-postgres/resources/backup.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"

--- a/services/dbaas-postgres/resources/backup.go
+++ b/services/dbaas-postgres/resources/backup.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -34,7 +33,7 @@ type backupsService struct {
 
 var _ BackupsService = &backupsService{}
 
-func NewBackupsService(client *config.Client, ctx context.Context) BackupsService {
+func NewBackupsService(client *client.Client, ctx context.Context) BackupsService {
 	return &backupsService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/resources/client_test.go
+++ b/services/dbaas-postgres/resources/client_test.go
@@ -1,9 +1,8 @@
 package resources
 
 import (
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -11,22 +10,22 @@ import (
 
 func TestNewClientService(t *testing.T) {
 	t.Run("no credentials", func(t *testing.T) {
-		svc, err := config.NewTestClient("", "", "", "")
+		svc, err := client.NewTestClient("", "", "", "")
 		assert.Nil(t, svc)
 		assert.EqualError(t, err, "username, password or token incorrect")
 
-		svc, err = config.NewTestClient("needspassword", "", "", "url")
+		svc, err = client.NewTestClient("needspassword", "", "", "url")
 		assert.Nil(t, svc)
 		assert.EqualError(t, err, "username, password or token incorrect")
 	})
 
 	t.Run("success", func(t *testing.T) {
-		svc, err := config.NewTestClient("", "", "token", "url")
+		svc, err := client.NewTestClient("", "", "token", "url")
 		assert.NotNil(t, svc)
 		assert.NoError(t, err)
 		assert.Equal(t, "token", svc.PostgresClient.GetConfig().Token)
 
-		svc, err = config.NewTestClient("user", "pass", "", "url")
+		svc, err = client.NewTestClient("user", "pass", "", "url")
 		assert.NotNil(t, svc)
 		assert.NoError(t, err)
 		assert.Equal(t, "user", svc.PostgresClient.GetConfig().Username)
@@ -34,8 +33,8 @@ func TestNewClientService(t *testing.T) {
 	})
 }
 
-func getTestClient(t *testing.T) *config.Client {
-	svc, err := config.NewTestClient("user", "pass", "", constants.DefaultApiURL)
+func getTestClient(t *testing.T) *client.Client {
+	svc, err := client.NewTestClient("user", "pass", "", constants.DefaultApiURL)
 	assert.NotNil(t, svc)
 	assert.NoError(t, err)
 	assert.Equal(t, "user", svc.PostgresClient.GetConfig().Username)

--- a/services/dbaas-postgres/resources/client_test.go
+++ b/services/dbaas-postgres/resources/client_test.go
@@ -1,8 +1,9 @@
 package resources
 
 import (
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/stretchr/testify/assert"

--- a/services/dbaas-postgres/resources/cluster.go
+++ b/services/dbaas-postgres/resources/cluster.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -52,7 +51,7 @@ type clustersService struct {
 
 var _ ClustersService = &clustersService{}
 
-func NewClustersService(client *config.Client, ctx context.Context) ClustersService {
+func NewClustersService(client *client.Client, ctx context.Context) ClustersService {
 	return &clustersService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/resources/cluster.go
+++ b/services/dbaas-postgres/resources/cluster.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"

--- a/services/dbaas-postgres/resources/info.go
+++ b/services/dbaas-postgres/resources/info.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"

--- a/services/dbaas-postgres/resources/info.go
+++ b/services/dbaas-postgres/resources/info.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -29,7 +28,7 @@ type infosService struct {
 
 var _ InfosService = &infosService{}
 
-func NewInfosService(client *config.Client, ctx context.Context) InfosService {
+func NewInfosService(client *client.Client, ctx context.Context) InfosService {
 	return &infosService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/resources/logs.go
+++ b/services/dbaas-postgres/resources/logs.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"time"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -31,7 +30,7 @@ type logsService struct {
 
 var _ LogsService = &logsService{}
 
-func NewLogsService(client *config.Client, ctx context.Context) LogsService {
+func NewLogsService(client *client.Client, ctx context.Context) LogsService {
 	return &logsService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/resources/logs.go
+++ b/services/dbaas-postgres/resources/logs.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"time"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )

--- a/services/dbaas-postgres/resources/mocks/ClientService.go
+++ b/services/dbaas-postgres/resources/mocks/ClientService.go
@@ -5,9 +5,8 @@
 package mock_resources
 
 import (
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	reflect "reflect"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,10 +35,10 @@ func (m *MockClientService) EXPECT() *MockClientServiceMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockClientService) Get() *config.Client {
+func (m *MockClientService) Get() *client.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get")
-	ret0, _ := ret[0].(*config.Client)
+	ret0, _ := ret[0].(*client.Client)
 	return ret0
 }
 

--- a/services/dbaas-postgres/resources/mocks/ClientService.go
+++ b/services/dbaas-postgres/resources/mocks/ClientService.go
@@ -5,8 +5,9 @@
 package mock_resources
 
 import (
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	reflect "reflect"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	gomock "github.com/golang/mock/gomock"
 )

--- a/services/dbaas-postgres/resources/restore.go
+++ b/services/dbaas-postgres/resources/restore.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"

--- a/services/dbaas-postgres/resources/restore.go
+++ b/services/dbaas-postgres/resources/restore.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -24,7 +23,7 @@ type restoresService struct {
 
 var _ RestoresService = &restoresService{}
 
-func NewRestoresService(client *config.Client, ctx context.Context) RestoresService {
+func NewRestoresService(client *client.Client, ctx context.Context) RestoresService {
 	return &restoresService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/resources/version.go
+++ b/services/dbaas-postgres/resources/version.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"

--- a/services/dbaas-postgres/resources/version.go
+++ b/services/dbaas-postgres/resources/version.go
@@ -2,8 +2,7 @@ package resources
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	sdkgo "github.com/ionos-cloud/sdk-go-dbaas-postgres"
 )
@@ -25,7 +24,7 @@ type versionsService struct {
 
 var _ VersionsService = &versionsService{}
 
-func NewVersionsService(client *config.Client, ctx context.Context) VersionsService {
+func NewVersionsService(client *client.Client, ctx context.Context) VersionsService {
 	return &versionsService{
 		client:  client.PostgresClient,
 		context: ctx,

--- a/services/dbaas-postgres/services.go
+++ b/services/dbaas-postgres/services.go
@@ -2,6 +2,7 @@ package dbaas_postgres
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-postgres/resources"

--- a/services/dbaas-postgres/services.go
+++ b/services/dbaas-postgres/services.go
@@ -2,8 +2,7 @@ package dbaas_postgres
 
 import (
 	"context"
-
-	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/services/dbaas-postgres/resources"
 )
@@ -21,7 +20,7 @@ type Services struct {
 }
 
 // InitServices for Commands
-func (c *Services) InitServices(client *config.Client) error {
+func (c *Services) InitServices(client *client.Client) error {
 	c.Clusters = func() resources.ClustersService { return resources.NewClustersService(client, c.Context) }
 	c.Backups = func() resources.BackupsService { return resources.NewBackupsService(client, c.Context) }
 	c.Versions = func() resources.VersionsService { return resources.NewVersionsService(client, c.Context) }


### PR DESCRIPTION
## What does this fix or implement?

Add the option to force killing the process if fail getting Client (to avoid verbose err handling outside `client` pkg)

Move client handling to own pkg `client` instead of `config`

Add pkg `die` which exports only one func currently: `Die` which allows breaking execution with the given string and exiting with code `1`

