### PR TITLE
doc: front matter quotes

### DIFF
--- a/docs/subcommands/Application-Load-Balancer/create.md
+++ b/docs/subcommands/Application-Load-Balancer/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create an Application Load Balancer
+description: "Create an Application Load Balancer"
 ---
 
 # ApplicationloadbalancerCreate

--- a/docs/subcommands/Application-Load-Balancer/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete an Application Load Balancer
+description: "Delete an Application Load Balancer"
 ---
 
 # ApplicationloadbalancerDelete

--- a/docs/subcommands/Application-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create an Application Load Balancer FlowLog
+description: "Create an Application Load Balancer FlowLog"
 ---
 
 # ApplicationloadbalancerFlowlogCreate

--- a/docs/subcommands/Application-Load-Balancer/flowlog/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete an Application Load Balancer FlowLog
+description: "Delete an Application Load Balancer FlowLog"
 ---
 
 # ApplicationloadbalancerFlowlogDelete

--- a/docs/subcommands/Application-Load-Balancer/flowlog/get.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get an Application Load Balancer FlowLog
+description: "Get an Application Load Balancer FlowLog"
 ---
 
 # ApplicationloadbalancerFlowlogGet

--- a/docs/subcommands/Application-Load-Balancer/flowlog/list.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Application Load Balancer FlowLogs
+description: "List Application Load Balancer FlowLogs"
 ---
 
 # ApplicationloadbalancerFlowlogList

--- a/docs/subcommands/Application-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update an Application Load Balancer FlowLog
+description: "Update an Application Load Balancer FlowLog"
 ---
 
 # ApplicationloadbalancerFlowlogUpdate

--- a/docs/subcommands/Application-Load-Balancer/get.md
+++ b/docs/subcommands/Application-Load-Balancer/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get an Application Load Balancer
+description: "Get an Application Load Balancer"
 ---
 
 # ApplicationloadbalancerGet

--- a/docs/subcommands/Application-Load-Balancer/list.md
+++ b/docs/subcommands/Application-Load-Balancer/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Application Load Balancers
+description: "List Application Load Balancers"
 ---
 
 # ApplicationloadbalancerList

--- a/docs/subcommands/Application-Load-Balancer/rule/create.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Application Load Balancer Forwarding Rule
+description: "Create a Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleCreate

--- a/docs/subcommands/Application-Load-Balancer/rule/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Application Load Balancer Forwarding Rule
+description: "Delete a Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleDelete

--- a/docs/subcommands/Application-Load-Balancer/rule/get.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Application Load Balancer Forwarding Rule
+description: "Get a Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleGet

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/add.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a Http Rule to Application Load Balancer Forwarding Rule
+description: "Add a Http Rule to Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleHttpruleAdd

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/list.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Application Load Balancer Forwarding Rule Http Rules
+description: "List Application Load Balancer Forwarding Rule Http Rules"
 ---
 
 # ApplicationloadbalancerRuleHttpruleList

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/remove.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a Http Rule from a Application Load Balancer Forwarding Rule
+description: "Remove a Http Rule from a Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleHttpruleRemove

--- a/docs/subcommands/Application-Load-Balancer/rule/list.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Application Load Balancer Forwarding Rules
+description: "List Application Load Balancer Forwarding Rules"
 ---
 
 # ApplicationloadbalancerRuleList

--- a/docs/subcommands/Application-Load-Balancer/rule/update.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Application Load Balancer Forwarding Rule
+description: "Update a Application Load Balancer Forwarding Rule"
 ---
 
 # ApplicationloadbalancerRuleUpdate

--- a/docs/subcommands/Application-Load-Balancer/update.md
+++ b/docs/subcommands/Application-Load-Balancer/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update an Application Load Balancer
+description: "Update an Application Load Balancer"
 ---
 
 # ApplicationloadbalancerUpdate

--- a/docs/subcommands/Authentication/token/delete.md
+++ b/docs/subcommands/Authentication/token/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete one or multiple Tokens
+description: "Delete one or multiple Tokens"
 ---
 
 # TokenDelete

--- a/docs/subcommands/Authentication/token/generate.md
+++ b/docs/subcommands/Authentication/token/generate.md
@@ -1,5 +1,5 @@
 ---
-description: Create a new Token
+description: "Create a new Token"
 ---
 
 # TokenGenerate

--- a/docs/subcommands/Authentication/token/get.md
+++ b/docs/subcommands/Authentication/token/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a specified Token
+description: "Get a specified Token"
 ---
 
 # TokenGet

--- a/docs/subcommands/Authentication/token/list.md
+++ b/docs/subcommands/Authentication/token/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Tokens
+description: "List Tokens"
 ---
 
 # TokenList

--- a/docs/subcommands/CLI Setup/login.md
+++ b/docs/subcommands/CLI Setup/login.md
@@ -1,5 +1,5 @@
 ---
-description: Authentication command for SDK
+description: "Authentication command for SDK"
 ---
 
 # Login

--- a/docs/subcommands/CLI Setup/version.md
+++ b/docs/subcommands/CLI Setup/version.md
@@ -1,5 +1,5 @@
 ---
-description: Show the current version
+description: "Show the current version"
 ---
 
 # Version

--- a/docs/subcommands/Certificate-Manager/add.md
+++ b/docs/subcommands/Certificate-Manager/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a new Certificate
+description: "Add a new Certificate"
 ---
 
 # CertificateManagerAdd

--- a/docs/subcommands/Certificate-Manager/api/version.md
+++ b/docs/subcommands/Certificate-Manager/api/version.md
@@ -1,5 +1,5 @@
 ---
-description: Get Certificate Manager API Version
+description: "Get Certificate Manager API Version"
 ---
 
 # CertificateManagerApiVersion

--- a/docs/subcommands/Certificate-Manager/delete.md
+++ b/docs/subcommands/Certificate-Manager/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete Certificate by ID or all Certificates
+description: "Delete Certificate by ID or all Certificates"
 ---
 
 # CertificateManagerDelete

--- a/docs/subcommands/Certificate-Manager/get.md
+++ b/docs/subcommands/Certificate-Manager/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get Certificate by ID
+description: "Get Certificate by ID"
 ---
 
 # CertificateManagerGet

--- a/docs/subcommands/Certificate-Manager/list.md
+++ b/docs/subcommands/Certificate-Manager/list.md
@@ -1,5 +1,5 @@
 ---
-description: List all Certificates
+description: "List all Certificates"
 ---
 
 # CertificateManagerList

--- a/docs/subcommands/Certificate-Manager/update.md
+++ b/docs/subcommands/Certificate-Manager/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update Certificate name
+description: "Update Certificate name"
 ---
 
 # CertificateManagerUpdate

--- a/docs/subcommands/Compute Engine/contract/get.md
+++ b/docs/subcommands/Compute Engine/contract/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get information about the Contract Resources on your account
+description: "Get information about the Contract Resources on your account"
 ---
 
 # ContractGet

--- a/docs/subcommands/Compute Engine/datacenter/create.md
+++ b/docs/subcommands/Compute Engine/datacenter/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Data Center
+description: "Create a Data Center"
 ---
 
 # DatacenterCreate

--- a/docs/subcommands/Compute Engine/datacenter/delete.md
+++ b/docs/subcommands/Compute Engine/datacenter/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Data Center
+description: "Delete a Data Center"
 ---
 
 # DatacenterDelete

--- a/docs/subcommands/Compute Engine/datacenter/get.md
+++ b/docs/subcommands/Compute Engine/datacenter/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Data Center
+description: "Get a Data Center"
 ---
 
 # DatacenterGet

--- a/docs/subcommands/Compute Engine/datacenter/list.md
+++ b/docs/subcommands/Compute Engine/datacenter/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Data Centers
+description: "List Data Centers"
 ---
 
 # DatacenterList

--- a/docs/subcommands/Compute Engine/datacenter/update.md
+++ b/docs/subcommands/Compute Engine/datacenter/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Data Center
+description: "Update a Data Center"
 ---
 
 # DatacenterUpdate

--- a/docs/subcommands/Compute Engine/firewallrule/create.md
+++ b/docs/subcommands/Compute Engine/firewallrule/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Firewall Rule
+description: "Create a Firewall Rule"
 ---
 
 # FirewallruleCreate

--- a/docs/subcommands/Compute Engine/firewallrule/delete.md
+++ b/docs/subcommands/Compute Engine/firewallrule/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a FirewallRule
+description: "Delete a FirewallRule"
 ---
 
 # FirewallruleDelete

