### PR TITLE
feat: Improve `image upload` user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## [6.7.0] (XXX 2023)
 
 ### Added
-- Added `cfg logout` command, which iterates through fields in your config file which contain sensitive data and removes their value
-- Added `cfg location` command which prints config file path.
-- Added `cfg whoami` command which prints the authenticated user, with the option (`-p/--provenance`) to print the source and rules/order  of credentials.
-- Added `--ftp-user`, `--ftp-pass` to image upload command, which doesn't support JWT token. They can be used to override auth credentials only for the FTP server.
+- Config:
+  - Added `cfg logout` command, which iterates through fields in your config file which contain sensitive data and removes their value
+  - Added `cfg location` command which prints config file path.
+  - Added `cfg whoami` command which prints the authenticated user, with the option (`-p/--provenance`) to print the source and rules/order  of credentials.
+- Command `image upload`:
+  - Added `--ftp-user`, `--ftp-pass` flags. They can be used to override auth credentials only for the FTP server. Your API credentials are now checked only when necessary (e.g. post-upload operations), and are no longer needed to be valid for the initial FTP upload.
+  - Added a significantly improved documentation and more verbose, detailed errors for this command
 
 ### Changed
 - `ionosctl login` is now deprecated: it will simply call `ionosctl cfg login`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `cfg logout` command, which iterates through fields in your config file which contain sensitive data and removes their value
 - Added `cfg location` command which prints config file path.
 - Added `cfg whoami` command which prints the authenticated user, with the option (`-p/--provenance`) to print the source and rules/order  of credentials.
-
+- Added `--ftp-user`, `--ftp-pass` to image upload command, which doesn't support JWT token. They can be used to override auth credentials only for the FTP server.
 
 ### Changed
 - `ionosctl login` is now deprecated: it will simply call `ionosctl cfg login`.

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -205,6 +205,11 @@ func ImageCmd() *core.Command {
 		CmdRun:     RunImageUpload,
 		InitClient: true,
 	})
+
+	// Username, Password override flags. DO NOT BIND TO VIPER, as the environment variables are linked to some linux things on certain apps, incl. zsh
+	upload.Command.Flags().String(constants.ArgUser, "", "Override username")
+	upload.Command.Flags().String(constants.ArgPassword, "", "Override password")
+
 	upload.AddStringSliceFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, nil, "Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit", core.RequiredFlagOption())
 	upload.AddStringSliceFlag("image", "i", nil, "Slice of paths to images, can be absolute path or relative to current working directory", core.RequiredFlagOption())
 	upload.AddStringFlag("ftp-url", "", "ftp-%s.ionos.com", "URL of FTP server, with %s flag if location is embedded into url")

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -598,10 +598,11 @@ func RunImageUpload(c *core.CommandConfig) error {
 		)
 		die.Die(errMsg.Error())
 	}
