### PR TITLE
fix #349: api url env var

### DIFF
--- a/commands/dns/dns.go
+++ b/commands/dns/dns.go
@@ -7,10 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	DefaultApiURL = "dns.de-fra.ionos.com"
-)
-
 func DNSCommand() *core.Command {
 	cmd := &core.Command{
 		Command: &cobra.Command{

--- a/commands/root.go
+++ b/commands/root.go
@@ -221,7 +221,7 @@ func addCommands() {
 		return command
 	}
 
-	rootCmd.AddCommand(funcChangeDefaultApiUrl(dns.DNSCommand(), dns.DefaultApiURL))
+	rootCmd.AddCommand(funcChangeDefaultApiUrl(dns.DNSCommand(), constants.DefaultDnsApiURL))
 }
 
 const helpTemplate = `USAGE: {{if .Runnable}}

--- a/commands/root.go
+++ b/commands/root.go
@@ -212,9 +212,11 @@ func addCommands() {
 
 		// If unset, manually set the flag to the new default. SIDE EFFECT: Now, this flag will always be considered "set", within DNS sub commands. Can't find a better alternative
 		command.Command.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-			if !cmd.Flags().Changed(constants.ArgServerUrl) {
-				viper.Set(constants.ArgServerUrl, newDefault)
+			setVal := newDefault
+			if val, _ := cmd.Flags().GetString(constants.ArgServerUrl); val != "" {
+				setVal = val
 			}
+			viper.Set(constants.ArgServerUrl, setVal)
 		}
 		return command
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/die"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/config"
+
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 	certmanager "github.com/ionos-cloud/sdk-go-cert-manager"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,6 @@ func GetServerUrl() string {
 	}
 	if cfgVal := viper.GetString(constants.ServerUrl); viper.IsSet(constants.ServerUrl) {
 		// 3. Fallback to non-empty cfg field
-		fmt.Println("cfg val: " + cfgVal)
 		return cfgVal
 	}
 	// 4. Return empty string. SDKs should handle it, per docs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
-
 	cloudv6 "github.com/ionos-cloud/sdk-go/v6"
 
 	"github.com/spf13/viper"
@@ -38,7 +38,7 @@ func GetServerUrl() string {
 	viper.AutomaticEnv()
 	if flagVal := viper.GetString(constants.ArgServerUrl); viper.IsSet(constants.ArgServerUrl) {
 		// 1. Above all, use global flag val
-		if flagVal != "dns.de-fra.ionos.com" {
+		if !strings.Contains(flagVal, constants.DefaultDnsApiURL) {
 			// Workaround for changing the default for dns namepsace and still allowing this to be customized via env var / cfg
 			return flagVal
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ func GetServerUrl() string {
 	}
 	if cfgVal := viper.GetString(constants.ServerUrl); viper.IsSet(constants.ServerUrl) {
 		// 3. Fallback to non-empty cfg field
+		fmt.Println("cfg val: " + cfgVal)
 		return cfgVal
 	}
 	// 4. Return empty string. SDKs should handle it, per docs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,15 +36,18 @@ func GetUserData() map[string]string {
 //	  so, a very natural reaction to this is checking the next chain variables yourself or leaving it blank - which creates a ton of technical debt and code duplication, or unpredictable behaviour for the user
 func GetServerUrl() string {
 	viper.AutomaticEnv()
-	if flagVal := viper.GetString(constants.ArgServerUrl); flagVal != "" {
-		// 1. Above all, use if the global flag is set
-		return flagVal
+	if flagVal := viper.GetString(constants.ArgServerUrl); viper.IsSet(constants.ArgServerUrl) {
+		// 1. Above all, use global flag val
+		if flagVal != "dns.de-fra.ionos.com" {
+			// Workaround for changing the default for dns namepsace and still allowing this to be customized via env var / cfg
+			return flagVal
+		}
 	}
-	if envVal := viper.GetString(constants.EnvServerUrl); envVal != "" {
+	if envVal := viper.GetString(constants.EnvServerUrl); viper.IsSet(constants.EnvServerUrl) {
 		// 2. Fallback to non-empty env vars
 		return envVal
 	}
-	if cfgVal := viper.GetString(constants.ServerUrl); cfgVal != "" {
+	if cfgVal := viper.GetString(constants.ServerUrl); viper.IsSet(constants.ServerUrl) {
 		// 3. Fallback to non-empty cfg field
 		return cfgVal
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -101,6 +101,7 @@ const (
 // Defaults
 const (
 	DefaultApiURL         = "https://api.ionos.com"
+	DefaultDnsApiURL      = "dns.de-fra.ionos.com"
 	DefaultConfigFileName = "/config.json"
 	DefaultOutputFormat   = "text"
 	DefaultWait           = false


### PR DESCRIPTION
fixes #349: `IONOS_API_URL` being overriden by default flag values