### PR TITLE
fix #249: -o json no longer renames items

### DIFF
--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -134,7 +134,7 @@ func (prt *Result) PrintJSON(out io.Writer) error {
 type ResultPrint struct {
 	Message   interface{} `json:"Status,omitempty"`
 	RequestId interface{} `json:"RequestId,omitempty"`
-	Output    interface{} `json:"Resources,omitempty"`
+	Output    interface{} `json:"items,omitempty"`
 }
 
 var (


### PR DESCRIPTION
Note: resources wrappers should be removed, such that `_links`, `metadata` etc on the top-level is no longer lost