### PR TITLE
feat: add ability to print all cols

### DIFF
--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/fatih/structs"
@@ -13,7 +12,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	authv1 "github.com/ionos-cloud/ionosctl/v6/services/auth-v1"
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
@@ -300,36 +298,10 @@ func getTokenPrint(c *core.CommandConfig, dcs []resources.Token) printer.Result 
 		if dcs != nil {
 			r.OutputJSON = dcs
 			r.KeyValue = getTokensKVMaps(dcs)
-			r.Columns = getTokenCols(core.GetFlagName(c.Resource, constants.ArgCols), c.Printer.GetStderr())
+			r.Columns = printer.GetHeadersAllDefault(allTokenCols, viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols)))
 		}
 	}
 	return r
-}
-
-func getTokenCols(flagName string, outErr io.Writer) []string {
-	var cols []string
-	if viper.IsSet(flagName) {
-		cols = viper.GetStringSlice(flagName)
-	} else {
-		return defaultTokenCols
-	}
-
-	columnsMap := map[string]string{
-		"TokenId":        "TokenId",
-		"CreatedDate":    "CreatedDate",
-		"ExpirationDate": "ExpirationDate",
-		"Href":           "Href",
-	}
-	var tokenCols []string
-	for _, k := range cols {
-		col := columnsMap[k]
-		if col != "" {
-			tokenCols = append(tokenCols, col)
-		} else {
-			clierror.CheckError(errors.New("unknown column "+k), outErr)
-		}
-	}
-	return tokenCols
 }
 
 func getTokens(tokens resources.Tokens) []resources.Token {

--- a/commands/auth-v1/token.go
+++ b/commands/auth-v1/token.go
@@ -30,7 +30,7 @@ func TokenCmd() *core.Command {
 		},
 	}
 	globalFlags := tokenCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultTokenCols, printer.ColsMessage(allTokenCols))