--- a/docs/subcommands/Compute Engine/firewallrule/get.md
+++ b/docs/subcommands/Compute Engine/firewallrule/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Firewall Rule
+description: "Get a Firewall Rule"
 ---
 
 # FirewallruleGet

--- a/docs/subcommands/Compute Engine/firewallrule/list.md
+++ b/docs/subcommands/Compute Engine/firewallrule/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Firewall Rules
+description: "List Firewall Rules"
 ---
 
 # FirewallruleList

--- a/docs/subcommands/Compute Engine/firewallrule/update.md
+++ b/docs/subcommands/Compute Engine/firewallrule/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a FirewallRule
+description: "Update a FirewallRule"
 ---
 
 # FirewallruleUpdate

--- a/docs/subcommands/Compute Engine/flowlog/create.md
+++ b/docs/subcommands/Compute Engine/flowlog/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a FlowLog on a NIC
+description: "Create a FlowLog on a NIC"
 ---
 
 # FlowlogCreate

--- a/docs/subcommands/Compute Engine/flowlog/delete.md
+++ b/docs/subcommands/Compute Engine/flowlog/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a FlowLog from a NIC
+description: "Delete a FlowLog from a NIC"
 ---
 
 # FlowlogDelete

--- a/docs/subcommands/Compute Engine/flowlog/get.md
+++ b/docs/subcommands/Compute Engine/flowlog/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a FlowLog
+description: "Get a FlowLog"
 ---
 
 # FlowlogGet

--- a/docs/subcommands/Compute Engine/flowlog/list.md
+++ b/docs/subcommands/Compute Engine/flowlog/list.md
@@ -1,5 +1,5 @@
 ---
-description: List FlowLogs
+description: "List FlowLogs"
 ---
 
 # FlowlogList

--- a/docs/subcommands/Compute Engine/group/create.md
+++ b/docs/subcommands/Compute Engine/group/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Group
+description: "Create a Group"
 ---
 
 # GroupCreate

--- a/docs/subcommands/Compute Engine/group/delete.md
+++ b/docs/subcommands/Compute Engine/group/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Group
+description: "Delete a Group"
 ---
 
 # GroupDelete

--- a/docs/subcommands/Compute Engine/group/get.md
+++ b/docs/subcommands/Compute Engine/group/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Group
+description: "Get a Group"
 ---
 
 # GroupGet

--- a/docs/subcommands/Compute Engine/group/list.md
+++ b/docs/subcommands/Compute Engine/group/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Groups
+description: "List Groups"
 ---
 
 # GroupList

--- a/docs/subcommands/Compute Engine/group/resource/list.md
+++ b/docs/subcommands/Compute Engine/group/resource/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Resources from a Group
+description: "List Resources from a Group"
 ---
 
 # GroupResourceList

--- a/docs/subcommands/Compute Engine/group/update.md
+++ b/docs/subcommands/Compute Engine/group/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Group
+description: "Update a Group"
 ---
 
 # GroupUpdate

--- a/docs/subcommands/Compute Engine/group/user/add.md
+++ b/docs/subcommands/Compute Engine/group/user/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add User to a Group
+description: "Add User to a Group"
 ---
 
 # GroupUserAdd

--- a/docs/subcommands/Compute Engine/group/user/list.md
+++ b/docs/subcommands/Compute Engine/group/user/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Users from a Group
+description: "List Users from a Group"
 ---
 
 # GroupUserList

--- a/docs/subcommands/Compute Engine/group/user/remove.md
+++ b/docs/subcommands/Compute Engine/group/user/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove User from a Group
+description: "Remove User from a Group"
 ---
 
 # GroupUserRemove

--- a/docs/subcommands/Compute Engine/image/delete.md
+++ b/docs/subcommands/Compute Engine/image/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete an image
+description: "Delete an image"
 ---
 
 # ImageDelete

--- a/docs/subcommands/Compute Engine/image/get.md
+++ b/docs/subcommands/Compute Engine/image/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a specified Image
+description: "Get a specified Image"
 ---
 
 # ImageGet

--- a/docs/subcommands/Compute Engine/image/list.md
+++ b/docs/subcommands/Compute Engine/image/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Images
+description: "List Images"
 ---
 
 # ImageList

--- a/docs/subcommands/Compute Engine/image/update.md
+++ b/docs/subcommands/Compute Engine/image/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a specified Image
+description: "Update a specified Image"
 ---
 
 # ImageUpdate

--- a/docs/subcommands/Compute Engine/image/upload.md
+++ b/docs/subcommands/Compute Engine/image/upload.md
@@ -1,5 +1,5 @@
 ---
-description: Upload an image to FTP server
+description: "Upload an image to FTP server"
 ---
 
 # ImageUpload

--- a/docs/subcommands/Compute Engine/ipblock/create.md
+++ b/docs/subcommands/Compute Engine/ipblock/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create/Reserve an IpBlock
+description: "Create/Reserve an IpBlock"
 ---
 
 # IpblockCreate

--- a/docs/subcommands/Compute Engine/ipblock/delete.md
+++ b/docs/subcommands/Compute Engine/ipblock/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete an IpBlock
+description: "Delete an IpBlock"
 ---
 
 # IpblockDelete

--- a/docs/subcommands/Compute Engine/ipblock/get.md
+++ b/docs/subcommands/Compute Engine/ipblock/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get an IpBlock
+description: "Get an IpBlock"
 ---
 
 # IpblockGet

--- a/docs/subcommands/Compute Engine/ipblock/list.md
+++ b/docs/subcommands/Compute Engine/ipblock/list.md
@@ -1,5 +1,5 @@
 ---
-description: List IpBlocks
+description: "List IpBlocks"
 ---
 
 # IpblockList

--- a/docs/subcommands/Compute Engine/ipblock/update.md
+++ b/docs/subcommands/Compute Engine/ipblock/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update an IpBlock
+description: "Update an IpBlock"
 ---
 
 # IpblockUpdate

--- a/docs/subcommands/Compute Engine/ipconsumer/list.md
+++ b/docs/subcommands/Compute Engine/ipconsumer/list.md
@@ -1,5 +1,5 @@
 ---
-description: List IpConsumers
+description: "List IpConsumers"
 ---
 
 # IpconsumerList

--- a/docs/subcommands/Compute Engine/ipfailover/add.md
+++ b/docs/subcommands/Compute Engine/ipfailover/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add IP Failover group to a LAN
+description: "Add IP Failover group to a LAN"
 ---
 
 # IpfailoverAdd

--- a/docs/subcommands/Compute Engine/ipfailover/list.md
+++ b/docs/subcommands/Compute Engine/ipfailover/list.md
@@ -1,5 +1,5 @@
 ---
-description: List IP Failovers groups from a LAN
+description: "List IP Failovers groups from a LAN"
 ---
 
 # IpfailoverList

--- a/docs/subcommands/Compute Engine/ipfailover/remove.md
+++ b/docs/subcommands/Compute Engine/ipfailover/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove IP Failover group from a LAN
+description: "Remove IP Failover group from a LAN"
 ---
 
 # IpfailoverRemove

--- a/docs/subcommands/Compute Engine/label/add.md
+++ b/docs/subcommands/Compute Engine/label/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a Label to a Resource
+description: "Add a Label to a Resource"
 ---
 
 # LabelAdd

--- a/docs/subcommands/Compute Engine/label/get.md
+++ b/docs/subcommands/Compute Engine/label/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Label
+description: "Get a Label"
 ---
 
 # LabelGet

--- a/docs/subcommands/Compute Engine/label/get/by/urn.md
+++ b/docs/subcommands/Compute Engine/label/get/by/urn.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Label using URN
+description: "Get a Label using URN"
 ---
 
 # LabelGetByUrn

--- a/docs/subcommands/Compute Engine/label/list.md
+++ b/docs/subcommands/Compute Engine/label/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Labels from Resources
+description: "List Labels from Resources"
 ---
 
 # LabelList

--- a/docs/subcommands/Compute Engine/label/remove.md
+++ b/docs/subcommands/Compute Engine/label/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a Label from a Resource
+description: "Remove a Label from a Resource"
 ---
 
 # LabelRemove

--- a/docs/subcommands/Compute Engine/lan/create.md
+++ b/docs/subcommands/Compute Engine/lan/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a LAN
+description: "Create a LAN"
 ---
 
 # LanCreate

