### PR TITLE
fix: completions for DNS if api url set to api.ionos.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [v6.6.5] (July 2023)
 
 ### Fixed
-* Changed `dataplatform cluster create --version` to 23.4 as 22.11 is no longer supported
+* Changed default for `dataplatform cluster create --version` to 23.4 as 22.11 is no longer supported
+* Fixed a bug for DNS completions regarding overriding the default value for `api-url`
 * Fixed filters breaking for camelcase properties (e.g. `imageAlias`)
 * Fixed missing filters for `RequestStatusMetadata` for command `request list` i.e. now you can also filter by `message, status`
 * Removed the hardcoded `INTEL_SKYLAKE` value for `CPU_FAMILY` if creating a CUBE server. Now, by default for CUBE servers, this field is sent as nil to the API.

--- a/commands/dns/record/record.go
+++ b/commands/dns/record/record.go
@@ -3,7 +3,6 @@ package record
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/zone"
@@ -121,9 +120,10 @@ func RecordsProperty[V any](f func(dns.RecordRead) V, fs ...Filter) []V {
 // Records returns all records matching the given filters
 func Records(fs ...Filter) (dns.RecordReadList, error) {
 	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); strings.Trim(url, "https://") == strings.Trim(constants.DefaultApiURL, "https://") {
+	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
 		viper.Set(constants.ArgServerUrl, "")
 	}
+
 	req := client.Must().DnsClient.RecordsApi.RecordsGet(context.Background())
 
 	for _, f := range fs {

--- a/commands/dns/record/record.go
+++ b/commands/dns/record/record.go
@@ -3,9 +3,11 @@ package record
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/zone"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/spf13/viper"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
@@ -118,6 +120,10 @@ func RecordsProperty[V any](f func(dns.RecordRead) V, fs ...Filter) []V {
 
 // Records returns all records matching the given filters
 func Records(fs ...Filter) (dns.RecordReadList, error) {
+	// Hack to enforce the dns-level flag default for API URL on the completions too
+	if url := config.GetServerUrl(); strings.Trim(url, "https://") == strings.Trim(constants.DefaultApiURL, "https://") {
+		viper.Set(constants.ArgServerUrl, "")
+	}
 	req := client.Must().DnsClient.RecordsApi.RecordsGet(context.Background())
 
 	for _, f := range fs {

--- a/commands/dns/zone/zone.go
+++ b/commands/dns/zone/zone.go
@@ -104,7 +104,7 @@ func makeZonePrintObj(data ...dns.ZoneRead) []map[string]interface{} {
 // Zones returns all zones matching the given filters
 func Zones(fs ...Filter) (dns.ZoneReadList, error) {
 	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); strings.Trim(url, "https://") == strings.Trim(constants.DefaultApiURL, "https://") {
+	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
 		viper.Set(constants.ArgServerUrl, "")
 	}
 

--- a/commands/dns/zone/zone.go
+++ b/commands/dns/zone/zone.go
@@ -9,11 +9,13 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
+	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/printer"
 	dns "github.com/ionos-cloud/sdk-go-dns"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func ZoneCommand() *core.Command {
@@ -101,6 +103,11 @@ func makeZonePrintObj(data ...dns.ZoneRead) []map[string]interface{} {
 
 // Zones returns all zones matching the given filters
 func Zones(fs ...Filter) (dns.ZoneReadList, error) {
+	// Hack to enforce the dns-level flag default for API URL on the completions too
+	if url := config.GetServerUrl(); strings.Trim(url, "https://") == strings.Trim(constants.DefaultApiURL, "https://") {
+		viper.Set(constants.ArgServerUrl, "")
+	}
+
 	req := client.Must().DnsClient.ZonesApi.ZonesGet(context.Background())
 
 	for _, f := range fs {


### PR DESCRIPTION
Fixes a bug in which DNS completions wouldn't work if the server URL is set to `api.ionos.com`. Seems like our dns-level flag default for `api-url` doesn't get set if calling completions from this namespace