### PR TITLE
fix: manually add properties of nested RequestStatusMetadata to RequestsFilters

### DIFF
--- a/commands/cloudapi-v6/completer/filters.go
+++ b/commands/cloudapi-v6/completer/filters.go
@@ -126,11 +126,11 @@ func LoadbalancersFiltersUsage() string {
 }
 
 func RequestsFilters() []string {
-	return getPropertiesName(ionoscloud.RequestProperties{}, ionoscloud.RequestMetadata{})
+	return getPropertiesName(ionoscloud.RequestProperties{}, ionoscloud.RequestMetadata{}, ionoscloud.RequestStatusMetadata{})
 }
 
 func RequestsFiltersUsage() string {
-	return getFilterUsage(getPropertiesName(ionoscloud.RequestProperties{}), getPropertiesName(ionoscloud.RequestMetadata{}))
+	return getFilterUsage(getPropertiesName(ionoscloud.RequestProperties{}), getPropertiesName(ionoscloud.RequestMetadata{}, ionoscloud.RequestStatusMetadata{}))
 }
 
 func UsersFilters() []string {

--- a/docs/subcommands/Compute Engine/request/list.md
+++ b/docs/subcommands/Compute Engine/request/list.md
@@ -31,7 +31,7 @@ Use this command to list all Requests on your account.
 You can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.
 Available Filters:
 * filter by property: [body headers method url]
-* filter by metadata: [createdBy createdDate etag requestStatus]
+* filter by metadata: [createdBy createdDate etag requestStatus etag message status]
 
 ## Options
 


### PR DESCRIPTION
Some filters for Requests weren't available. The way the current implementation works, is that we manually add each resource's available filters by iterating through the SDK struct properties and adding them as available filters

The fix in this PR adds the nested object `RequestStatusMetadata` 