--- a/docs/subcommands/Compute Engine/lan/delete.md
+++ b/docs/subcommands/Compute Engine/lan/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a LAN
+description: "Delete a LAN"
 ---
 
 # LanDelete

--- a/docs/subcommands/Compute Engine/lan/get.md
+++ b/docs/subcommands/Compute Engine/lan/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a LAN
+description: "Get a LAN"
 ---
 
 # LanGet

--- a/docs/subcommands/Compute Engine/lan/list.md
+++ b/docs/subcommands/Compute Engine/lan/list.md
@@ -1,5 +1,5 @@
 ---
-description: List LANs
+description: "List LANs"
 ---
 
 # LanList

--- a/docs/subcommands/Compute Engine/lan/update.md
+++ b/docs/subcommands/Compute Engine/lan/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a LAN
+description: "Update a LAN"
 ---
 
 # LanUpdate

--- a/docs/subcommands/Compute Engine/loadbalancer/create.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Load Balancer
+description: "Create a Load Balancer"
 ---
 
 # LoadbalancerCreate

--- a/docs/subcommands/Compute Engine/loadbalancer/delete.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Load Balancer
+description: "Delete a Load Balancer"
 ---
 
 # LoadbalancerDelete

--- a/docs/subcommands/Compute Engine/loadbalancer/get.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Load Balancer
+description: "Get a Load Balancer"
 ---
 
 # LoadbalancerGet

--- a/docs/subcommands/Compute Engine/loadbalancer/list.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Load Balancers
+description: "List Load Balancers"
 ---
 
 # LoadbalancerList

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/attach.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/attach.md
@@ -1,5 +1,5 @@
 ---
-description: Attach a NIC to a Load Balancer
+description: "Attach a NIC to a Load Balancer"
 ---
 
 # LoadbalancerNicAttach

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/detach.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/detach.md
@@ -1,5 +1,5 @@
 ---
-description: Detach a NIC from a Load Balancer
+description: "Detach a NIC from a Load Balancer"
 ---
 
 # LoadbalancerNicDetach

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/get.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get an attached NIC to a Load Balancer
+description: "Get an attached NIC to a Load Balancer"
 ---
 
 # LoadbalancerNicGet

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/list.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/list.md
@@ -1,5 +1,5 @@
 ---
-description: List attached NICs from a Load Balancer
+description: "List attached NICs from a Load Balancer"
 ---
 
 # LoadbalancerNicList

--- a/docs/subcommands/Compute Engine/loadbalancer/update.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Load Balancer
+description: "Update a Load Balancer"
 ---
 
 # LoadbalancerUpdate

--- a/docs/subcommands/Compute Engine/location/cpu/list.md
+++ b/docs/subcommands/Compute Engine/location/cpu/list.md
@@ -1,5 +1,5 @@
 ---
-description: List available CPU Architecture from a Location
+description: "List available CPU Architecture from a Location"
 ---
 
 # LocationCpuList

--- a/docs/subcommands/Compute Engine/location/get.md
+++ b/docs/subcommands/Compute Engine/location/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Location
+description: "Get a Location"
 ---
 
 # LocationGet

--- a/docs/subcommands/Compute Engine/location/list.md
+++ b/docs/subcommands/Compute Engine/location/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Locations
+description: "List Locations"
 ---
 
 # LocationList

--- a/docs/subcommands/Compute Engine/nic/create.md
+++ b/docs/subcommands/Compute Engine/nic/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a NIC
+description: "Create a NIC"
 ---
 
 # NicCreate

--- a/docs/subcommands/Compute Engine/nic/delete.md
+++ b/docs/subcommands/Compute Engine/nic/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a NIC
+description: "Delete a NIC"
 ---
 
 # NicDelete

--- a/docs/subcommands/Compute Engine/nic/get.md
+++ b/docs/subcommands/Compute Engine/nic/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a NIC
+description: "Get a NIC"
 ---
 
 # NicGet

--- a/docs/subcommands/Compute Engine/nic/list.md
+++ b/docs/subcommands/Compute Engine/nic/list.md
@@ -1,5 +1,5 @@
 ---
-description: List NICs
+description: "List NICs"
 ---
 
 # NicList

--- a/docs/subcommands/Compute Engine/nic/update.md
+++ b/docs/subcommands/Compute Engine/nic/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a NIC
+description: "Update a NIC"
 ---
 
 # NicUpdate

--- a/docs/subcommands/Compute Engine/pcc/create.md
+++ b/docs/subcommands/Compute Engine/pcc/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Private Cross-Connect
+description: "Create a Private Cross-Connect"
 ---
 
 # PccCreate

--- a/docs/subcommands/Compute Engine/pcc/delete.md
+++ b/docs/subcommands/Compute Engine/pcc/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Private Cross-Connect
+description: "Delete a Private Cross-Connect"
 ---
 
 # PccDelete

--- a/docs/subcommands/Compute Engine/pcc/get.md
+++ b/docs/subcommands/Compute Engine/pcc/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Private Cross-Connect
+description: "Get a Private Cross-Connect"
 ---
 
 # PccGet

--- a/docs/subcommands/Compute Engine/pcc/list.md
+++ b/docs/subcommands/Compute Engine/pcc/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Private Cross-Connects
+description: "List Private Cross-Connects"
 ---
 
 # PccList

--- a/docs/subcommands/Compute Engine/pcc/peers/list.md
+++ b/docs/subcommands/Compute Engine/pcc/peers/list.md
@@ -1,5 +1,5 @@
 ---
-description: Get a list of Peers from a Private Cross-Connect
+description: "Get a list of Peers from a Private Cross-Connect"
 ---
 
 # PccPeersList

--- a/docs/subcommands/Compute Engine/pcc/update.md
+++ b/docs/subcommands/Compute Engine/pcc/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Private Cross-Connect
+description: "Update a Private Cross-Connect"
 ---
 
 # PccUpdate

--- a/docs/subcommands/Compute Engine/request/get.md
+++ b/docs/subcommands/Compute Engine/request/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Request
+description: "Get a Request"
 ---
 
 # RequestGet

--- a/docs/subcommands/Compute Engine/request/list.md
+++ b/docs/subcommands/Compute Engine/request/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Requests
+description: "List Requests"
 ---
 
 # RequestList

--- a/docs/subcommands/Compute Engine/request/wait.md
+++ b/docs/subcommands/Compute Engine/request/wait.md
@@ -1,5 +1,5 @@
 ---
-description: Wait a Request
+description: "Wait a Request"
 ---
 
 # RequestWait

--- a/docs/subcommands/Compute Engine/resource/get.md
+++ b/docs/subcommands/Compute Engine/resource/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get all Resources of a Type or a specific Resource Type
+description: "Get all Resources of a Type or a specific Resource Type"
 ---
 
 # ResourceGet

--- a/docs/subcommands/Compute Engine/resource/list.md
+++ b/docs/subcommands/Compute Engine/resource/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Resources
+description: "List Resources"
 ---
 
 # ResourceList

--- a/docs/subcommands/Compute Engine/server/cdrom/attach.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/attach.md
@@ -1,5 +1,5 @@
 ---
-description: Attach a CD-ROM to a Server
+description: "Attach a CD-ROM to a Server"
 ---
 
 # ServerCdromAttach

--- a/docs/subcommands/Compute Engine/server/cdrom/detach.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/detach.md
@@ -1,5 +1,5 @@
 ---
-description: Detach a CD-ROM from a Server
+description: "Detach a CD-ROM from a Server"
 ---
 
 # ServerCdromDetach

--- a/docs/subcommands/Compute Engine/server/cdrom/get.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a specific attached CD-ROM from a Server
+description: "Get a specific attached CD-ROM from a Server"
 ---
 
 # ServerCdromGet

--- a/docs/subcommands/Compute Engine/server/cdrom/list.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/list.md
@@ -1,5 +1,5 @@
 ---
-description: List attached CD-ROMs from a Server
+description: "List attached CD-ROMs from a Server"
 ---
 
 # ServerCdromList

--- a/docs/subcommands/Compute Engine/server/console/get.md
+++ b/docs/subcommands/Compute Engine/server/console/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get the Remote Console URL to access a Server
+description: "Get the Remote Console URL to access a Server"
 ---
 
 # ServerConsoleGet

