### PR TITLE
fix: permanent `--cols` fix

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -127,6 +127,12 @@ func init() {
 		"Print step-by-step process when running command",
 	)
 	_ = viper.BindPFlag(constants.ArgVerbose, rootPFlagSet.Lookup(constants.ArgVerbose))
+	rootPFlagSet.StringSlice(
+		constants.ArgCols, nil, "Case insensitively limit table columns to those mentioned in this flag. "+
+			"ignores non-existing columns",
+	)
+	_ = viper.BindPFlag(constants.ArgCols, rootPFlagSet.Lookup(constants.ArgCols))
+	_ = viper.BindEnv(constants.ArgCols, constants.EnvCols)
 
 	// Add SubCommands to RootCmd
 	addCommands()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -86,6 +86,7 @@ const (
 	ArgTimeout             = "timeout"
 	ArgTimeoutShort        = "t"
 	ArgCols                = "cols"
+	EnvCols                = "IONOSCTL_CUSTOM_COLUMNS"
 	ArgUpdates             = "updates"
 	ArgToken               = "token"
 	ArgTokenShort          = "t"

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -69,6 +69,9 @@ func (p *JSONPrinter) write(out io.Writer, v interface{}) error {
 	switch v.(type) {
 	case Result:
 		result := v.(Result)
+		if customCols := viper.GetStringSlice(constants.ArgCols); len(customCols) > 0 {
+			result.Filter(customCols)
+		}
 		if err := result.PrintJSON(out); err != nil {
 			return err
 		}
@@ -128,6 +131,9 @@ func (p *TextPrinter) write(out io.Writer, v interface{}) error {
 	switch v.(type) {
 	case Result:
 		result := v.(Result)
+		if customCols := viper.GetStringSlice("test"); len(customCols) > 0 {
+			result.Filter(customCols)
+		}
 		if err := result.PrintText(out, p.NoHeaders); err != nil {
 			return err
 		}

--- a/pkg/printer/result.go
+++ b/pkg/printer/result.go
@@ -33,16 +33,19 @@ type Result struct {
 	ApiResponse *resources.Response
 }
 
-// Filter limits the Result's columns to those specified in the parameter
+// Filter case insensitively limits the Result's columns to those specified in the parameter
 // and ignores column names from `cols` that are non-existent in r.Columns
 // an empty `cols` will result in no filter being applied.
-func (r *Result) Filter(cols []string) {
-	if cols == nil || len(cols) == 0 {
+func (r *Result) Filter(customCols []string) {
+	if customCols == nil || len(customCols) == 0 {
 		return
 	}
 
-	r.Columns = functional.Filter(cols, func(col string) bool {
-		return slices.Contains(r.Columns, col)
+	allColumnsLowercase := functional.Map(r.Columns, func(col string) string {
+		return strings.ToLower(col)
+	})
+	r.Columns = functional.Filter(customCols, func(customColumn string) bool {
+		return slices.Contains(allColumnsLowercase, strings.ToLower(customColumn))
 	})
 
 	// Keep old behaviour of nil slices if empty

--- a/pkg/printer/result_test.go
+++ b/pkg/printer/result_test.go
@@ -100,3 +100,85 @@ string   1     1.123000   true   a,b
 `
 	assert.Equal(t, expectOut, buf.String())
 }
+
+func TestResult_Filter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		fields     Result
+		customCols []string
+		expected   Result
+	}{
+		{
+			name:       "Empty Fields Filter",
+			fields:     Result{},
+			customCols: []string{"a"},
+			expected:   Result{},
+		},
+		{
+			name: "No Filter - nil",
+			fields: Result{
+				Columns: []string{"a", "b"},
+			},
+			customCols: nil,
+			expected: Result{
+				Columns: []string{"a", "b"},
+			},
+		},
+		{
+			name: "All Columns Exist",
+			fields: Result{
+				Columns: []string{"a", "b", "c"},
+			},
+			customCols: []string{"a", "b"},
+			expected: Result{
+				Columns: []string{"a", "b"},
+			},
+		},
+		{
+			name: "Some Columns Do Not Exist",
+			fields: Result{
+				Columns: []string{"a", "b"},
+			},
+			customCols: []string{"a", "c"},
+			expected: Result{
+				Columns: []string{"a"},
+			},
+		},
+		{
+			name: "No Columns Exist",
+			fields: Result{
+				Columns: []string{"a", "b"},
+			},
+			customCols: []string{"c", "d"},
+			expected: Result{
+				Columns: nil,
+			},
+		},
+		{
+			name: "Empty Custom Cols should return original columns",
+			fields: Result{
+				Columns: []string{"a", "b"},
+			},
+			customCols: []string{},
+			expected: Result{
+				Columns: []string{"a", "b"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fields.Filter(tt.customCols)
+			type SimplerStructForComprehensiveError struct {
+				cols []string
+			}
+			assert.Equal(t,
+				SimplerStructForComprehensiveError{
+					cols: tt.expected.Columns,
+				}, SimplerStructForComprehensiveError{
+					cols: tt.fields.Columns,
+				},
+			)
+		})
+	}
+}


### PR DESCRIPTION
#### Changes

A permanent fix for issues like #333 

Moves `--cols` to global root-level flags. Adds a `result.Filter` func to filter out the columns automatically upon writing the result - as such, `GetHeaders`, `GetHeadersAllDefault`, etc. should now just be concerned with retrieving the SDK property fields and shouldn't be concerned with filtering the columns anymore - and probably they can be refactored down to a single func.
 

#### Status

This is blocked by https://github.com/spf13/cobra/blob/main/completions.go#L133 - We can't access the root command (upon which --cols is now defined) inside of deeper commands and register completions for it - even though that func should imo be defined on a lesser scope e.g. `c.Flag()` in Cobra in the first place.

I think we need to bite the bullet already and fork Cobra - since our implementation diverged a bit from its ideal usage, certain "features" are blockers for us.

This PR is not complete. TODO LIST:

0. Fork cobra. Add `flagObject.RegisterCompletions` in favor of existing cobra `command.RegisterCompletions` (we can't reference the root command in child commands)
1. result.Filter should handle `--all` (use `r.KeyValue`'s keys.)
2. All duplicated `--cols` flags should be removed - keep the "RegisterFlagCompletion" calls to only handle completions with a new func added to our future Cobra fork (defined on Flag obj rather than Command obj)
3. Remove column filter functionality from`result`'s pkg `GetHeaders`, `GetHeadersAllDefault` etc, do they need to be removed completely?
4. Injected printer pkg caller should use the correct viper key (`--cols` rather than `--test`)