### PR TITLE
feat: auto generated and random postfix for server names

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,7 @@ const (
 	FlagIdShort         = "i"
 	FlagName            = "name"
 	FlagNameShort       = "n"
+	FlagGenerateName    = "generate-name"
 	FlagTemplateId      = "template-id"
 	FlagInstances       = "instances"
 	FlagMaintenanceTime = "maintenance-time"
@@ -99,6 +100,7 @@ const (
 const (
 	DefaultApiURL         = "https://api.ionos.com"
 	DefaultConfigFileName = "/config.json"
+	DefaultGenerateName   = false
 	DefaultOutputFormat   = "text"
 	DefaultWait           = false
 	DefaultTimeoutSeconds = int(60)


### PR DESCRIPTION
## What does this fix or implement?

Create a random postfix of 8 characters for server names. This is implemented with the "--generate-name" flag. The name and implementation are similar to kubernetes.

## Rational

I noticed that names in a datacenter are not unique to resources, which is different from what I come to expect from other platforms (e.g. Kubernetes, Azure, GCP).
It also means that names carry less additional value, e.g. I can't do `ionosctl server get -n test-server-1 --dataceneter-id test-id`.
Using auto-generated postfixes makes this shortcoming more explicit.

To be honest, the optimal solution would be to enforce unique name+resource combinations inside a datacenter on the server. 

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