--- a/docs/subcommands/Compute Engine/server/create.md
+++ b/docs/subcommands/Compute Engine/server/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Server
+description: "Create a Server"
 ---
 
 # ServerCreate

--- a/docs/subcommands/Compute Engine/server/delete.md
+++ b/docs/subcommands/Compute Engine/server/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Server
+description: "Delete a Server"
 ---
 
 # ServerDelete

--- a/docs/subcommands/Compute Engine/server/get.md
+++ b/docs/subcommands/Compute Engine/server/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Server
+description: "Get a Server"
 ---
 
 # ServerGet

--- a/docs/subcommands/Compute Engine/server/list.md
+++ b/docs/subcommands/Compute Engine/server/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Servers
+description: "List Servers"
 ---
 
 # ServerList

--- a/docs/subcommands/Compute Engine/server/reboot.md
+++ b/docs/subcommands/Compute Engine/server/reboot.md
@@ -1,5 +1,5 @@
 ---
-description: Force a hard reboot of a Server
+description: "Force a hard reboot of a Server"
 ---
 
 # ServerReboot

--- a/docs/subcommands/Compute Engine/server/resume.md
+++ b/docs/subcommands/Compute Engine/server/resume.md
@@ -1,5 +1,5 @@
 ---
-description: Resume a Cube Server
+description: "Resume a Cube Server"
 ---
 
 # ServerResume

--- a/docs/subcommands/Compute Engine/server/start.md
+++ b/docs/subcommands/Compute Engine/server/start.md
@@ -1,5 +1,5 @@
 ---
-description: Start a Server
+description: "Start a Server"
 ---
 
 # ServerStart

--- a/docs/subcommands/Compute Engine/server/stop.md
+++ b/docs/subcommands/Compute Engine/server/stop.md
@@ -1,5 +1,5 @@
 ---
-description: Stop a Server
+description: "Stop a Server"
 ---
 
 # ServerStop

--- a/docs/subcommands/Compute Engine/server/suspend.md
+++ b/docs/subcommands/Compute Engine/server/suspend.md
@@ -1,5 +1,5 @@
 ---
-description: Suspend a Cube Server
+description: "Suspend a Cube Server"
 ---
 
 # ServerSuspend

--- a/docs/subcommands/Compute Engine/server/token/get.md
+++ b/docs/subcommands/Compute Engine/server/token/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Token from a Server
+description: "Get a Token from a Server"
 ---
 
 # ServerTokenGet

--- a/docs/subcommands/Compute Engine/server/update.md
+++ b/docs/subcommands/Compute Engine/server/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Server
+description: "Update a Server"
 ---
 
 # ServerUpdate

--- a/docs/subcommands/Compute Engine/server/volume/attach.md
+++ b/docs/subcommands/Compute Engine/server/volume/attach.md
@@ -1,5 +1,5 @@
 ---
-description: Attach a Volume to a Server
+description: "Attach a Volume to a Server"
 ---
 
 # ServerVolumeAttach

--- a/docs/subcommands/Compute Engine/server/volume/detach.md
+++ b/docs/subcommands/Compute Engine/server/volume/detach.md
@@ -1,5 +1,5 @@
 ---
-description: Detach a Volume from a Server
+description: "Detach a Volume from a Server"
 ---
 
 # ServerVolumeDetach

--- a/docs/subcommands/Compute Engine/server/volume/get.md
+++ b/docs/subcommands/Compute Engine/server/volume/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get an attached Volume from a Server
+description: "Get an attached Volume from a Server"
 ---
 
 # ServerVolumeGet

--- a/docs/subcommands/Compute Engine/server/volume/list.md
+++ b/docs/subcommands/Compute Engine/server/volume/list.md
@@ -1,5 +1,5 @@
 ---
-description: List attached Volumes from a Server
+description: "List attached Volumes from a Server"
 ---
 
 # ServerVolumeList

--- a/docs/subcommands/Compute Engine/share/create.md
+++ b/docs/subcommands/Compute Engine/share/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Resource Share for a Group
+description: "Create a Resource Share for a Group"
 ---
 
 # ShareCreate

--- a/docs/subcommands/Compute Engine/share/delete.md
+++ b/docs/subcommands/Compute Engine/share/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Resource Share from a Group
+description: "Delete a Resource Share from a Group"
 ---
 
 # ShareDelete

--- a/docs/subcommands/Compute Engine/share/get.md
+++ b/docs/subcommands/Compute Engine/share/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Resource Share from a Group
+description: "Get a Resource Share from a Group"
 ---
 
 # ShareGet

--- a/docs/subcommands/Compute Engine/share/list.md
+++ b/docs/subcommands/Compute Engine/share/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Resources Shares through a Group
+description: "List Resources Shares through a Group"
 ---
 
 # ShareList

--- a/docs/subcommands/Compute Engine/share/update.md
+++ b/docs/subcommands/Compute Engine/share/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Resource Share from a Group
+description: "Update a Resource Share from a Group"
 ---
 
 # ShareUpdate

--- a/docs/subcommands/Compute Engine/snapshot/create.md
+++ b/docs/subcommands/Compute Engine/snapshot/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Snapshot of a Volume within the Virtual Data Center
+description: "Create a Snapshot of a Volume within the Virtual Data Center"
 ---
 
 # SnapshotCreate

--- a/docs/subcommands/Compute Engine/snapshot/delete.md
+++ b/docs/subcommands/Compute Engine/snapshot/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Snapshot
+description: "Delete a Snapshot"
 ---
 
 # SnapshotDelete

--- a/docs/subcommands/Compute Engine/snapshot/get.md
+++ b/docs/subcommands/Compute Engine/snapshot/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Snapshot
+description: "Get a Snapshot"
 ---
 
 # SnapshotGet

--- a/docs/subcommands/Compute Engine/snapshot/list.md
+++ b/docs/subcommands/Compute Engine/snapshot/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Snapshots
+description: "List Snapshots"
 ---
 
 # SnapshotList

--- a/docs/subcommands/Compute Engine/snapshot/restore.md
+++ b/docs/subcommands/Compute Engine/snapshot/restore.md
@@ -1,5 +1,5 @@
 ---
-description: Restore a Snapshot onto a Volume
+description: "Restore a Snapshot onto a Volume"
 ---
 
 # SnapshotRestore

--- a/docs/subcommands/Compute Engine/snapshot/update.md
+++ b/docs/subcommands/Compute Engine/snapshot/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Snapshot
+description: "Update a Snapshot"
 ---
 
 # SnapshotUpdate

--- a/docs/subcommands/Compute Engine/targetgroup/create.md
+++ b/docs/subcommands/Compute Engine/targetgroup/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Target Group
+description: "Create a Target Group"
 ---
 
 # TargetgroupCreate

--- a/docs/subcommands/Compute Engine/targetgroup/delete.md
+++ b/docs/subcommands/Compute Engine/targetgroup/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Target Group
+description: "Delete a Target Group"
 ---
 
 # TargetgroupDelete

--- a/docs/subcommands/Compute Engine/targetgroup/get.md
+++ b/docs/subcommands/Compute Engine/targetgroup/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Target Group
+description: "Get a Target Group"
 ---
 
 # TargetgroupGet

--- a/docs/subcommands/Compute Engine/targetgroup/list.md
+++ b/docs/subcommands/Compute Engine/targetgroup/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Target Groups
+description: "List Target Groups"
 ---
 
 # TargetgroupList

--- a/docs/subcommands/Compute Engine/targetgroup/target/add.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a Target to a Target Group
+description: "Add a Target to a Target Group"
 ---
 
 # TargetgroupTargetAdd

--- a/docs/subcommands/Compute Engine/targetgroup/target/list.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Target Groups Targets
+description: "List Target Groups Targets"
 ---
 
 # TargetgroupTargetList

--- a/docs/subcommands/Compute Engine/targetgroup/target/remove.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a Target from a Target Group
+description: "Remove a Target from a Target Group"
 ---
 
 # TargetgroupTargetRemove

--- a/docs/subcommands/Compute Engine/targetgroup/update.md
+++ b/docs/subcommands/Compute Engine/targetgroup/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Target Group
+description: "Update a Target Group"
 ---
 
 # TargetgroupUpdate

--- a/docs/subcommands/Compute Engine/template/get.md
+++ b/docs/subcommands/Compute Engine/template/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a specified Template
+description: "Get a specified Template"
 ---
 
 # TemplateGet

