### PR TITLE
fix: Don't rewrap JSON output

### DIFF
--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -73,9 +73,7 @@ func (p *JSONPrinter) write(out io.Writer, v interface{}) error {
 			return err
 		}
 	default:
-		var msg DefaultMsgPrint
-		msg.Message = v
-		err := WriteJSON(&msg, out)
+		err := WriteJSON(v, out)
 		if err != nil {
 			return err
 		}
@@ -179,10 +177,6 @@ func (p *TextPrinter) GetStderr() io.Writer {
 
 func (p *TextPrinter) SetStderr(writer io.Writer) {
 	p.Stderr = writer
-}
-
-type DefaultMsgPrint struct {
-	Message interface{} `json:"Message,omitempty"`
 }
 
 type ToPrint struct {

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -93,9 +93,7 @@ func TestPrinterPrintStandardResultJson(t *testing.T) {
 func TestPrinterPrintDefaultJson(t *testing.T) {
 	var (
 		b   bytes.Buffer
-		str = `{
-  "Message": "command executed"
-}`
+		str = `"command executed"`
 	)
 	viper.Set(constants.ArgOutput, "json")
 	viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)


### PR DESCRIPTION
## What does this fix or implement?

The CLI rewraps any output that's not a `Result` in a dummy struct for marshalling.
As a user, I would expect `-o json` to be the "raw" version of the response from the server, i.e. without omitting or adding any extra fields.
Adding some indent is fine, since it's a CLI which is likely used by humans.

Consider this example to get the newest available k8s version:

```
curl ... https://api.ionos.com/cloudapi/v6/k8s/versions | jq -r '. | first'
ionosctl k8s version list -o json | jq -r '.Message | first'
```

It can be somewhat confusing for new users of `ionosctl` if the output differs in such a slight way.

This is somewhat related to https://github.com/ionos-cloud/ionosctl/issues/249, but I have no issues with the `items` approach that was implemented.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [X] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [X] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
