### PR TITLE
fix: remove hardcoded INTEL_SKYLAKE for creating cubes

### DIFF
--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -971,8 +971,20 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 
 	// CUBE Server Properties
 	if viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgType)) == serverCubeType {
-		// Right now, for the CUBE Server - only INTEL_SKYLAKE is supported
-		input.SetCpuFamily("INTEL_SKYLAKE")
+		input.ServerProperties.CpuFamily = nil
+		if fn := core.GetFlagName(c.NS, constants.FlagCpuFamily); viper.IsSet(fn) {
+			// NOTE 19.07.2023:
+			// In the past, all CUBE servers had to have "INTEL_SKYLAKE" as a CPU Family.
+			// As such, INTEL_SKYLAKE was hardcoded as the CpuFamily field.
+			//
+			// However, something changed on the API side, and started throwing errs if Cpu Family was set:
+			// `[VDC-5-1921] The attribute 'cpuFamily' must not be provided for Cube servers.`
+			//
+			// I will allow the user to modify this field, but only if the flag is explicitly set,
+			// in case the API changes back to its old state in the future
+
+			input.SetCpuFamily(viper.GetString(fn))
+		}
 		if !input.HasName() {
 			input.SetName("Unnamed Cube")
 		}

--- a/commands/cloudapi-v6/server_test.go
+++ b/commands/cloudapi-v6/server_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/ionos-cloud/ionosctl/v6/internal/pointer"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
@@ -506,7 +507,38 @@ func TestRunServerCreateCube(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
 		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCubeCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
+		sentServer := serverCubeCreate
+		sentServer.Properties.CpuFamily = nil
+		expectedServer := s
+		expectedServer.Properties.CpuFamily = nil
+		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
+		err := RunServerCreate(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRunServerCreateCubeExplicitCpuFamily(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+		viper.Reset()
+		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+		viper.Set(constants.ArgQuiet, false)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgType), testServerCubeType)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), "AMD_OPTERON")
+		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
+		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+		sentServer := serverCubeCreate
+		sentServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
+		expectedServer := s
+		expectedServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
+		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
 		err := RunServerCreate(cfg)
 		assert.NoError(t, err)
 	})
@@ -529,7 +561,11 @@ func TestRunServerCreateCubeImgAlias(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
 		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCubeCreateImg, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
+		sentServer := serverCubeCreateImg
+		sentServer.Properties.CpuFamily = nil
+		expectedServer := s
+		s.Properties.CpuFamily = nil
+		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
 		err := RunServerCreate(cfg)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
In the past, all CUBE servers had to have "INTEL_SKYLAKE" as a CPU Family. As such, INTEL_SKYLAKE was hardcoded as the CpuFamily field. something changed on the API side, and API started throwing errs if Cpu Family was set: `[VDC-5-1921] The attribute 'cpuFamily' must not be provided for Cube servers.`

This PR removes the hardcoded value, now this field will be nil if the flag is not set - but still allows the user to modify this field, in case the API returns to its old state in the future 