--- a/docs/subcommands/Compute Engine/template/list.md
+++ b/docs/subcommands/Compute Engine/template/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Templates
+description: "List Templates"
 ---
 
 # TemplateList

--- a/docs/subcommands/Compute Engine/volume/create.md
+++ b/docs/subcommands/Compute Engine/volume/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Volume
+description: "Create a Volume"
 ---
 
 # VolumeCreate

--- a/docs/subcommands/Compute Engine/volume/delete.md
+++ b/docs/subcommands/Compute Engine/volume/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Volume
+description: "Delete a Volume"
 ---
 
 # VolumeDelete

--- a/docs/subcommands/Compute Engine/volume/get.md
+++ b/docs/subcommands/Compute Engine/volume/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Volume
+description: "Get a Volume"
 ---
 
 # VolumeGet

--- a/docs/subcommands/Compute Engine/volume/list.md
+++ b/docs/subcommands/Compute Engine/volume/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Volumes
+description: "List Volumes"
 ---
 
 # VolumeList

--- a/docs/subcommands/Compute Engine/volume/update.md
+++ b/docs/subcommands/Compute Engine/volume/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Volume
+description: "Update a Volume"
 ---
 
 # VolumeUpdate

--- a/docs/subcommands/Container-Registry/locations.md
+++ b/docs/subcommands/Container-Registry/locations.md
@@ -1,5 +1,5 @@
 ---
-description: List all Registries Locations
+description: "List all Registries Locations"
 ---
 
 # ContainerRegistryLocations

--- a/docs/subcommands/Container-Registry/names.md
+++ b/docs/subcommands/Container-Registry/names.md
@@ -1,5 +1,5 @@
 ---
-description: Check if a Registry Name is available
+description: "Check if a Registry Name is available"
 ---
 
 # ContainerRegistryNames

--- a/docs/subcommands/Container-Registry/registry/create.md
+++ b/docs/subcommands/Container-Registry/registry/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a registry
+description: "Create a registry"
 ---
 
 # ContainerRegistryRegistryCreate

--- a/docs/subcommands/Container-Registry/registry/delete.md
+++ b/docs/subcommands/Container-Registry/registry/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Registry
+description: "Delete a Registry"
 ---
 
 # ContainerRegistryRegistryDelete

--- a/docs/subcommands/Container-Registry/registry/get.md
+++ b/docs/subcommands/Container-Registry/registry/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get Properties of a Registry
+description: "Get Properties of a Registry"
 ---
 
 # ContainerRegistryRegistryGet

--- a/docs/subcommands/Container-Registry/registry/list.md
+++ b/docs/subcommands/Container-Registry/registry/list.md
@@ -1,5 +1,5 @@
 ---
-description: List all Registries
+description: "List all Registries"
 ---
 
 # ContainerRegistryRegistryList

--- a/docs/subcommands/Container-Registry/registry/replace.md
+++ b/docs/subcommands/Container-Registry/registry/replace.md
@@ -1,5 +1,5 @@
 ---
-description: Replace a registry
+description: "Replace a registry"
 ---
 
 # ContainerRegistryRegistryReplace

--- a/docs/subcommands/Container-Registry/registry/update.md
+++ b/docs/subcommands/Container-Registry/registry/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update the properties of a registry
+description: "Update the properties of a registry"
 ---
 
 # ContainerRegistryRegistryUpdate

--- a/docs/subcommands/Container-Registry/repository.md
+++ b/docs/subcommands/Container-Registry/repository.md
@@ -1,5 +1,5 @@
 ---
-description: Delete all repository contents.
+description: "Delete all repository contents."
 ---
 
 # ContainerRegistryRepository

--- a/docs/subcommands/Container-Registry/token/create.md
+++ b/docs/subcommands/Container-Registry/token/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a new token
+description: "Create a new token"
 ---
 
 # ContainerRegistryTokenCreate

--- a/docs/subcommands/Container-Registry/token/delete.md
+++ b/docs/subcommands/Container-Registry/token/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a token
+description: "Delete a token"
 ---
 
 # ContainerRegistryTokenDelete

--- a/docs/subcommands/Container-Registry/token/get.md
+++ b/docs/subcommands/Container-Registry/token/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a token
+description: "Get a token"
 ---
 
 # ContainerRegistryTokenGet

--- a/docs/subcommands/Container-Registry/token/list.md
+++ b/docs/subcommands/Container-Registry/token/list.md
@@ -1,5 +1,5 @@
 ---
-description: List all tokens
+description: "List all tokens"
 ---
 
 # ContainerRegistryTokenList

--- a/docs/subcommands/Container-Registry/token/replace.md
+++ b/docs/subcommands/Container-Registry/token/replace.md
@@ -1,5 +1,5 @@
 ---
-description: Create or replace a token
+description: "Create or replace a token"
 ---
 
 # ContainerRegistryTokenReplace

--- a/docs/subcommands/Container-Registry/token/scope/add.md
+++ b/docs/subcommands/Container-Registry/token/scope/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add scopes to a token
+description: "Add scopes to a token"
 ---
 
 # ContainerRegistryTokenScopeAdd

--- a/docs/subcommands/Container-Registry/token/scope/delete.md
+++ b/docs/subcommands/Container-Registry/token/scope/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a token scope
+description: "Delete a token scope"
 ---
 
 # ContainerRegistryTokenScopeDelete

--- a/docs/subcommands/Container-Registry/token/scope/list.md
+++ b/docs/subcommands/Container-Registry/token/scope/list.md
@@ -1,5 +1,5 @@
 ---
-description: Get a token scopes
+description: "Get a token scopes"
 ---
 
 # ContainerRegistryTokenScopeList

--- a/docs/subcommands/Container-Registry/token/update.md
+++ b/docs/subcommands/Container-Registry/token/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a token's properties
+description: "Update a token's properties"
 ---
 
 # ContainerRegistryTokenUpdate

--- a/docs/subcommands/DNS/record/create.md
+++ b/docs/subcommands/DNS/record/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-tos/create-a-new-dns-record
+description: "Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-tos/create-a-new-dns-record"
 ---
 
 # DnsRecordCreate

--- a/docs/subcommands/DNS/record/delete.md
+++ b/docs/subcommands/DNS/record/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a record
+description: "Delete a record"
 ---
 
 # DnsRecordDelete

--- a/docs/subcommands/DNS/record/get.md
+++ b/docs/subcommands/DNS/record/get.md
@@ -1,5 +1,5 @@
 ---
-description: Retrieve a record
+description: "Retrieve a record"
 ---
 
 # DnsRecordGet

--- a/docs/subcommands/DNS/record/list.md
+++ b/docs/subcommands/DNS/record/list.md
@@ -1,5 +1,5 @@
 ---
-description: Retrieve all records
+description: "Retrieve all records"
 ---
 
 # DnsRecordList

--- a/docs/subcommands/DNS/record/update.md
+++ b/docs/subcommands/DNS/record/update.md
@@ -1,5 +1,5 @@
 ---
-description: Partially modify a record's properties. This command uses a combination of GET and PUT to simulate a PATCH operation
+description: "Partially modify a record's properties. This command uses a combination of GET and PUT to simulate a PATCH operation"
 ---
 
 # DnsRecordUpdate

--- a/docs/subcommands/DNS/zone/create.md
+++ b/docs/subcommands/DNS/zone/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a zone
+description: "Create a zone"
 ---
 
 # DnsZoneCreate

--- a/docs/subcommands/DNS/zone/delete.md
+++ b/docs/subcommands/DNS/zone/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a zone
+description: "Delete a zone"
 ---
 
 # DnsZoneDelete

--- a/docs/subcommands/DNS/zone/get.md
+++ b/docs/subcommands/DNS/zone/get.md
@@ -1,5 +1,5 @@
 ---
-description: Retrieve a zone
+description: "Retrieve a zone"
 ---
 
 # DnsZoneGet

--- a/docs/subcommands/DNS/zone/list.md
+++ b/docs/subcommands/DNS/zone/list.md
@@ -1,5 +1,5 @@
 ---
-description: Retrieve zones
+description: "Retrieve zones"
 ---
 
 # DnsZoneList

--- a/docs/subcommands/DNS/zone/update.md
+++ b/docs/subcommands/DNS/zone/update.md
@@ -1,5 +1,5 @@
 ---
