### PR TITLE
fix #261: alb, targetgroup examples

### DIFF
--- a/commands/cloudapi-v6/examples.go
+++ b/commands/cloudapi-v6/examples.go
@@ -350,8 +350,8 @@ ionosctl natgateway lan add --datacenter-id DATACENTER_ID --natgateway-id NATGAT
 		Network Load Balancer ForwardingRule Target Example
 	*/
 	listNetworkLoadBalancerRuleTargetExample   = `ionosctl networkloadbalancer rule target list --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID`
-	addNetworkLoadBalancerRuleTargetExample    = `ionosctl networkloadbalancer rule target add --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --target-ip TARGET_IP --target-port TARGET_PORT -w`
-	removeNetworkLoadBalancerRuleTargetExample = `ionosctl nlb rule target remove --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --target-ip TARGET_IP --target-port TARGET_PORT -w`
+	addNetworkLoadBalancerRuleTargetExample    = `ionosctl networkloadbalancer rule target add --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --ip TARGET_IP --port TARGET_PORT`
+	removeNetworkLoadBalancerRuleTargetExample = `ionosctl nlb rule target remove --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --ip TARGET_IP --port TARGET_PORT`
 
 	/*
 		Target Group Example
@@ -363,8 +363,8 @@ ionosctl natgateway lan add --datacenter-id DATACENTER_ID --natgateway-id NATGAT
 	deleteTargetGroupExample = `ionosctl targetgroup delete --targetgroup-id TARGET_GROUP_ID --force`
 
 	listTargetGroupTargetExample   = `ionosctl targetgroup target list --targetgroup-id TARGET_GROUP_ID`
-	addTargetGroupTargetExample    = `ionosctl targetgroup target add --targetgroup-id TARGET_GROUP_ID --target-ip TARGET_IP --target-port TARGET_PORT`
-	removeTargetGroupTargetExample = `ionosctl targetgroup target remove --targetgroup-id TARGET_GROUP_ID --target-ip TARGET_IP --target-port TARGET_PORT`
+	addTargetGroupTargetExample    = `ionosctl targetgroup target add --targetgroup-id TARGET_GROUP_ID --ip TARGET_IP --port TARGET_PORT`
+	removeTargetGroupTargetExample = `ionosctl targetgroup target remove --targetgroup-id TARGET_GROUP_ID --ip TARGET_IP --port TARGET_PORT`
 
 	/*
 		Application Load Balancer Example
@@ -396,7 +396,7 @@ ionosctl natgateway lan add --datacenter-id DATACENTER_ID --natgateway-id NATGAT
 	*/
 	listApplicationLoadBalancerFlowLogExample   = `ionosctl applicationloadbalancer flowlog list --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID`
 	getApplicationLoadBalancerFlowLogExample    = `ionosctl applicationloadbalancer flowlog get --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID -i FLOWLOG_ID`
-	createApplicationLoadBalancerFlowLogExample = `ionosctl applicationloadbalancer flowlog create --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID --action ACTION --name NAME --direction DIRECTION --bucket-name BUCKET_NAME`
+	createApplicationLoadBalancerFlowLogExample = `ionosctl applicationloadbalancer flowlog create --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID --action ACTION --name NAME --direction DIRECTION --s3bucket BUCKET_NAME`
 	updateApplicationLoadBalancerFlowLogExample = `ionosctl applicationloadbalancer flowlog update --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID -i FLOWLOG_ID --name NAME`
 	deleteApplicationLoadBalancerFlowLogExample = `ionosctl applicationloadbalancer flowlog delete --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID -i FLOWLOG_ID`
 )

--- a/docs/subcommands/application-load-balancer/applicationloadbalancer-flowlog-create.md
+++ b/docs/subcommands/application-load-balancer/applicationloadbalancer-flowlog-create.md
@@ -68,6 +68,6 @@ Required values to run command:
 ## Examples
 
 ```text
-ionosctl applicationloadbalancer flowlog create --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID --action ACTION --name NAME --direction DIRECTION --bucket-name BUCKET_NAME
+ionosctl applicationloadbalancer flowlog create --datacenter-id DATACENTER_ID --applicationloadbalancer-id APPLICATIONLOADBALANCER_ID --action ACTION --name NAME --direction DIRECTION --s3bucket BUCKET_NAME
 ```
 

