### PR TITLE
fix #310: camelcase filters key bug

### DIFF
--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -7,7 +7,6 @@ package query
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
@@ -39,7 +38,6 @@ const FiltersPartitionChar = "="
 //
 // by MANUALLY setting the flag values, as well as the viper (global config) values.
 func ValidateFilters(c *core.PreCommandConfig, availableFilters []string, usageFilters string) error {
-	log.Printf("before: %s\n", viper.Get(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)))
 	filtersKV, err := getFilters(viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)), c.Command)
 	if err != nil {
 		return err
@@ -78,8 +76,6 @@ func ValidateFilters(c *core.PreCommandConfig, availableFilters []string, usageF
 	viper.Set(core.GetFlagName(c.NS, cloudapiv6.ArgFilters), setString)
 	_ = c.Command.Command.Flags().Set(cloudapiv6.ArgFilters, setString)
 	// End hacky workaround
-
-	log.Printf("after: %s\n", viper.Get(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)))
 
 	return nil
 }

--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -23,8 +23,11 @@ import (
 const FiltersPartitionChar = "="
 
 // ValidateFilters is currently being used in PreRun to check if the user provided any invalid filters
-// availableFilters is set by the caller to be the properties of the struct (e.g. Name, Description, etc) with the first letter non-caps
+// availableFilters is set by the caller to be the properties of the struct (e.g. Name, Description, etc) with the first letter non-caps, by using the SDK generated structs.
 // usageFilters is the usage string printed to output if the usage is wrong
+//
+// WARNING: It just so happens that we can find the `availableFilters` by using the SDK structs namings with non-caps first letter,
+// but if the SDK struct fields naming were to change, then we would be forced to refactor the whole file commands/cloudapi/completer/filters.go
 //
 // HACKY WORKAROUND WARNING: To work around the fact that we don't have access to availableFilters after this func's
 // execution ends, and to keep support for 'any caps notation for properties is valid' rule e.g naME=myserver

--- a/commands/cloudapi-v6/query/query_params.go
+++ b/commands/cloudapi-v6/query/query_params.go
@@ -7,6 +7,7 @@ package query
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
@@ -22,19 +23,36 @@ import (
 
 const FiltersPartitionChar = "="
 
+// ValidateFilters is currently being used in PreRun to check if the user provided any invalid filters
+// availableFilters is set by the caller to be the properties of the struct (e.g. Name, Description, etc) with the first letter non-caps
+// usageFilters is the usage string printed to output if the usage is wrong
+//
+// HACKY WORKAROUND WARNING: To work around the fact that we don't have access to availableFilters after this func's
+// execution ends, and to keep support for 'any caps notation for properties is valid' rule e.g naME=myserver
+// is a valid input, this func 'corrects' the caps of all keys that are valid. For example,
+//
+//	'--filters NAME=myserver,NAME=otherserver,imagetype=LINUX'
+//
+// would be corrected to
+//
+//	'--filters name=myserver,name=otherserver,imageType=LINUX'
+//
+// by MANUALLY setting the flag values, as well as the viper (global config) values.
 func ValidateFilters(c *core.PreCommandConfig, availableFilters []string, usageFilters string) error {
+	log.Printf("before: %s\n", viper.Get(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)))
 	filtersKV, err := getFilters(viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)), c.Command)
 	if err != nil {
 		return err
 	}
 	c.Printer.Verbose("Validating %v filters...", len(filtersKV))
 	invalidFilters := make([]string, 0)
-	for filterKey, _ := range filtersKV {
-		if !isValidFilter(filterKey, availableFilters) {
-			c.Printer.Verbose("Invalid Filter: %s", filterKey)
-			invalidFilters = append(invalidFilters, filterKey)
-		} else {
-			c.Printer.Verbose("Valid Filter: %s", filterKey)
+	correctedFilters := make(map[string][]string, 0)
+	for key, vals := range filtersKV {
+		validFilter, err := isValidFilter(key, availableFilters) // filterKey with proper caps
+		correctedFilters[validFilter] = append(correctedFilters[validFilter], vals...)
+		if err != nil {
+			c.Printer.Verbose("Invalid Filter: %s", key)
+			invalidFilters = append(invalidFilters, key)
 		}
 	}
 	if len(invalidFilters) > 0 {
@@ -48,6 +66,21 @@ func ValidateFilters(c *core.PreCommandConfig, availableFilters []string, usageF
 			),
 		)
 	}
+
+	// Hacky workaround
+	setString := ""
+	for k, v := range correctedFilters {
+		for _, vals := range v {
+			setString += fmt.Sprintf("%s%s%s ", k, FiltersPartitionChar, vals)
+		}
+	}
+	setString = fmt.Sprintf("%s", strings.TrimSuffix(setString, " "))
+	viper.Set(core.GetFlagName(c.NS, cloudapiv6.ArgFilters), setString)
+	_ = c.Command.Command.Flags().Set(cloudapiv6.ArgFilters, setString)
+	// End hacky workaround
+
+	log.Printf("after: %s\n", viper.Get(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)))
+
 	return nil
 }
 
@@ -94,7 +127,7 @@ func getFilters(args []string, cmd *core.Command) (map[string][]string, error) {
 	for _, arg := range args {
 		if strings.Contains(arg, FiltersPartitionChar) {
 			kv := strings.Split(arg, FiltersPartitionChar)
-			filtersKV[strings.ToLower(kv[0])] = append(filtersKV[strings.ToLower(kv[0])], kv[1])
+			filtersKV[kv[0]] = append(filtersKV[kv[0]], kv[1])
 		} else {
 			return filtersKV, errors.New(
 				fmt.Sprintf("\"%s --filters\" option set incorrectly.\n\nUsage: %s --filters KEY1%sVALUE1,KEY2%sVALUE2\n\nFor more details, see '%s --help'.",
@@ -112,15 +145,15 @@ func getFilters(args []string, cmd *core.Command) (map[string][]string, error) {
 
 // isValidFilter will return true if the filter is part
 // of the available filters array and false if is not.
-func isValidFilter(filter string, availableFiltersObjs ...[]string) bool {
+func isValidFilter(filter string, availableFiltersObjs ...[]string) (string, error) {
 	for _, availableFilters := range availableFiltersObjs {
 		for _, availableFilter := range availableFilters {
 			if strings.ToLower(availableFilter) == strings.ToLower(filter) {
-				return true
+				return availableFilter, nil
 			}
 		}
 	}
-	return false
+	return "", fmt.Errorf("TODO")
 }
 
 func pluralize(word string, number int) string {


### PR DESCRIPTION
Fixes #310 - keys being set to lowercase, and as such, filters for keys such as `imageType` don't work, CLI sends `imagetype` to API  

Hacky fix, we manually overwrite the `--filters` values to change keys to those expected by API (by using `availableFilters`). for some reason, `getFilters` doesn't have access to `availableFilters`

The optimal fix would have been to  add `availableFilters` as an argument to `getFilters`, but this would involve touching code in every single command that uses filters /  refactoring this file: https://github.com/ionos-cloud/ionosctl/blob/master/commands/cloudapi-v6/completer/filters.go - both would take a lot of work.

in any case, this PR simply hides the technical debt a bit better rather than being a permanent fix - now it is implied that GetListQueryParams is called after ValidateFilters. We definitely must address this so that these funcs do not have any side effects - honestly we should just use a single function in `Run`