-description: Partially modify a zone's properties. This command uses a combination of GET and PUT to simulate a PATCH operation
+description: "Partially modify a zone's properties. This command uses a combination of GET and PUT to simulate a PATCH operation"
 ---
 
 # DnsZoneUpdate

--- a/docs/subcommands/Database-as-a-Service/mongo/api/versions.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/api/versions.md
@@ -1,5 +1,5 @@
 ---
-description: Get Mongo API swagger files
+description: "Get Mongo API swagger files"
 ---
 
 # DbaasMongoApiVersions

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create Mongo Clusters
+description: "Create Mongo Clusters"
 ---
 
 # DbaasMongoClusterCreate

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Mongo Cluster by ID
+description: "Delete a Mongo Cluster by ID"
 ---
 
 # DbaasMongoClusterDelete

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Mongo Cluster by ID
+description: "Get a Mongo Cluster by ID"
 ---
 
 # DbaasMongoClusterGet

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Mongo Clusters
+description: "List Mongo Clusters"
 ---
 
 # DbaasMongoClusterList

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/restore.md
@@ -1,5 +1,5 @@
 ---
-description: Restore a Mongo Cluster by ID, using a snapshot
+description: "Restore a Mongo Cluster by ID, using a snapshot"
 ---
 
 # DbaasMongoClusterRestore

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Mongo Cluster by ID
+description: "Update a Mongo Cluster by ID"
 ---
 
 # DbaasMongoClusterUpdate

--- a/docs/subcommands/Database-as-a-Service/mongo/logs/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/logs/list.md
@@ -1,5 +1,5 @@
 ---
-description: List the logs of your Mongo Cluster
+description: "List the logs of your Mongo Cluster"
 ---
 
 # DbaasMongoLogsList

--- a/docs/subcommands/Database-as-a-Service/mongo/snapshot/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/snapshot/list.md
@@ -1,5 +1,5 @@
 ---
-description: List the snapshots of your Mongo Cluster
+description: "List the snapshots of your Mongo Cluster"
 ---
 
 # DbaasMongoSnapshotList

--- a/docs/subcommands/Database-as-a-Service/mongo/templates/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/templates/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Mongo Templates
+description: "List Mongo Templates"
 ---
 
 # DbaasMongoTemplatesList

--- a/docs/subcommands/Database-as-a-Service/mongo/user/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create MongoDB users.
+description: "Create MongoDB users."
 ---
 
 # DbaasMongoUserCreate

--- a/docs/subcommands/Database-as-a-Service/mongo/user/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a MongoDB user
+description: "Delete a MongoDB user"
 ---
 
 # DbaasMongoUserDelete

--- a/docs/subcommands/Database-as-a-Service/mongo/user/get.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a MongoDB user
+description: "Get a MongoDB user"
 ---
 
 # DbaasMongoUserGet

--- a/docs/subcommands/Database-as-a-Service/mongo/user/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/list.md
@@ -1,5 +1,5 @@
 ---
-description: Retrieves a list of MongoDB users.
+description: "Retrieves a list of MongoDB users."
 ---
 
 # DbaasMongoUserList

--- a/docs/subcommands/Database-as-a-Service/postgres/api/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/api/version/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get current version of DBaaS PostgreSQL API
+description: "Get current version of DBaaS PostgreSQL API"
 ---
 
 # DbaasPostgresApiVersionGet

--- a/docs/subcommands/Database-as-a-Service/postgres/api/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/api/version/list.md
@@ -1,5 +1,5 @@
 ---
-description: List DBaaS PostgreSQL API Versions
+description: "List DBaaS PostgreSQL API Versions"
 ---
 
 # DbaasPostgresApiVersionList

--- a/docs/subcommands/Database-as-a-Service/postgres/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/backup/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Cluster Backup
+description: "Get a Cluster Backup"
 ---
 
 # DbaasPostgresBackupGet

--- a/docs/subcommands/Database-as-a-Service/postgres/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/backup/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Cluster Backups
+description: "List Cluster Backups"
 ---
 
 # DbaasPostgresBackupList

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/backup/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Cluster Backups from a Cluster
+description: "List Cluster Backups from a Cluster"
 ---
 
 # DbaasPostgresClusterBackupList

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a PostgreSQL Cluster
+description: "Create a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresClusterCreate

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a PostgreSQL Cluster
+description: "Delete a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresClusterDelete

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a PostgreSQL Cluster
+description: "Get a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresClusterGet

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/list.md
@@ -1,5 +1,5 @@
 ---
-description: List PostgreSQL Clusters
+description: "List PostgreSQL Clusters"
 ---
 
 # DbaasPostgresClusterList

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/restore.md
@@ -1,5 +1,5 @@
 ---
-description: Restore a PostgreSQL Cluster
+description: "Restore a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresClusterRestore

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a PostgreSQL Cluster
+description: "Update a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresClusterUpdate

--- a/docs/subcommands/Database-as-a-Service/postgres/logs/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/logs/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Logs for a PostgreSQL Cluster
+description: "List Logs for a PostgreSQL Cluster"
 ---
 
 # DbaasPostgresLogsList

--- a/docs/subcommands/Database-as-a-Service/postgres/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/version/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get DBaaS PostgreSQLVersions for a Cluster
+description: "Get DBaaS PostgreSQLVersions for a Cluster"
 ---
 
 # DbaasPostgresVersionGet

--- a/docs/subcommands/Database-as-a-Service/postgres/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/version/list.md
@@ -1,5 +1,5 @@
 ---
-description: List DBaaS PostgreSQL Versions
+description: "List DBaaS PostgreSQL Versions"
 ---
 
 # DbaasPostgresVersionList

--- a/docs/subcommands/Managed-Backup/create.md
+++ b/docs/subcommands/Managed-Backup/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a BackupUnit
+description: "Create a BackupUnit"
 ---
 
 # BackupunitCreate

--- a/docs/subcommands/Managed-Backup/delete.md
+++ b/docs/subcommands/Managed-Backup/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a BackupUnit
+description: "Delete a BackupUnit"
 ---
 
 # BackupunitDelete

--- a/docs/subcommands/Managed-Backup/get.md
+++ b/docs/subcommands/Managed-Backup/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a BackupUnit
+description: "Get a BackupUnit"
 ---
 
 # BackupunitGet

--- a/docs/subcommands/Managed-Backup/get/sso/url.md
+++ b/docs/subcommands/Managed-Backup/get/sso/url.md
@@ -1,5 +1,5 @@
 ---
-description: Get BackupUnit SSO URL
+description: "Get BackupUnit SSO URL"
 ---
 
 # BackupunitGetSsoUrl

--- a/docs/subcommands/Managed-Backup/list.md
+++ b/docs/subcommands/Managed-Backup/list.md
@@ -1,5 +1,5 @@
 ---
-description: List BackupUnits
+description: "List BackupUnits"
 ---
 
 # BackupunitList

--- a/docs/subcommands/Managed-Backup/update.md
+++ b/docs/subcommands/Managed-Backup/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a BackupUnit
+description: "Update a BackupUnit"
 ---
 
 # BackupunitUpdate

--- a/docs/subcommands/Managed-Kubernetes/cluster/create.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Kubernetes Cluster
+description: "Create a Kubernetes Cluster"
 ---
 
 # K8sClusterCreate

--- a/docs/subcommands/Managed-Kubernetes/cluster/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Kubernetes Cluster
+description: "Delete a Kubernetes Cluster"
 ---
 
 # K8sClusterDelete

--- a/docs/subcommands/Managed-Kubernetes/cluster/get.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Kubernetes Cluster
+description: "Get a Kubernetes Cluster"
 ---
 
 # K8sClusterGet

--- a/docs/subcommands/Managed-Kubernetes/cluster/list.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Kubernetes Clusters
+description: "List Kubernetes Clusters"
 ---
 
 # K8sClusterList

--- a/docs/subcommands/Managed-Kubernetes/cluster/update.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Kubernetes Cluster
+description: "Update a Kubernetes Cluster"
 ---
 
 # K8sClusterUpdate

--- a/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
+++ b/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get the kubeconfig file for a Kubernetes Cluster
+description: "Get the kubeconfig file for a Kubernetes Cluster"
 ---
 
 # K8sKubeconfigGet

--- a/docs/subcommands/Managed-Kubernetes/node/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/node/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Kubernetes Node
+description: "Delete a Kubernetes Node"
 ---
 
 # K8sNodeDelete

