### PR TITLE
feat: flag completion descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [6.7.0] (XXX 2023)
 
+### Added
+- Commenced the phased introduction of help text for flag completions to improve usability. The enhancements in this release include:
+  - Help text for flag completions in `ionosctl image` command
+  - Help text for flag completions in `ionosctl server cdrom` command
+  - **Note**: We are progressively implementing this feature across all commands.
+
 ### Fixed
 - Deprecated warnings only show if the deprecated flag is being used
+
+
 
 ## [6.6.2] (April 2023)
 

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -27,10 +27,13 @@ func ServerCdromCmd() *core.Command {
 	ctx := context.TODO()
 	serverCdromCmd := &core.Command{
 		Command: &cobra.Command{
-			Use:              "cdrom",
-			Aliases:          []string{"cd"},
-			Short:            "Server CD-ROM Operations",
-			Long:             "The sub-commands of `ionosctl server cdrom` allow you to attach, get, list, detach CD-ROMs from Servers.",
+			Use:     "cdrom",
+			Aliases: []string{"cd"},
+			Short:   "Server CD-ROM Operations",
+			Long: `The sub-commands of 'ionosctl server cdrom' allow you to attach, get, list, detach CD-ROMs from Servers.
+CD-ROMs cannot be created stand-alone like volumes. They are either attached to a server or do not exist. They always have an ISO-Image associated; empty CD-ROMs can not be provisioned. It is possible to attach up to two CD-ROMs to the same server.
+
+WARNING: Attaching a CD-ROM leads to a reset of the server!`,
 			TraverseChildren: true,
 		},
 	}
@@ -49,8 +52,10 @@ func ServerCdromCmd() *core.Command {
 		Resource:  "cdrom",
 		Verb:      "attach",
 		Aliases:   []string{"a"},
-		ShortDesc: "Attach a CD-ROM to a Server",
-		LongDesc: `Use this command to attach a CD-ROM to an existing Server.
+		ShortDesc: "Attach an image CD-ROM to a Server",
+		LongDesc: `Use this command to attach a CD-ROM to an existing Server. It is possible to attach up to two CD-ROMs to the same server.
+
+WARNING: Attaching a CD-ROM leads to a reset of the server!
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -58,7 +63,7 @@ Required values to run command:
 
 * Data Center Id
 * Server Id
-* Cdrom Id`,
+* ID of an Image with type CD-ROM`,
 		Example:    attachCdromServerExample,
 		PreCmdRun:  PreRunDcServerCdromIds,
 		CmdRun:     RunServerCdromAttach,

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"go.uber.org/multierr"
@@ -233,7 +232,7 @@ func RunServerCdromAttach(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 	cdRomId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId))
 	c.Printer.Verbose("CD-ROM with id: %v is attaching to server with id: %v from Datacenter with id: %v... ", cdRomId, serverId, dcId)
-	attachedCdrom, resp, err := client.Must().CloudClient.ServersApi.DatacentersServersCdromsPost().Execute() // c.CloudApiV6Services.Servers().AttachCdrom(dcId, serverId, cdRomId, queryParams)
+	attachedCdrom, resp, err := c.CloudApiV6Services.Servers().AttachCdrom(dcId, serverId, cdRomId, queryParams)
 	if resp != nil && printer.GetId(resp) != "" {
 		c.Printer.Verbose(constants.MessageRequestInfo, printer.GetId(resp), resp.RequestTime)
 	}

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -914,3 +914,29 @@ func sortImagesByTime(images resources.Images, n int) resources.Images {
 	}
 	return images
 }
+
+type Filter func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest
+
+// ImagesE returns all images matching the given filters
+func ImagesE(fs ...Filter) (ionoscloud.Images, error) {
+	req := client.Must().CloudClient.ImagesApi.ImagesGet(context.Background())
+
+	for _, f := range fs {
+		req = f(req)
+	}
+
+	ls, _, err := req.Execute()
+	if err != nil {
+		return ionoscloud.Images{}, err
+	}
+	return ls, nil
+}
+
+// Images returns all images matching the given filters
+func Images(fs ...Filter) ionoscloud.Images {
+	imgs, err := ImagesE(fs...)
+	if err != nil {
+		return ionoscloud.Images{}
+	}
+	return imgs
+}


### PR DESCRIPTION
Adds help text describing what each completion value is, e.g.

```
 % ionosctl server cdrom attach --datacenter-id 2b9bcc46-bb46-41c0-aaa4-6e60aa51bda7 --server-id 48e5f0d7-2f19-459f-a85b-2400dc8cc728 --cdrom-id (tab)
Completing completions
010a8c06-6028-11ed-a67c-fe6d461d20e1  -- ClearOS-DVD-x86_64_7.7.0.iso (fr/par):
012cf206-09d5-11ed-b441-96ff36bbb3ad  -- windows-VirtIO-drivers-1.217-1.iso (us/ewr): windows:virtiodriver_iso
018b05d4-59ed-11e9-b7e8-525400f64d8d  -- Microsoft-SQL-2017-full-trial-english.iso (de/fra): mssql:2017_trial_iso
```