### PR TITLE
test: Fix dataplatform tests

### DIFF
--- a/commands/dataplatform/dataplatform_integration_test.go
+++ b/commands/dataplatform/dataplatform_integration_test.go
@@ -38,6 +38,7 @@ func TestDataplatformCmd(t *testing.T) {
 	}
 	t.Cleanup(teardown)
 	testClusterOk(t)
+	testNodepoolOk(t)
 }
 
 func testClusterOk(t *testing.T) {
@@ -132,7 +133,7 @@ func teardown() {
 		fmt.Printf("failed deleting cluster: %v\n", err)
 	}
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	_, err = client.Must().CloudClient.DataCentersApi.DatacentersDelete(context.Background(), createdDcId).Execute()
 	if err != nil {


### PR DESCRIPTION
fixes various issues with the dataplatform tests

- Add a missing call for nodepool test
- Add missing check for setup error
- Remove a debug print 
- Add more explicit messages in case of failed asserts
- Increase sleep time for test teardown