--- a/docs/subcommands/Managed-Kubernetes/node/get.md
+++ b/docs/subcommands/Managed-Kubernetes/node/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Kubernetes Node
+description: "Get a Kubernetes Node"
 ---
 
 # K8sNodeGet

--- a/docs/subcommands/Managed-Kubernetes/node/list.md
+++ b/docs/subcommands/Managed-Kubernetes/node/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Kubernetes Nodes
+description: "List Kubernetes Nodes"
 ---
 
 # K8sNodeList

--- a/docs/subcommands/Managed-Kubernetes/node/recreate.md
+++ b/docs/subcommands/Managed-Kubernetes/node/recreate.md
@@ -1,5 +1,5 @@
 ---
-description: Recreate a Kubernetes Node
+description: "Recreate a Kubernetes Node"
 ---
 
 # K8sNodeRecreate

--- a/docs/subcommands/Managed-Kubernetes/nodepool/create.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Kubernetes NodePool
+description: "Create a Kubernetes NodePool"
 ---
 
 # K8sNodepoolCreate

--- a/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Kubernetes NodePool
+description: "Delete a Kubernetes NodePool"
 ---
 
 # K8sNodepoolDelete

--- a/docs/subcommands/Managed-Kubernetes/nodepool/get.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Kubernetes NodePool
+description: "Get a Kubernetes NodePool"
 ---
 
 # K8sNodepoolGet

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a Kubernetes NodePool LAN
+description: "Add a Kubernetes NodePool LAN"
 ---
 
 # K8sNodepoolLanAdd

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Kubernetes NodePool LANs
+description: "List Kubernetes NodePool LANs"
 ---
 
 # K8sNodepoolLanList

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a Kubernetes NodePool LAN
+description: "Remove a Kubernetes NodePool LAN"
 ---
 
 # K8sNodepoolLanRemove

--- a/docs/subcommands/Managed-Kubernetes/nodepool/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Kubernetes NodePools
+description: "List Kubernetes NodePools"
 ---
 
 # K8sNodepoolList

--- a/docs/subcommands/Managed-Kubernetes/nodepool/update.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Kubernetes NodePool
+description: "Update a Kubernetes NodePool"
 ---
 
 # K8sNodepoolUpdate

--- a/docs/subcommands/Managed-Kubernetes/version/get.md
+++ b/docs/subcommands/Managed-Kubernetes/version/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get Kubernetes Default Version
+description: "Get Kubernetes Default Version"
 ---
 
 # K8sVersionGet

--- a/docs/subcommands/Managed-Kubernetes/version/list.md
+++ b/docs/subcommands/Managed-Kubernetes/version/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Kubernetes Versions
+description: "List Kubernetes Versions"
 ---
 
 # K8sVersionList

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create Dataplatform Cluster
+description: "Create Dataplatform Cluster"
 ---
 
 # DataplatformClusterCreate

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/delete.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Dataplatform Cluster by ID
+description: "Delete a Dataplatform Cluster by ID"
 ---
 
 # DataplatformClusterDelete

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/get.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Dataplatform Cluster by ID
+description: "Get a Dataplatform Cluster by ID"
 ---
 
 # DataplatformClusterGet

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/kubeconfig.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/kubeconfig.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Dataplatform Cluster's Kubeconfig by ID
+description: "Get a Dataplatform Cluster's Kubeconfig by ID"
 ---
 
 # DataplatformClusterKubeconfig

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/list.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Dataplatform Clusters
+description: "List Dataplatform Clusters"
 ---
 
 # DataplatformClusterList

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/update.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Dataplatform Cluster by ID
+description: "Update a Dataplatform Cluster by ID"
 ---
 
 # DataplatformClusterUpdate

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create Dataplatform Nodepools
+description: "Create Dataplatform Nodepools"
 ---
 
 # DataplatformNodepoolCreate

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/delete.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Dataplatform Cluster by ID
+description: "Delete a Dataplatform Cluster by ID"
 ---
 
 # DataplatformNodepoolDelete

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/get.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get Dataplatform Nodepool by cluster and nodepool id
+description: "Get Dataplatform Nodepool by cluster and nodepool id"
 ---
 
 # DataplatformNodepoolGet

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/list.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Dataplatform Nodepools of a certain cluster
+description: "List Dataplatform Nodepools of a certain cluster"
 ---
 
 # DataplatformNodepoolList

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/update.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update Dataplatform Nodepools
+description: "Update Dataplatform Nodepools"
 ---
 
 # DataplatformNodepoolUpdate

--- a/docs/subcommands/NAT-Gateway/create.md
+++ b/docs/subcommands/NAT-Gateway/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a NAT Gateway
+description: "Create a NAT Gateway"
 ---
 
 # NatgatewayCreate

--- a/docs/subcommands/NAT-Gateway/delete.md
+++ b/docs/subcommands/NAT-Gateway/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a NAT Gateway
+description: "Delete a NAT Gateway"
 ---
 
 # NatgatewayDelete

--- a/docs/subcommands/NAT-Gateway/flowlog/create.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a NAT Gateway FlowLog
+description: "Create a NAT Gateway FlowLog"
 ---
 
 # NatgatewayFlowlogCreate

--- a/docs/subcommands/NAT-Gateway/flowlog/delete.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a NAT Gateway FlowLog
+description: "Delete a NAT Gateway FlowLog"
 ---
 
 # NatgatewayFlowlogDelete

--- a/docs/subcommands/NAT-Gateway/flowlog/get.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a NAT Gateway FlowLog
+description: "Get a NAT Gateway FlowLog"
 ---
 
 # NatgatewayFlowlogGet

--- a/docs/subcommands/NAT-Gateway/flowlog/list.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/list.md
@@ -1,5 +1,5 @@
 ---
-description: List NAT Gateway FlowLogs
+description: "List NAT Gateway FlowLogs"
 ---
 
 # NatgatewayFlowlogList

--- a/docs/subcommands/NAT-Gateway/flowlog/update.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a NAT Gateway FlowLog
+description: "Update a NAT Gateway FlowLog"
 ---
 
 # NatgatewayFlowlogUpdate

--- a/docs/subcommands/NAT-Gateway/get.md
+++ b/docs/subcommands/NAT-Gateway/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a NAT Gateway
+description: "Get a NAT Gateway"
 ---
 
 # NatgatewayGet

--- a/docs/subcommands/NAT-Gateway/lan/add.md
+++ b/docs/subcommands/NAT-Gateway/lan/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a NAT Gateway Lan
+description: "Add a NAT Gateway Lan"
 ---
 
 # NatgatewayLanAdd

--- a/docs/subcommands/NAT-Gateway/lan/list.md
+++ b/docs/subcommands/NAT-Gateway/lan/list.md
@@ -1,5 +1,5 @@
 ---
-description: List NAT Gateway Lans
+description: "List NAT Gateway Lans"
 ---
 
 # NatgatewayLanList

--- a/docs/subcommands/NAT-Gateway/lan/remove.md
+++ b/docs/subcommands/NAT-Gateway/lan/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a NAT Gateway Lan
+description: "Remove a NAT Gateway Lan"
 ---
 
 # NatgatewayLanRemove

--- a/docs/subcommands/NAT-Gateway/list.md
+++ b/docs/subcommands/NAT-Gateway/list.md
@@ -1,5 +1,5 @@
 ---
-description: List NAT Gateways
+description: "List NAT Gateways"
 ---
 
 # NatgatewayList

--- a/docs/subcommands/NAT-Gateway/rule/create.md
+++ b/docs/subcommands/NAT-Gateway/rule/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a NAT Gateway Rule
+description: "Create a NAT Gateway Rule"
 ---
 
 # NatgatewayRuleCreate

--- a/docs/subcommands/NAT-Gateway/rule/delete.md
+++ b/docs/subcommands/NAT-Gateway/rule/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a NAT Gateway Rule
+description: "Delete a NAT Gateway Rule"
 ---
 
 # NatgatewayRuleDelete

--- a/docs/subcommands/NAT-Gateway/rule/get.md
+++ b/docs/subcommands/NAT-Gateway/rule/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a NAT Gateway Rule
+description: "Get a NAT Gateway Rule"
 ---
 
 # NatgatewayRuleGet

--- a/docs/subcommands/NAT-Gateway/rule/list.md
+++ b/docs/subcommands/NAT-Gateway/rule/list.md
@@ -1,5 +1,5 @@
 ---
