### PR TITLE
fix #289: ionosctl k8s np lan add using only last network

### DIFF
--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ionos-cloud/ionosctl/v6/internal/pointer"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/die"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/query"
@@ -352,7 +354,7 @@ func getNewK8sNodePoolLanInfo(c *core.CommandConfig, oldNg *resources.K8sNodePoo
 				for i, net := range network {
 					routes = append(routes,
 						ionoscloud.KubernetesNodePoolLanRoutes{
-							Network:   &net,
+							Network:   pointer.From(net), // Copy the loop variable and take its address. See #289 - always same address would be used
 							GatewayIp: &gatewayIp[i],
 						},
 					)

--- a/commands/dataplatform/cluster/kubeconfig.go
+++ b/commands/dataplatform/cluster/kubeconfig.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dataplatform/completer"

--- a/commands/dataplatform/cluster/update.go
+++ b/commands/dataplatform/cluster/update.go
@@ -2,8 +2,9 @@ package cluster
 
 import (
 	"context"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"os"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
 	"github.com/cilium/fake"
 	cloudapiv6completer "github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"


### PR DESCRIPTION
Copy the address of the loop variable before assigning it

Before:
```
 % ionosctl k8s np lan add ... --network 80.120.160.240/24,40.80.120.160/24 --gateway-ip 1.2.3.4,1.2.3.6 --lan-id 4 
LanId   Dhcp   RoutesNetwork                       RoutesGatewayIp
4       true   40.80.120.160/24,40.80.120.160/24   1.2.3.4,1.2.3.6
```

After:
```
 % ionosctl k8s np lan add ...
LanId   Dhcp   RoutesNetwork                        RoutesGatewayIp
1       true   80.120.160.240/24,40.80.120.160/24   1.2.3.4,1.2.3.6
```