### PR TITLE
fix: DNS API hostUrl workaround

### DIFF
--- a/commands/dns/dns.go
+++ b/commands/dns/dns.go
@@ -17,5 +17,6 @@ func DNSCommand() *core.Command {
 	}
 	cmd.AddCommand(zone.ZoneCommand())
 	cmd.AddCommand(record.RecordCommand())
+
 	return cmd
 }

--- a/commands/dns/dns.go
+++ b/commands/dns/dns.go
@@ -7,6 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	DefaultApiURL = "dns.de-fra.ionos.com"
+)
+
 func DNSCommand() *core.Command {
 	cmd := &core.Command{
 		Command: &cobra.Command{

--- a/commands/root.go
+++ b/commands/root.go
@@ -206,8 +206,11 @@ func addCommands() {
 	// DNS
 
 	funcChangeDefaultApiUrl := func(command *core.Command, newDefault string) *core.Command {
+		// For some reason, this line only changes the help text
 		command.Command.PersistentFlags().StringP(
-			constants.ArgServerUrl, constants.ArgServerUrlShort, newDefault, "Server URL for DNS API")
+			constants.ArgServerUrl, constants.ArgServerUrlShort, newDefault, "Override default host url")
+
+		// If unset, manually set the flag to the new default. SIDE EFFECT: Now, this flag will always be considered "set", within DNS sub commands. Can't find a better alternative
 		command.Command.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 			if !cmd.Flags().Changed(constants.ArgServerUrl) {
 				viper.Set(constants.ArgServerUrl, newDefault)

--- a/docs/subcommands/DNS/record/create.md
+++ b/docs/subcommands/DNS/record/create.md
@@ -31,7 +31,7 @@ Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-to
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Content Type Enabled FQDN State ZoneId ZoneName]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/record/delete.md
+++ b/docs/subcommands/DNS/record/delete.md
@@ -42,7 +42,7 @@ Here, PARTIAL_NAME is a part of the name of the DNS record you want to delete. I
 
 ```text
   -a, --all              Delete all records. You can optionally filter the deleted records using --zone (full name / ID) and --record (partial name)
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Content Type Enabled FQDN State ZoneId ZoneName]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/record/get.md
+++ b/docs/subcommands/DNS/record/get.md
@@ -31,7 +31,7 @@ Retrieve a record
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Content Type Enabled FQDN State ZoneId ZoneName]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/record/list.md
+++ b/docs/subcommands/DNS/record/list.md
@@ -31,7 +31,7 @@ Retrieve all records
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host url (default "dns.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [Id Name Content Type Enabled FQDN State ZoneId ZoneName]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/record/update.md
+++ b/docs/subcommands/DNS/record/update.md
@@ -31,7 +31,7 @@ Partially modify a record's properties. This command uses a combination of GET a
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Content Type Enabled FQDN State ZoneId ZoneName]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/zone/create.md
+++ b/docs/subcommands/DNS/zone/create.md
@@ -31,7 +31,7 @@ Create a zone
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host url (default "dns.de-fra.ionos.com")
       --cols strings         Set of columns to be printed on output 
                              Available columns: [Id Name Description NameServers Enabled State]
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/zone/delete.md
+++ b/docs/subcommands/DNS/zone/delete.md
@@ -32,7 +32,7 @@ Delete a zone
 
 ```text
   -a, --all              Delete all zones. Required or -z
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Description NameServers Enabled State]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/zone/get.md
+++ b/docs/subcommands/DNS/zone/get.md
@@ -31,7 +31,7 @@ Retrieve a zone
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host url (default "dns.de-fra.ionos.com")
       --cols strings     Set of columns to be printed on output 
                          Available columns: [Id Name Description NameServers Enabled State]
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/zone/list.md
+++ b/docs/subcommands/DNS/zone/list.md
@@ -31,7 +31,7 @@ Retrieve zones
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host url (default "dns.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [Id Name Description NameServers Enabled State]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/docs/subcommands/DNS/zone/update.md
+++ b/docs/subcommands/DNS/zone/update.md
@@ -31,7 +31,7 @@ Partially modify a zone's properties. This command uses a combination of GET and
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host url (default "dns.de-fra.ionos.com")
       --cols strings         Set of columns to be printed on output 
                              Available columns: [Id Name Description NameServers Enabled State]
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/die"
@@ -63,14 +62,7 @@ func newClient(name, pwd, token, hostUrl string) (*Client, error) {
 	registryConfig := registry.NewConfiguration(name, pwd, token, hostUrl)
 	registryConfig.UserAgent = appendUserAgent(registryConfig.UserAgent)
 
-	// Hacky workaround for not being able to change defaults of root level flags, in sub-commands.
-	// Rationale: If it is the global default, it probably didn't get changed by the user
-	// FIXME: Replace me with a better alternative. What if the user specifically sets api.ionos.com for DNS ? (Presently, he should get 404, but not sure about future)
-	dnsHostUrl := hostUrl // Absolutely do not use `dnsHostUrl` anywhere other than DNS Configuration
-	if strings.Trim("https://", hostUrl) == strings.Trim("https://", constants.DefaultApiURL) {
-		dnsHostUrl = ""
-	}
-	dnsConfig := dns.NewConfiguration(name, pwd, token, dnsHostUrl)
+	dnsConfig := dns.NewConfiguration(name, pwd, token, hostUrl)
 	dnsConfig.UserAgent = appendUserAgent(dnsConfig.UserAgent)
 
 	return &Client{


### PR DESCRIPTION
Currently, in #287, you aren't able to change the api-url flag, and always the host-url is hardcoded to be `dns.de-fra.ionos.com`, while the help text shows that the default is actually `api.ionos.com`.

This PR implements a workaround to manually set the flag to the desired default, if the flag hasn't changed (is unset), and fixes the discrepancy of the help text and the actually used default value