-description: List NAT Gateway Rules
+description: "List NAT Gateway Rules"
 ---
 
 # NatgatewayRuleList

--- a/docs/subcommands/NAT-Gateway/rule/update.md
+++ b/docs/subcommands/NAT-Gateway/rule/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a NAT Gateway Rule
+description: "Update a NAT Gateway Rule"
 ---
 
 # NatgatewayRuleUpdate

--- a/docs/subcommands/NAT-Gateway/update.md
+++ b/docs/subcommands/NAT-Gateway/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a NAT Gateway
+description: "Update a NAT Gateway"
 ---
 
 # NatgatewayUpdate

--- a/docs/subcommands/Network-Load-Balancer/create.md
+++ b/docs/subcommands/Network-Load-Balancer/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Network Load Balancer
+description: "Create a Network Load Balancer"
 ---
 
 # NetworkloadbalancerCreate

--- a/docs/subcommands/Network-Load-Balancer/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Network Load Balancer
+description: "Delete a Network Load Balancer"
 ---
 
 # NetworkloadbalancerDelete

--- a/docs/subcommands/Network-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Network Load Balancer FlowLog
+description: "Create a Network Load Balancer FlowLog"
 ---
 
 # NetworkloadbalancerFlowlogCreate

--- a/docs/subcommands/Network-Load-Balancer/flowlog/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Network Load Balancer FlowLog
+description: "Delete a Network Load Balancer FlowLog"
 ---
 
 # NetworkloadbalancerFlowlogDelete

--- a/docs/subcommands/Network-Load-Balancer/flowlog/get.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Network Load Balancer FlowLog
+description: "Get a Network Load Balancer FlowLog"
 ---
 
 # NetworkloadbalancerFlowlogGet

--- a/docs/subcommands/Network-Load-Balancer/flowlog/list.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Network Load Balancer FlowLogs
+description: "List Network Load Balancer FlowLogs"
 ---
 
 # NetworkloadbalancerFlowlogList

--- a/docs/subcommands/Network-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Network Load Balancer FlowLog
+description: "Update a Network Load Balancer FlowLog"
 ---
 
 # NetworkloadbalancerFlowlogUpdate

--- a/docs/subcommands/Network-Load-Balancer/get.md
+++ b/docs/subcommands/Network-Load-Balancer/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Network Load Balancer
+description: "Get a Network Load Balancer"
 ---
 
 # NetworkloadbalancerGet

--- a/docs/subcommands/Network-Load-Balancer/list.md
+++ b/docs/subcommands/Network-Load-Balancer/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Network Load Balancers
+description: "List Network Load Balancers"
 ---
 
 # NetworkloadbalancerList

--- a/docs/subcommands/Network-Load-Balancer/rule/create.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a Network Load Balancer Forwarding Rule
+description: "Create a Network Load Balancer Forwarding Rule"
 ---
 
 # NetworkloadbalancerRuleCreate

--- a/docs/subcommands/Network-Load-Balancer/rule/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a Network Load Balancer Forwarding Rule
+description: "Delete a Network Load Balancer Forwarding Rule"
 ---
 
 # NetworkloadbalancerRuleDelete

--- a/docs/subcommands/Network-Load-Balancer/rule/get.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a Network Load Balancer Forwarding Rule
+description: "Get a Network Load Balancer Forwarding Rule"
 ---
 
 # NetworkloadbalancerRuleGet

--- a/docs/subcommands/Network-Load-Balancer/rule/list.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Network Load Balancer Forwarding Rules
+description: "List Network Load Balancer Forwarding Rules"
 ---
 
 # NetworkloadbalancerRuleList

--- a/docs/subcommands/Network-Load-Balancer/rule/target/add.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/add.md
@@ -1,5 +1,5 @@
 ---
-description: Add a Network Load Balancer Forwarding Rule Target
+description: "Add a Network Load Balancer Forwarding Rule Target"
 ---
 
 # NetworkloadbalancerRuleTargetAdd

--- a/docs/subcommands/Network-Load-Balancer/rule/target/list.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Network Load Balancer Forwarding Rule Targets
+description: "List Network Load Balancer Forwarding Rule Targets"
 ---
 
 # NetworkloadbalancerRuleTargetList

--- a/docs/subcommands/Network-Load-Balancer/rule/target/remove.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/remove.md
@@ -1,5 +1,5 @@
 ---
-description: Remove a Target from a Network Load Balancer Forwarding Rule
+description: "Remove a Target from a Network Load Balancer Forwarding Rule"
 ---
 
 # NetworkloadbalancerRuleTargetRemove

--- a/docs/subcommands/Network-Load-Balancer/rule/update.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Network Load Balancer Forwarding Rule
+description: "Update a Network Load Balancer Forwarding Rule"
 ---
 
 # NetworkloadbalancerRuleUpdate

--- a/docs/subcommands/Network-Load-Balancer/update.md
+++ b/docs/subcommands/Network-Load-Balancer/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a Network Load Balancer
+description: "Update a Network Load Balancer"
 ---
 
 # NetworkloadbalancerUpdate

--- a/docs/subcommands/User-Management/create.md
+++ b/docs/subcommands/User-Management/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a User under a particular contract
+description: "Create a User under a particular contract"
 ---
 
 # UserCreate

--- a/docs/subcommands/User-Management/delete.md
+++ b/docs/subcommands/User-Management/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Blacklists the User, disabling them
+description: "Blacklists the User, disabling them"
 ---
 
 # UserDelete

--- a/docs/subcommands/User-Management/get.md
+++ b/docs/subcommands/User-Management/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a User
+description: "Get a User"
 ---
 
 # UserGet

--- a/docs/subcommands/User-Management/list.md
+++ b/docs/subcommands/User-Management/list.md
@@ -1,5 +1,5 @@
 ---
-description: List Users
+description: "List Users"
 ---
 
 # UserList

--- a/docs/subcommands/User-Management/s3key/create.md
+++ b/docs/subcommands/User-Management/s3key/create.md
@@ -1,5 +1,5 @@
 ---
-description: Create a S3Key for a User
+description: "Create a S3Key for a User"
 ---
 
 # UserS3keyCreate

--- a/docs/subcommands/User-Management/s3key/delete.md
+++ b/docs/subcommands/User-Management/s3key/delete.md
@@ -1,5 +1,5 @@
 ---
-description: Delete a S3Key
+description: "Delete a S3Key"
 ---
 
 # UserS3keyDelete

--- a/docs/subcommands/User-Management/s3key/get.md
+++ b/docs/subcommands/User-Management/s3key/get.md
@@ -1,5 +1,5 @@
 ---
-description: Get a User S3Key
+description: "Get a User S3Key"
 ---
 
 # UserS3keyGet

--- a/docs/subcommands/User-Management/s3key/list.md
+++ b/docs/subcommands/User-Management/s3key/list.md
@@ -1,5 +1,5 @@
 ---
-description: List User S3Keys
+description: "List User S3Keys"
 ---
 
 # UserS3keyList

--- a/docs/subcommands/User-Management/s3key/update.md
+++ b/docs/subcommands/User-Management/s3key/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a S3Key
+description: "Update a S3Key"
 ---
 
 # UserS3keyUpdate

--- a/docs/subcommands/User-Management/update.md
+++ b/docs/subcommands/User-Management/update.md
@@ -1,5 +1,5 @@
 ---
-description: Update a User
+description: "Update a User"
 ---
 
 # UserUpdate

--- a/pkg/doc/doc.go
+++ b/pkg/doc/doc.go
@@ -189,7 +189,7 @@ func writeDoc(cmd *core.Command, w io.Writer) error {
 	name := cmd.Command.CommandPath()
 
 	buf.WriteString("---\n")
-	buf.WriteString(fmt.Sprintf("description: %s\n", cmd.Command.Short))
+	buf.WriteString(fmt.Sprintf("description: \"%s\"\n", cmd.Command.Short))
 	buf.WriteString("---\n\n")
 
 	// Customize title


### PR DESCRIPTION
Having multiple "keys" in the description of a command would break the documentation. For example,


```
Error in user YAML: (<unknown>): mapping values are not allowed in this context at line 1 column 35
---
description: Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-tos/create-a-new-dns-record
---
```

This section is called a "Front Matter", and must provide metadata via key value pairs formatted in valid YAML. 

This PR encloses value of "description" in quotes to stop it from breaking if more things that look like key-value are sent.

```
---
description: "Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-tos/create-a-new-dns-record"
---
```