+	globalFlags.StringSliceP(constants.ArgCols, "", nil, printer.ColsMessage(allTokenCols))
 	_ = viper.BindPFlag(core.GetFlagName(tokenCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
 	_ = tokenCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allTokenCols, cobra.ShellCompDirectiveNoFileComp

--- a/commands/auth-v1/token_test.go
+++ b/commands/auth-v1/token_test.go
@@ -5,12 +5,10 @@ import (
 	"bytes"
 	"errors"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	authv1 "github.com/ionos-cloud/ionosctl/v6/services/auth-v1"
 	"github.com/ionos-cloud/ionosctl/v6/services/auth-v1/resources"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
@@ -574,28 +572,4 @@ func TestRunTokenDeleteAllAskForConfirmErr(t *testing.T) {
 		err := RunTokenDeleteAll(cfg)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetTokensCols(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() { return }
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("token", constants.ArgCols), []string{"ExpirationDate"})
-	getTokenCols(core.GetFlagName("token", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-}
-
-func TestGetTokensColsErr(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() { return }
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("token", constants.ArgCols), []string{"Unknown"})
-	getTokenCols(core.GetFlagName("token", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-	re := regexp.MustCompile(`unknown column Unknown`)
-	assert.True(t, re.Match(b.Bytes()))
 }

--- a/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/utils"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	cloudapiv6 "github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -532,41 +530,10 @@ func getAlbRuleHttpRulePrint(resp *resources.Response, c *core.CommandConfig, ss
 		if ss != nil {
 			r.OutputJSON = ss
 			r.KeyValue = getAlbRuleHttpRulesKVMaps(ss)
-			r.Columns = getAlbRuleHttpRulesCols(core.GetFlagName(c.Resource, constants.ArgCols), c.Printer.GetStderr())
+			r.Columns = printer.GetHeaders(allAlbRuleHttpRuleCols, defaultAlbRuleHttpRuleCols, viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols)))
 		}
 	}
 	return r
-}
-
-func getAlbRuleHttpRulesCols(flagName string, outErr io.Writer) []string {
-	var cols []string
-	if viper.IsSet(flagName) {
-		cols = viper.GetStringSlice(flagName)
-	} else {
-		return defaultAlbRuleHttpRuleCols
-	}
-
-	columnsMap := map[string]string{
-		"Name":            "Name",
-		"Type":            "Type",
-		"TargetGroupId":   "TargetGroupId",
-		"DropQuery":       "DropQuery",
-		"Location":        "Location",
-		"StatusCode":      "StatusCode",
-		"ResponseMessage": "ResponseMessage",
-		"ContentType":     "ContentType",
-		"Condition":       "Condition",
-	}
-	var ruleHttpRuleCols []string
-	for _, k := range cols {
-		col := columnsMap[k]
-		if col != "" {
-			ruleHttpRuleCols = append(ruleHttpRuleCols, col)
-		} else {
-			clierror.CheckError(errors.New("unknown column "+k), outErr)
-		}
-	}
-	return ruleHttpRuleCols
 }
 
 func getAlbRuleHttpRules(httprules *[]ionoscloud.ApplicationLoadBalancerHttpRule) []resources.ApplicationLoadBalancerHttpRule {

--- a/commands/cloudapi-v6/applicationloadbalancer_rule_httprule_test.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_httprule_test.go
@@ -5,14 +5,12 @@ import (
 	"bytes"
 	"errors"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	cloudapiv6 "github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -629,28 +627,4 @@ func TestRunAlbRuleHttpRuleRemoveAskForConfirmErr(t *testing.T) {
 		err := RunAlbRuleHttpRuleRemove(cfg)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetAlbRuleHttpRulesCols(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() {}
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("httprule", constants.ArgCols), []string{"Name"})
-	getAlbRuleHttpRulesCols(core.GetFlagName("httprule", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-}
-
-func TestGetAlbRuleColsErr(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() {}
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("httprule", constants.ArgCols), []string{"Unknown"})
-	getAlbRuleHttpRulesCols(core.GetFlagName("httprule", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-	re := regexp.MustCompile(`unknown column Unknown`)
-	assert.True(t, re.Match(b.Bytes()))
 }

--- a/commands/cloudapi-v6/contract_test.go
+++ b/commands/cloudapi-v6/contract_test.go
@@ -4,14 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"regexp"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/utils/clierror"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/spf13/viper"
@@ -99,28 +97,4 @@ func TestRunContractGetErr(t *testing.T) {
 		err := RunContractGet(cfg)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetContractsCols(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() { return }
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("contract", constants.ArgCols), []string{"ContractNumber"})
-	getContractCols(core.GetFlagName("contract", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-}
-
-func TestGetContractsColsErr(t *testing.T) {
-	defer func(a func()) { clierror.ErrAction = a }(clierror.ErrAction)
-	var b bytes.Buffer
-	clierror.ErrAction = func() { return }
-	w := bufio.NewWriter(&b)
-	viper.Set(core.GetFlagName("contract", constants.ArgCols), []string{"Unknown"})
-	getContractCols(core.GetFlagName("contract", constants.ArgCols), w)
-	err := w.Flush()
-	assert.NoError(t, err)
-	re := regexp.MustCompile(`unknown column Unknown`)
-	assert.True(t, re.Match(b.Bytes()))
 }

--- a/docs/subcommands/Authentication/token.md
+++ b/docs/subcommands/Authentication/token.md
@@ -32,7 +32,7 @@ Required values to run command:
   -A, --all               Delete the Tokens under your account (required)
   -u, --api-url string    Override default host url (default "https://api.ionos.com")
       --cols strings      Set of columns to be printed on output 
-                          Available columns: [TokenId CreatedDate ExpirationDate Href] (default [TokenId,CreatedDate,ExpirationDate])
+                          Available columns: [TokenId CreatedDate ExpirationDate Href]
   -c, --config string     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
       --contract int      Users with multiple contracts must provide the contract number, for which the tokens are deleted
   -C, --current           Delete the Token that is currently used. This requires a token to be set for authentication via environment variable IONOS_TOKEN or via config file (required)

--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -43,7 +43,7 @@ func GetHeadersAllDefault(allColumns []string, customColumns []string) []string 
 // returns the headers of the table. (Some legacy code might refer to these headers as "Columns")
 // allColumns can be found by using structs.Names on a Print struct (i.e. structs.Names(DatacenterPrint{}))
 func GetHeaders(allColumns []string, defaultColumns []string, customColumns []string) []string {
-	if customColumns[0] == "all" {
+	if len(customColumns) > 0 && customColumns[0] == "all" {
 		return GetHeaders(allColumns, defaultColumns, allColumns)
 	}
 

--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -43,6 +43,10 @@ func GetHeadersAllDefault(allColumns []string, customColumns []string) []string 
 // returns the headers of the table. (Some legacy code might refer to these headers as "Columns")
 // allColumns can be found by using structs.Names on a Print struct (i.e. structs.Names(DatacenterPrint{}))
 func GetHeaders(allColumns []string, defaultColumns []string, customColumns []string) []string {
+	if customColumns[0] == "all" {
+		return GetHeaders(allColumns, defaultColumns, allColumns)
+	}
+
 	if customColumns == nil {
 		return defaultColumns
 	}


### PR DESCRIPTION
Add ability to print all columns using `all`, eg `ionosctl dc ls --cols all`

refactored: some resources weren't using `printer.GetHeaders` and were still tightly coupled to their own column making func