-	if ftpUser == "" || ftpPass == "" {
-		cfg := client.Must(errHandler).CloudClient.GetConfig()
-		ftpUser = cfg.Username
-		ftpPass = cfg.Password
+	if ftpUser == "" {
+		ftpUser = client.Must(errHandler).CloudClient.GetConfig().Username
+	}
+	if ftpPass == "" {
+		ftpPass = client.Must(errHandler).CloudClient.GetConfig().Password
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context, time.Duration(viper.GetInt(core.GetFlagName(c.NS, constants.ArgTimeout)))*time.Second)
@@ -640,7 +641,6 @@ func RunImageUpload(c *core.CommandConfig) error {
 			// Catching error from goroutines. https://stackoverflow.com/questions/62387307/how-to-catch-errors-from-goroutines
 			// Uploads each image to each location.
 			eg.Go(func() error {
-
 				err := c.CloudApiV6Services.Images().Upload(
 					c.Context,
 					resources.UploadProperties{

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -266,24 +266,6 @@ func PreRunImageUpload(c *core.PreCommandConfig) error {
 		return err
 	}
 
-	ftpUser := viper.GetString(core.GetFlagName(c.NS, FlagFtpUser))
-	ftpPass := viper.GetString(core.GetFlagName(c.NS, FlagFtpPass))
-
-	errHandler := func(err error) {
-		_ = c.Printer.Warn("Warn: " +
-			fmt.Errorf(
-				"failed trying to use standard client credentials for FTP server: %w",
-				err,
-			).Error(),
-		)
-	}
-	if ftpUser == "" || ftpPass == "" {
-		if client.Must(errHandler).IsTokenAuth() {
-			c.Printer.Warn("Warn: You are using token authentication for your client. FTP connection does not support JWT token")
-			c.Printer.Warn("Warn: You can use --ftp-user and --ftp-pass to override the client's credentials for the FTP server only")
-		}
-	}
-
 	validExts := []string{".iso", ".img", ".vmdk", ".vhd", ".vhdx", ".cow", ".qcow", ".qcow2", ".raw", ".vpc", ".vdi"}
 	images := viper.GetStringSlice(core.GetFlagName(c.NS, FlagImage))
 	invalidImages := functional.Filter(
@@ -375,7 +357,7 @@ func RunImageUpload(c *core.CommandConfig) error {
 
 	errHandler := func(err error) {
 		errMsg := fmt.Errorf(
-			"failed trying to use standard client credentials for FTP server: %w",
+			"failed trying to get client in order to fall back to standard client credentials for FTP server: %w",
 			err,
 		)
 		die.Die(errMsg.Error())

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -211,22 +211,30 @@ func ImageCmd() *core.Command {
 		Verb:      "upload",
 		Aliases:   []string{"ftp-upload", "ftp", "upl"},
 		ShortDesc: "Upload an image to FTP server using FTP over TLS (FTPS)",
-		LongDesc: fmt.Sprintf(`Use this command to securely upload one or more HDD or ISO images to the specified FTP server using FTP over TLS (FTPS). This command supports a variety of options to provide flexibility during the upload process.
-To override your client's (API) credentials, you can use --%s and --%s. Note that, by default, this command will query the '/images' endpoint for your uploaded images, then try to use the PATCH operation to update the uploaded images with the given property fields. It is necessary to use valid API credentials for this. To skip this API behaviour, you can use '--%s'.
+		LongDesc: fmt.Sprintf(`OVERVIEW:
+  Use this command to securely upload one or more HDD or ISO images to the specified FTP server using FTP over TLS (FTPS). This command supports a variety of options to provide flexibility during the upload process:
+  - To override your client's (API) credentials, you can use '--%s' and '--%s', note that if only using only these and not standard auth methods ('ionosctl login'), you may only use this command for FTP uploads.
+  - The command supports renaming the uploaded images with the '--%s' flag. If uploading multiple images, you must provide an alias for each image.
+  - Specify the context deadline for the FTP connection using the '--%s' flag. The operation as a whole will terminate after the specified number of seconds, i.e. if the FTP upload had finished but your PATCH operation did not, only the PATCH operation will be intrerrupted.
 
-This command supports usage of other FTP servers too, not just the default ones. Use the --%s flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url, but be warned that this could expose you to a man-in-the-middle attack. If you're using a self-signed FTP server, you can provide the path to the server certificate file using the --%s flag.
+POST-UPLOAD OPERATIONS:
+  By default, this command will query 'GET /images' endpoint for your uploaded images, then try to use 'PATCH /images/<UUID>' to update the uploaded images with the given property fields.
+  - It is necessary to use valid API credentials for this.
+  - To skip this API behaviour, you can use '--%s'.
 
-For flexibility purposes, the --%s flag is only required if your --%s contains a placeholder variable (i.e. %%s). In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
+CUSTOM URLs:
+  This command supports usage of other FTP servers too, not just the IONOS ones.
+  - The '--%s' flag is only required if your '--%s' contains a placeholder variable (i.e. %%s).
+  In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
+  - Use the '--%s' flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url,
+  but be warned that this could expose you to a man-in-the-middle attack.
+  - If you're using a self-signed FTP server, you can provide the path to the server certificate file using the '--%s' flag.
+`, FlagFtpUser, FlagFtpPass, cloudapiv6.ArgImageAlias, constants.ArgTimeout, FlagSkipUpdate, cloudapiv6.ArgLocation, FlagFtpUrl, FlagSkipVerify, FlagCertificatePath),
+		Example: `- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': Simply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
+- 'ionosctl img u -i kolibri.iso -l fra': Upload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.
 
-The command supports renaming the uploaded images with the --%s flag. However, if you're uploading multiple images, make sure to provide an alias for each image as uploading multiple images with the same alias is forbidden.
-
-You can specify the context deadline for the FTP connection using the --%s flag. The operation as a whole will terminate after the specified number of seconds, i.e. if the FTP upload had finished but your PATCH operation did not, only the PATCH operation will be intrerrupted.
-`, FlagFtpUser, FlagFtpPass, FlagSkipUpdate, FlagSkipVerify, FlagCertificatePath, cloudapiv6.ArgLocation, FlagFtpUrl, cloudapiv6.ArgImageAlias, constants.ArgTimeout),
-		Example: `- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': \t\tSimply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
-- 'ionosctl img u -i kolibri.iso --skip-update --skip-verify --ftp-url ftp://12.34.56.78': \t\tThe same operation, but use your own custom server. Use skip verify to skip checking server's identity
-- 'ionosctl img u -i kolibri.iso -l fra': \t\tUpload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.
-- 'ionosctl img u -i kolibri.iso -l fra --ftp-url ftp://myComplexFTPServer/locations/%s --crt-path certificates/my-servers-cert.crt --location Paris,Berlin,LA,ZZZ --skip-update': \t\tUpload the image to multiple FTP servers, with location embedding into URL.
-`,
+- 'ionosctl img u -i kolibri.iso --skip-update --skip-verify --ftp-url ftp://12.34.56.78': Use your own custom server. Use skip verify to skip checking server's identity
+- 'ionosctl img u -i kolibri.iso -l fra --ftp-url ftp://myComplexFTPServer/locations/%s --crt-path certificates/my-servers-cert.crt --location Paris,Berlin,LA,ZZZ --skip-update': Upload the image to multiple FTP servers, with location embedding into URL.`,
 		PreCmdRun:  PreRunImageUpload,
 		CmdRun:     RunImageUpload,
 		InitClient: true,

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -449,9 +449,11 @@ func PreRunImageUpload(c *core.PreCommandConfig) error {
 	ftpPass := viper.GetString(core.GetFlagName(c.NS, "ftp-pass"))
 
 	errHandler := func(err error) {
-		errMsg := fmt.Errorf(
-			"failed trying to use standard client credentials for FTP server: %w",
-			err,
+		errMsg := c.Printer.Warn("Warn: " +
+			fmt.Errorf(
+				"failed trying to use standard client credentials for FTP server: %w",
+				err,
+			).Error(),
 		)
 		die.Die(errMsg.Error())
 	}

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -219,7 +219,7 @@ CUSTOM URLs:
   In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
   - Use the '--%s' flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url,
   but be warned that this could expose you to a man-in-the-middle attack.
-  - If you're using a self-signed FTP server, you can provide the path to the server certificate file using the '--%s' flag.
+  - If you're using a self-signed FTP server, you can provide the path to the server certificate file in base64 PEM format using the '--%s' flag.
 `, FlagFtpUser, FlagFtpPass, cloudapiv6.ArgImageAlias, constants.ArgTimeout, FlagSkipUpdate, cloudapiv6.ArgLocation, FlagFtpUrl, FlagSkipVerify, FlagCertificatePath),
 		Example: `- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': Simply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
 - 'ionosctl img u -i kolibri.iso -l fra': Upload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.

--- a/docs/subcommands/Compute Engine/image/upload.md
+++ b/docs/subcommands/Compute Engine/image/upload.md
@@ -43,7 +43,7 @@ CUSTOM URLs:
   In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
   - Use the '--skip-verify' flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url,
   but be warned that this could expose you to a man-in-the-middle attack.
-  - If you're using a self-signed FTP server, you can provide the path to the server certificate file using the '--crt-path' flag.
+  - If you're using a self-signed FTP server, you can provide the path to the server certificate file in base64 PEM format using the '--crt-path' flag.
 
 
 ## Options

--- a/docs/subcommands/Compute Engine/image/upload.md
+++ b/docs/subcommands/Compute Engine/image/upload.md
@@ -56,7 +56,7 @@ CUSTOM URLs:
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
       --cpu-hot-plug             'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug (default true)
       --cpu-hot-unplug           'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug
-      --crt-path string          (Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.
+      --crt-path string          (Not needed for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.
   -d, --description string       Description of the Image
       --disc-scsi-hot-plug       'Hot-Plug' SCSI drive (default true)
       --disc-scsi-hot-unplug     'Hot-Unplug' SCSI drive

--- a/docs/subcommands/Compute Engine/image/upload.md
+++ b/docs/subcommands/Compute Engine/image/upload.md
@@ -26,16 +26,24 @@ For `upload` command:
 
 ## Description
 
-Use this command to securely upload one or more HDD or ISO images to the specified FTP server using FTP over TLS (FTPS). This command supports a variety of options to provide flexibility during the upload process.
-To override your client's (API) credentials, you can use --ftp-user and --ftp-pass. Note that, by default, this command will query the '/images' endpoint for your uploaded images, then try to use the PATCH operation to update the uploaded images with the given property fields. It is necessary to use valid API credentials for this. To skip this API behaviour, you can use '--skip-update'.
+OVERVIEW:
+  Use this command to securely upload one or more HDD or ISO images to the specified FTP server using FTP over TLS (FTPS). This command supports a variety of options to provide flexibility during the upload process:
+  - To override your client's (API) credentials, you can use '--ftp-user' and '--ftp-pass', note that if only using only these and not standard auth methods ('ionosctl login'), you may only use this command for FTP uploads.
+  - The command supports renaming the uploaded images with the '--image-alias' flag. If uploading multiple images, you must provide an alias for each image.
+  - Specify the context deadline for the FTP connection using the '--timeout' flag. The operation as a whole will terminate after the specified number of seconds, i.e. if the FTP upload had finished but your PATCH operation did not, only the PATCH operation will be intrerrupted.
 
-This command supports usage of other FTP servers too, not just the default ones. Use the --skip-verify flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url, but be warned that this could expose you to a man-in-the-middle attack. If you're using a self-signed FTP server, you can provide the path to the server certificate file using the --crt-path flag.
+POST-UPLOAD OPERATIONS:
+  By default, this command will query 'GET /images' endpoint for your uploaded images, then try to use 'PATCH /images/<UUID>' to update the uploaded images with the given property fields.
+  - It is necessary to use valid API credentials for this.
+  - To skip this API behaviour, you can use '--skip-update'.
 
-For flexibility purposes, the --location flag is only required if your --ftp-url contains a placeholder variable (i.e. %s). In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
-
-The command supports renaming the uploaded images with the --image-alias flag. However, if you're uploading multiple images, make sure to provide an alias for each image as uploading multiple images with the same alias is forbidden.
-
-You can specify the context deadline for the FTP connection using the --timeout flag. The operation as a whole will terminate after the specified number of seconds, i.e. if the FTP upload had finished but your PATCH operation did not, only the PATCH operation will be intrerrupted.
+CUSTOM URLs:
+  This command supports usage of other FTP servers too, not just the IONOS ones.
+  - The '--location' flag is only required if your '--ftp-url' contains a placeholder variable (i.e. %s).
+  In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
+  - Use the '--skip-verify' flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url,
+  but be warned that this could expose you to a man-in-the-middle attack.
+  - If you're using a self-signed FTP server, you can provide the path to the server certificate file using the '--crt-path' flag.
 
 
 ## Options
@@ -79,10 +87,10 @@ You can specify the context deadline for the FTP connection using the --timeout 
 ## Examples
 
 ```text
-- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': \t\tSimply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
-- 'ionosctl img u -i kolibri.iso --skip-update --skip-verify --ftp-url ftp://12.34.56.78': \t\tThe same operation, but use your own custom server. Use skip verify to skip checking server's identity
-- 'ionosctl img u -i kolibri.iso -l fra': \t\tUpload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.
-- 'ionosctl img u -i kolibri.iso -l fra --ftp-url ftp://myComplexFTPServer/locations/%s --crt-path certificates/my-servers-cert.crt --location Paris,Berlin,LA,ZZZ --skip-update': \t\tUpload the image to multiple FTP servers, with location embedding into URL.
+- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': Simply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
+- 'ionosctl img u -i kolibri.iso -l fra': Upload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.
 
+- 'ionosctl img u -i kolibri.iso --skip-update --skip-verify --ftp-url ftp://12.34.56.78': Use your own custom server. Use skip verify to skip checking server's identity
+- 'ionosctl img u -i kolibri.iso -l fra --ftp-url ftp://myComplexFTPServer/locations/%s --crt-path certificates/my-servers-cert.crt --location Paris,Berlin,LA,ZZZ --skip-update': Upload the image to multiple FTP servers, with location embedding into URL.
 ```
 

--- a/services/cloudapi-v6/resources/image.go
+++ b/services/cloudapi-v6/resources/image.go
@@ -42,6 +42,8 @@ type FTPServerProperties struct {
 	Port              int
 	SkipVerify        bool           // Skip FTP server certificate verification. WARNING man-in-the-middle attack possible
 	ServerCertificate *x509.CertPool // If FTP server uses self signed certificates, put this in tlsConfig. IONOS FTP Servers in prod DON'T need this
+	Username          string
+	Password          string
 }
 
 // ImagesService is a wrapper around ionoscloud.Image

--- a/services/cloudapi-v6/resources/image.go
+++ b/services/cloudapi-v6/resources/image.go
@@ -48,7 +48,6 @@ type FTPServerProperties struct {
 
 // ImagesService is a wrapper around ionoscloud.Image
 type ImagesService interface {
-	Upload(ctx context.Context, properties UploadProperties) error
 	List(params ListQueryParams) (Images, *Response, error)
 	Get(imageId string, params QueryParams) (*Image, *Response, error)
 	Update(imageId string, imgProp ImageProperties, params QueryParams) (*Image, *Response, error)
@@ -69,7 +68,7 @@ func NewImageService(client *client.Client, ctx context.Context) ImagesService {
 	}
 }
 
-func (s *imagesService) Upload(ctx context.Context, p UploadProperties) error {
+func FtpUpload(ctx context.Context, p UploadProperties) error {
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: p.SkipVerify,
 		ServerName:         p.Url,


### PR DESCRIPTION
This PR is based on (uses some functionalities of) #295 

## Overview 

  - Added `--ftp-user`, `--ftp-pass` flags. They can be used to override auth credentials only for the FTP server. Client credentials (API credentials) are now checked only when necessary (e.g. post-upload operations), and are no longer needed to be valid for the initial FTP upload if using these flags.
  - Added a significantly improved documentation and more verbose, detailed errors for this command

## Other things

### Image already exists: Still try to upload it, but use this info to build a more detailed error 
```
 % ionosctl image upload --location fra --image testtest.vdi
Error: failed while uploading testtest.vdi to FTP server: upload data: cmd failed read expected code 1 with message "": failed to read code, got code 550 and message testtest.vdi: Operation not permitted: 550 testtest.vdi: Operation not permitted
Note: testtest.vdi already exists at ftp-fra.ionos.com. Please contact support at support@cloud.ionos.com to delete the old image. We're sorry for the inconvenience
```
### Using no API credentials (not logged in, in any way) and not passing `--skip-update` 
```
 % ionosctl image upload --location fra --ftp-user $myusername --ftp-pass $mypassword --image testest.vdi 

you did not provide valid API credentials and did not use --skip-update. FTP Upload successful, but cannot query 'GET /images' for your uploaded image: failed selecting an auth layer: none of the layers provided a value for either token or username & password. use `ionosctl whoami --provenance` for help
```
Now you can remain logged in with a JWT, and use these flags for this command without modifying your overall configuration. Also treats the case when you would want to use a custom `--ftp-url`, in this case you definitely do not want to use your IONOS credentials.

### FtpUpload is no longer tied to Image Service

Old: `func (s *imagesService) Upload(ctx context.Context, p UploadProperties) error` 

New: `func FtpUpload(ctx context.Context, p UploadProperties) error`


See above point. If it was to remain tightly coupled to ImagesService, I am forced to initialize a valid ApiClient for it. This is in direct conflict with the command's new help text: `To override your client's (API) credentials, you can use '--ftp-user' and '--ftp-pass', note that if only using only these and not standard auth methods ('ionosctl login'), you may only use this command for FTP uploads.`  (I.e. if having a bad API configuration, the command is still supposed to work in 'upload only mode' with these new flags, but tying this command to Image Service would instead force us to have a correct API configuration).

Note that now the services quite literally no longer serve any purpose and we can safely remove ALL of them, by replacing them all with `client.(apiClient).etc`. 



### New help text

```
OVERVIEW:
  Use this command to securely upload one or more HDD or ISO images to the specified FTP server using FTP over TLS (FTPS). This command supports a variety of options to provide flexibility during the upload process:
  - To override your client's (API) credentials, you can use '--ftp-user' and '--ftp-pass', note that if only using only these and not standard auth methods ('ionosctl login'), you may only use this command for FTP uploads.
  - The command supports renaming the uploaded images with the '--image-alias' flag. If uploading multiple images, you must provide an alias for each image.
  - Specify the context deadline for the FTP connection using the '--timeout' flag. The operation as a whole will terminate after the specified number of seconds, i.e. if the FTP upload had finished but your PATCH operation did not, only the PATCH operation will be intrerrupted.

POST-UPLOAD OPERATIONS:
  By default, this command will query 'GET /images' endpoint for your uploaded images, then try to use 'PATCH /images/<UUID>' to update the uploaded images with the given property fields.
  - It is necessary to use valid API credentials for this.
  - To skip this API behaviour, you can use '--skip-update'.

CUSTOM URLs:
  This command supports usage of other FTP servers too, not just the IONOS ones.
  - The '--location' flag is only required if your '--ftp-url' contains a placeholder variable (i.e. %s).
  In this case, for every location in that slice, an attempt of FTP upload would be made at the URL computed by embedding it into the placeholder variable
  - Use the '--skip-verify' flag to skip the verification of the server certificate. This can be useful when using a custom ftp-url,
  but be warned that this could expose you to a man-in-the-middle attack.
  - If you're using a self-signed FTP server, you can provide the path to the server certificate file using the '--crt-path' flag.

EXAMPLES:
- 'ionosctl img u -i kolibri.iso -l fkb,fra,vit --skip-update': Simply upload the image 'kolibri.iso' from the current directory to IONOS FTP servers 'ftp://ftp-fkb.ionos.com/iso-images', 'ftp://ftp-fra.ionos.com/iso-images', 'ftp://ftp-vit.ionos.com/iso-images'.
- 'ionosctl img u -i kolibri.iso -l fra': Upload the image 'kolibri.iso' from the current directory to IONOS FTP server 'ftp://ftp-fra.ionos.com/iso-images'. Once the upload has finished, start querying 'GET /images' with a filter for 'kolibri', to get the UUID of the image as seen by the Images API. When UUID is found, perform a 'PATCH /images/<UUID>' to set the default flag values.

- 'ionosctl img u -i kolibri.iso --skip-update --skip-verify --ftp-url ftp://12.34.56.78': Use your own custom server. Use skip verify to skip checking server's identity
- 'ionosctl img u -i kolibri.iso -l fra --ftp-url ftp://myComplexFTPServer/locations/%s --crt-path certificates/my-servers-cert.crt --location Paris,Berlin,LA,ZZZ --skip-update': Upload the image to multiple FTP servers, with location embedding into URL.


```