--- a/docs/subcommands/application-load-balancer/targetgroup-target-add.md
+++ b/docs/subcommands/application-load-balancer/targetgroup-target-add.md
@@ -69,6 +69,6 @@ Required values to run command:
 ## Examples
 
 ```text
-ionosctl targetgroup target add --targetgroup-id TARGET_GROUP_ID --target-ip TARGET_IP --target-port TARGET_PORT
+ionosctl targetgroup target add --targetgroup-id TARGET_GROUP_ID --ip TARGET_IP --port TARGET_PORT
 ```
 

--- a/docs/subcommands/application-load-balancer/targetgroup-target-remove.md
+++ b/docs/subcommands/application-load-balancer/targetgroup-target-remove.md
@@ -63,6 +63,6 @@ Required values to run command:
 ## Examples
 
 ```text
-ionosctl targetgroup target remove --targetgroup-id TARGET_GROUP_ID --target-ip TARGET_IP --target-port TARGET_PORT
+ionosctl targetgroup target remove --targetgroup-id TARGET_GROUP_ID --ip TARGET_IP --port TARGET_PORT
 ```
 

--- a/docs/subcommands/compute-engine/container-registry-registry-create.md
+++ b/docs/subcommands/compute-engine/container-registry-registry-create.md
@@ -43,7 +43,7 @@ Create a registry to hold container images or OCI compliant artifacts
   -c, --config string                              Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                                      Force command to execute without user input
       --garbage-collection-schedule-days strings   Specify the garbage collection schedule days
-      --garbage-collection-schedule-time string    Specify the garbage collection schedule time of day
+      --garbage-collection-schedule-time string    Specify the garbage collection schedule time of day using RFC3339 format
   -h, --help                                       Print usage
       --location string                            Specify the location of the registry (required)
   -n, --name string                                Specify the name of the registry (required)

--- a/docs/subcommands/compute-engine/container-registry-repository.md
+++ b/docs/subcommands/compute-engine/container-registry-repository.md
@@ -21,7 +21,7 @@ For `container-registry` command:
 For `repository` command:
 
 ```text
-[rd del repo rep-del]
+[rd del repo rep-del repository-delete]
 ```
 
 ## Description
@@ -46,6 +46,6 @@ Delete all repository contents. The registry V2 API allows manifests and blobs t
 ## Examples
 
 ```text
-ionosctl container-registry locations
+ionosctl container-registry repository-delete --registry-id [REGISTRY-ID], --name [REPOSITORY-NAME]
 ```
 

--- a/docs/subcommands/compute-engine/image-upload.md
+++ b/docs/subcommands/compute-engine/image-upload.md
@@ -55,7 +55,7 @@ Required values to run command:
   -i, --image strings            Slice of paths to images, can be absolute path or relative to current working directory (required)
   -a, --image-alias strings      Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path
       --licence-type string      The OS type of this image. Can be one of: UNKNOWN, WINDOWS, WINDOWS2016, WINDOWS2022, LINUX, OTHER (default "UNKNOWN")
-  -l, --location strings         Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit (required) (default [fra])
+  -l, --location strings         Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit (required)
   -n, --name string              Name of the Image
       --nic-hot-plug             'Hot-Plug' NIC (default true)
       --nic-hot-unplug           'Hot-Unplug' NIC

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-add.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-add.md
@@ -75,6 +75,6 @@ Required values to run command:
 ## Examples
 
 ```text
-ionosctl networkloadbalancer rule target add --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --target-ip TARGET_IP --target-port TARGET_PORT -w
+ionosctl networkloadbalancer rule target add --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --ip TARGET_IP --port TARGET_PORT
 ```
 

--- a/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-remove.md
+++ b/docs/subcommands/networkloadbalancer/networkloadbalancer-rule-target-remove.md
@@ -70,6 +70,6 @@ Required values to run command:
 ## Examples
 
 ```text
-ionosctl nlb rule target remove --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --target-ip TARGET_IP --target-port TARGET_PORT -w
+ionosctl nlb rule target remove --datacenter-id DATACENTER_ID --networkloadbalancer-id NETWORKLOADBALANCER_ID --rule-id FORWARDINGRULE_ID --ip TARGET_IP --port TARGET_PORT
 ```
 


### PR DESCRIPTION
Some flags were wrong, possibly renamed after the example was written.

Most of our examples are non-docopt compliant, and maintaining them is unfeasible. We need to generate these automatically at some point.

#261 