### PR TITLE
fix: change dataplatform default version to 23.7

### DIFF
--- a/commands/dataplatform/cluster/create.go
+++ b/commands/dataplatform/cluster/create.go
@@ -68,7 +68,7 @@ func ClusterCreateCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return fake.Names(10), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringVarFlag(createProperties.DataPlatformVersion, constants.FlagVersion, "", "23.4", "The version of your cluster")
+	cmd.AddStringVarFlag(createProperties.DataPlatformVersion, constants.FlagVersion, "", "23.7", "The version of your cluster")
 	cmd.AddStringVarFlag(createProperties.DatacenterId, constants.FlagDatacenterId, constants.FlagIdShort, "", "The ID of the connected datacenter")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagDatacenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersIds(nil), cobra.ShellCompDirectiveNoFileComp

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -53,7 +53,7 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries). Minimum of 3 for enterprise edition (default 1)
       --lan-id string             The numeric LAN ID with which you connect your cluster (required)
   -l, --location string           The physical location where the cluster will be created. (defaults to the location of the connected datacenter)
-      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Monday")
+      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Tuesday")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "11:00:00")
   -n, --name string               The name of your cluster (required)
       --no-headers                When using text output, don't print headers

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
@@ -52,7 +52,7 @@ The cluster will be provisioned in the datacenter matching the provided datacent
   -q, --quiet                     Quiet output
   -t, --timeout int               Timeout option for Request [seconds] (default 60)
   -v, --verbose                   Print step-by-step process when running command
-      --version string            The version of your cluster (default "23.4")
+      --version string            The version of your cluster (default "23.7")
   -w, --wait-for-request          Wait for the Request to be executed
 ```
 


### PR DESCRIPTION
version 23.4 is no longer available

```
Error: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"dsaas-o-422","message":"request not possible because: the version '23.4' is not available anymore"}]}
```


also, setting field to nil still results in API choosing a bad version anyway:


```
Error: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"dsaas-o-691","message":"version 1.1.0 is not a valid version from '22.06, 22.09, 22.11, 23.4, 23.7'"}]}
```

 so this PR explicitly sets 23.7 as a default