### PR TITLE
fix: change dataplatform cluster default version to 23.4

### DIFF
--- a/commands/dataplatform/cluster/create.go
+++ b/commands/dataplatform/cluster/create.go
@@ -68,7 +68,7 @@ func ClusterCreateCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return fake.Names(10), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringVarFlag(createProperties.DataPlatformVersion, constants.FlagVersion, "", "22.11", "The version of your cluster")
+	cmd.AddStringVarFlag(createProperties.DataPlatformVersion, constants.FlagVersion, "", "23.4", "The version of your cluster")
 	cmd.AddStringVarFlag(createProperties.DatacenterId, constants.FlagDatacenterId, constants.FlagIdShort, "", "The ID of the connected datacenter")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagDatacenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersIds(nil), cobra.ShellCompDirectiveNoFileComp

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
@@ -52,7 +52,7 @@ The cluster will be provisioned in the datacenter matching the provided datacent
   -q, --quiet                     Quiet output
   -t, --timeout int               Timeout option for Request [seconds] (default 60)
   -v, --verbose                   Print step-by-step process when running command
-      --version string            The version of your cluster (default "22.11")
+      --version string            The version of your cluster (default "23.4")
   -w, --wait-for-request          Wait for the Request to be executed
 ```
 


### PR DESCRIPTION
seems like 22.11 is no longer supported. 

```
Error: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"dsaas-o-422","message":"request not possible because: the version '22.11' is not available anymore"}]}
```


also, setting field to nil results in API choosing a bad version anyway:


```
Error: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"dsaas-o-691","message":"version 1.1.0 is not a valid version from '22.06, 22.09, 22.11, 23.4'"}]}
```

 so this PR explicitly sets 23.4 as a default