### PR TITLE
feat: whoami

### DIFF
--- a/commands/cfg/cfg.go
+++ b/commands/cfg/cfg.go
@@ -17,5 +17,6 @@ func ConfigCmd() *core.Command {
 	cmd.AddCommand(LocationCmd())
 	cmd.AddCommand(LoginCmd())
 	cmd.AddCommand(LogoutCmd())
+	cmd.AddCommand(WhoamiCmd())
 	return cmd
 }

--- a/commands/cfg/cfg_test.go
+++ b/commands/cfg/cfg_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package cfg_test
 
 import (

--- a/commands/cfg/cfg_test.go
+++ b/commands/cfg/cfg_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package cfg_test
 
 import (
@@ -228,7 +225,7 @@ func TestAuthCmds(t *testing.T) {
 		assert.Equal(t, before[constants.CfgServerUrl], after[constants.CfgServerUrl])
 	})
 
-	// TODO: Move to location_test
+	// cfg location tests
 	t.Run("cfg location cmd returns valid location", func(t *testing.T) {
 		cfgLocCmd := cfg.LocationCmd()
 		out := &bytes.Buffer{}
@@ -238,6 +235,22 @@ func TestAuthCmds(t *testing.T) {
 
 		assert.Equal(t, config.GetConfigFile(), out.String())
 	})
+
+	// cfg whoami tests
+	t.Run("cfg whoami returns current user - Env Username & Password", func(t *testing.T) {
+		cmd := cfg.WhoamiCmd()
+
+		viper.Set(core.GetFlagName(cmd.NS, constants.ArgUser), GoodUsername)
+		viper.Set(core.GetFlagName(cmd.NS, constants.ArgPassword), GoodPassword)
+
+		out := &bytes.Buffer{}
+		cmd.Command.SetOut(out)
+		err := cmd.Command.Execute()
+		assert.NoError(t, err)
+
+		assert.Contains(t, out.String(), GoodUsername)
+	})
+
 }
 
 func setup() error {

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -41,13 +41,15 @@ ionosctl cfg whoami --provenance`,
 			if fn := core.GetFlagName(c.NS, FlagProvenance); authErr != nil || viper.GetBool(fn) {
 				var out string
 				if authErr != nil {
-					out = "Note: Authentication failed!\n"
+					out = "Note: Authentication failed!"
+					if cl.UsedLayer() == nil {
+						out += " None of the authentication layers had a token, or both username & password set."
+					}
+					out += "\n"
 				}
 				out += "Authentication layers, in order of priority:\n"
 				for i, layer := range client.ConfigurationPriorityRules {
-					fmt.Println(cl.UsedLayer)
-					fmt.Println(layer)
-					if layer == cl.UsedLayer {
+					if cl.UsedLayer() != nil && *cl.UsedLayer() == layer {
 						out += fmt.Sprintf("* [%d] %s (USED)\n", i+1, layer.Description)
 						if cl.IsTokenAuth() {
 							out += "    - Using token for authentication.\n"

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -63,10 +63,8 @@ ionosctl cfg whoami --provenance`,
 
 			// -- Below this point, we are 100% certain the client is using valid credentials. --
 
-			token := cl.CloudClient.GetConfig().Token
-			if client.TestCreds("", "", token) != nil {
-				// Valid token
-				usernameViaToken, err := jwt.Username(token)
+			if cl.IsTokenAuth() {
+				usernameViaToken, err := jwt.Username(cl.CloudClient.GetConfig().Token)
 				if err != nil {
 					return fmt.Errorf("failed getting username via token: %w", err)
 				}

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -30,28 +30,27 @@ If no token is present, the command will fall back to using the username and pas
 ionosctl cfg whoami --provenance`,
 		PreCmdRun: core.NoPreRun,
 		CmdRun: func(c *core.CommandConfig) error {
-			cl, err := client.Get()
+			cl, authErr := client.Get()
 
-			if fn := core.GetFlagName(c.NS, constants.FlagProvenance); err != nil || viper.GetBool(fn) {
-				return handleProvenance(c, cl, err)
+			if fn := core.GetFlagName(c.NS, constants.FlagProvenance); authErr != nil || viper.GetBool(fn) {
+				return handleProvenance(c, cl, authErr)
 			}
 
 			// - - - Below this point, we are sure that client.Get() has returned a valid client object.
 
 			if !cl.IsTokenAuth() {
 				// Handle Username & Password Authentication
-				_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), cl.CloudClient.GetConfig().Username)
+				_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), cl.CloudClient.GetConfig().Username)
 				return err
 			}
 
 			// Handle token authentication
 			usernameViaToken, jwtParseErr := jwt.Username(cl.CloudClient.GetConfig().Token)
 			if jwtParseErr != nil {
-				return fmt.Errorf("failed getting username via token: %w", err)
+				return fmt.Errorf("failed getting username via token: %w", jwtParseErr)
 			}
-			_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), usernameViaToken)
+			_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), usernameViaToken)
 			return err
-
 		},
 		InitClient: false,
 	})

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -1,0 +1,87 @@
+package cfg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	"github.com/ionos-cloud/ionosctl/v6/internal/jwt"
+	"github.com/spf13/viper"
+
+	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
+)
+
+func WhoamiCmd() *core.Command {
+
+	const (
+		FlagProvenance      = "provenance"
+		FlagProvenanceShort = "p"
+	)
+
+	cmd := core.NewCommand(context.Background(), nil, core.CommandBuilder{
+		Verb:      "whoami",
+		ShortDesc: "Tells you who you are logged in as. Use `--provenance` to debug where your credentials are being used from",
+		LongDesc: fmt.Sprintf(`This command will tell you the email of the user you are logged in as.
+You can use '--provenance' flag to see which of these sources are being used.
+If using a token, it will use the JWT's claims payload to find out your user UUID, then use the Users API on that UUID to find out your e-mail address.
+If no token is present, the command will fall back to using the username and password for authentication.
+
+%s`, constants.DescAuthenticationOrder),
+		Example: `ionosctl cfg whoami
+ionosctl cfg whoami --provenance`,
+		PreCmdRun: core.NoPreRun,
+		CmdRun: func(c *core.CommandConfig) error {
+			cl, err := client.Get()
+
+			// Does user want to see provenance of his configuration? i.e. where does each key get its value from.
+			if fn := core.GetFlagName(c.NS, FlagProvenance); viper.GetBool(fn) {
+				out := "Authentication layers, in order of priority:\n"
+				for i, layer := range client.ConfigurationPriorityRules {
+					if layer == cl.UsedLayer {
+						out += fmt.Sprintf("* [%d] %s (USED)\n", i+1, layer.Description)
+						if cl.IsTokenAuth() {
+							out += "    - Using token for authentication.\n"
+						} else {
+							out += "    - Using username and password for authentication.\n"
+						}
+					} else {
+						out += fmt.Sprintf("  [%d] %s\n", i+1, layer.Description)
+					}
+				}
+				_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), out)
+				return err
+			}
+
+			// Get Client error. Intentionally handled after provenance rule prints
+			if err != nil {
+				return err
+			}
+
+			// -- Below this point, we are 100% certain the client is using valid credentials. --
+
+			token := cl.CloudClient.GetConfig().Token
+			if client.TestCreds("", "", token) != nil {
+				// Valid token
+				usernameViaToken, err := jwt.Username(token)
+				if err != nil {
+					return fmt.Errorf("failed getting username via token: %w", err)
+				}
+				_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), usernameViaToken)
+				return err
+			}
+
+			// -- Below this point, we are 100% certain the client is using valid username & password. --
+
+			_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), cl.CloudClient.GetConfig().Username)
+			return err
+
+		},
+		InitClient: false,
+	})
+
+	cmd.AddBoolFlag(FlagProvenance, FlagProvenanceShort, false, "If set, the command prints the layers of authentication sources, their order of priority, and which one was used. It also tells you if a token or username and password are being used for authentication.")
+
+	return cmd
+}

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -34,13 +34,13 @@ If no token is present, the command will fall back to using the username and pas
 ionosctl cfg whoami --provenance`,
 		PreCmdRun: core.NoPreRun,
 		CmdRun: func(c *core.CommandConfig) error {
-			cl, err := client.Get()
+			cl, authErr := client.Get()
 
 			// Does user want to see provenance of his configuration? i.e. where does each key get its value from.
 			// Also, if failed getting client, print provenance.
-			if fn := core.GetFlagName(c.NS, FlagProvenance); err != nil || viper.GetBool(fn) {
+			if fn := core.GetFlagName(c.NS, FlagProvenance); authErr != nil || viper.GetBool(fn) {
 				var out string
-				if err != nil {
+				if authErr != nil {
 					out = "Note: Authentication failed!\n"
 				}
 				out += "Authentication layers, in order of priority:\n"
@@ -57,7 +57,7 @@ ionosctl cfg whoami --provenance`,
 						out += fmt.Sprintf("  [%d] %s\n", i+1, layer.Description)
 					}
 				}
-				_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), out)
+				_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), out)
 				return err
 			}
 
@@ -76,7 +76,7 @@ ionosctl cfg whoami --provenance`,
 
 			// -- Below this point, we are 100% certain the client is using valid username & password. --
 
-			_, err = fmt.Fprintln(c.Command.Command.OutOrStdout(), cl.CloudClient.GetConfig().Username)
+			_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), cl.CloudClient.GetConfig().Username)
 			return err
 
 		},

--- a/commands/cfg/whoami.go
+++ b/commands/cfg/whoami.go
@@ -45,6 +45,8 @@ ionosctl cfg whoami --provenance`,
 				}
 				out += "Authentication layers, in order of priority:\n"
 				for i, layer := range client.ConfigurationPriorityRules {
+					fmt.Println(cl.UsedLayer)
+					fmt.Println(layer)
 					if layer == cl.UsedLayer {
 						out += fmt.Sprintf("* [%d] %s (USED)\n", i+1, layer.Description)
 						if cl.IsTokenAuth() {

--- a/commands/dns/dns_integration_test.go
+++ b/commands/dns/dns_integration_test.go
@@ -47,9 +47,7 @@ func TestDNSCommands(t *testing.T) {
 func setup() error {
 	if GoodToken = os.Getenv("IONOS_TOKEN"); GoodToken != "" {
 		cl = client.NewClient("", "", GoodToken, "")
-		if cl.TestCreds() != nil {
-			return nil
-		}
+		return nil
 	}
 
 	// Otherwise, generate a token, since DNS doesn't function without it, only with username & password
@@ -74,7 +72,7 @@ func setup() error {
 	GoodToken = *tok.Token
 	tokCreationTime = time.Now().In(time.UTC).Add(-10 * time.Second)
 
-	cl = client.NewClient("", "", *tok.Token, "")
+	cl = client.NewClient("", "", GoodToken, "")
 
 	return nil
 }

--- a/commands/dns/dns_integration_test.go
+++ b/commands/dns/dns_integration_test.go
@@ -47,7 +47,9 @@ func TestDNSCommands(t *testing.T) {
 func setup() error {
 	if GoodToken = os.Getenv("IONOS_TOKEN"); GoodToken != "" {
 		cl = client.NewClient("", "", GoodToken, "")
-		return nil
+		if cl.TestCreds() != nil {
+			return nil
+		}
 	}
 
 	// Otherwise, generate a token, since DNS doesn't function without it, only with username & password
@@ -72,7 +74,7 @@ func setup() error {
 	GoodToken = *tok.Token
 	tokCreationTime = time.Now().In(time.UTC).Add(-10 * time.Second)
 
-	cl = client.NewClient("", "", GoodToken, "")
+	cl = client.NewClient("", "", *tok.Token, "")
 
 	return nil
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -163,7 +163,6 @@ func initConfig() {
 // AddCommands adds sub commands to the base command.
 func addCommands() {
 	rootCmd.AddCommand(VersionCmd())
-
 	// cfg
 	rootCmd.AddCommand(cfg.ConfigCmd())
 	// Config namespace commands are also available via the root command, but are hidden

--- a/docs/subcommands/Compute Engine/config/whoami.md
+++ b/docs/subcommands/Compute Engine/config/whoami.md
@@ -1,0 +1,53 @@
+---
+description: "Tells you who you are logged in as. Use `--provenance` to debug where your credentials are being used from"
+---
+
+# ConfigWhoami
+
+## Usage
+
+```text
+ionosctl config whoami [flags]
+```
+
+## Aliases
+
+For `config` command:
+
+```text
+[cfg]
+```
+
+## Description
+
+This command will tell you the email of the user you are logged in as.
+You can use '--provenance' flag to see which of these sources are being used. Note that If authentication fails, this flag is set by default.
+If using a token, it will use the JWT's claims payload to find out your user UUID, then use the Users API on that UUID to find out your e-mail address.
+If no token is present, the command will fall back to using the username and password for authentication.
+
+ionosctl uses a layered approach for authentication, prioritizing sources in this order:
+  1. Global flags
+  2. Environment variables
+  3. Config file entries
+Within each layer, a token takes precedence over a username and password combination. For instance, if a token and a username/password pair are both defined in environment variables, ionosctl will prioritize the token. However, higher layers can override the use of a token from a lower layer. For example, username and password environment variables will supersede a token found in the config file.
+
+## Options
+
+```text
+  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
+  -f, --force            Force command to execute without user input
+  -h, --help             Print usage
+  -o, --output string    Desired output format [text|json] (default "text")
+  -p, --provenance       If set, the command prints the layers of authentication sources, their order of priority, and which one was used. It also tells you if a token or username and password are being used for authentication.
+  -q, --quiet            Quiet output
+  -v, --verbose          Print step-by-step process when running command
+```
+
+## Examples
+
+```text
+ionosctl cfg whoami
+ionosctl cfg whoami --provenance
+```
+

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -49,6 +49,7 @@
         * [location](subcommands%2FCompute%20Engine%2Fconfig%2Flocation.md)
         * [login](subcommands%2FCompute%20Engine%2Fconfig%2Flogin.md)
         * [logout](subcommands%2FCompute%20Engine%2Fconfig%2Flogout.md)
+        * [whoami](subcommands%2FCompute%20Engine%2Fconfig%2Fwhoami.md)
     * contract
         * [get](subcommands%2FCompute%20Engine%2Fcontract%2Fget.md)
     * datacenter

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -63,8 +63,7 @@ func Get() (*Client, error) {
 			return
 		}
 
-		instance = newClient(values["username"], values["password"], values["token"], values["serverUrl"])
-		instance.UsedLayer = usedLayer
+		instance = newClient(values["username"], values["password"], values["token"], values["serverUrl"], &usedLayer)
 
 		if err := instance.TestCreds(); err != nil {
 			getClientErr = errors.Join(getClientErr, fmt.Errorf("failed creating client: %w", err))
@@ -99,11 +98,11 @@ func Must(ehs ...func(error)) *Client {
 
 // NewClient bypasses the singleton check, not recommended for normal use.
 func NewClient(name, pwd, token, hostUrl string) *Client {
-	return newClient(name, pwd, token, hostUrl)
+	return newClient(name, pwd, token, hostUrl, nil)
 }
 
 func TestCreds(user, pass, token string) error {
-	cl := newClient(user, pass, token, constants.DefaultApiURL)
+	cl := newClient(user, pass, token, constants.DefaultApiURL, nil)
 	return cl.TestCreds()
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -22,7 +22,7 @@ func selectAuthLayer(layers []Layer) (values map[string]string, usedLayer Layer,
 		username := viper.GetString(layer.UsernameKey)
 		password := viper.GetString(layer.PasswordKey)
 
-		if token != "" || username != "" && password != "" {
+		if token != "" || (username != "" && password != "") {
 			return map[string]string{
 				"token":    token,
 				"username": username,

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -37,8 +37,15 @@ func (c *Client) IsTokenAuth() bool {
 	return c.CloudClient.GetConfig().Token != ""
 }
 
+func (c *Client) UsedLayer() *Layer {
+	if c == nil || c.usedLayer == nil {
+		return nil
+	}
+	return c.usedLayer
+}
+
 type Client struct {
-	UsedLayer Layer // i.e. which auth layer are we using. Flags / Env Vars / Config File
+	usedLayer *Layer // i.e. which auth layer are we using. Flags / Env Vars / Config File
 
 	CloudClient        *cloudv6.APIClient
 	AuthClient         *sdkgoauth.APIClient
@@ -54,7 +61,7 @@ func appendUserAgent(userAgent string) string {
 	return fmt.Sprintf("%v_%v", viper.GetString(constants.CLIHttpUserAgent), userAgent)
 }
 
-func newClient(name, pwd, token, hostUrl string) *Client {
+func newClient(name, pwd, token, hostUrl string, usedLayer *Layer) *Client {
 	clientConfig := cloudv6.NewConfiguration(name, pwd, token, hostUrl)
 	clientConfig.UserAgent = appendUserAgent(clientConfig.UserAgent)
 	// Set Depth Query Parameter globally
@@ -90,5 +97,6 @@ func newClient(name, pwd, token, hostUrl string) *Client {
 		DataplatformClient: dataplatform.NewAPIClient(dpConfig),
 		RegistryClient:     registry.NewAPIClient(registryConfig),
 		DnsClient:          dns.NewAPIClient(dnsConfig),
+		usedLayer:          usedLayer,
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,8 @@ func GetServerUrl() string {
 }
 
 // GetServerUrlOrApiIonos calls GetServerUrl and returns https://api.ionos.com if empty
+//
+// It is a useful func for informing the user of the behaviour of the SDKs - For the SDKs if the server URL is empty, they will default to https://api.ionos.com
 func GetServerUrlOrApiIonos() string {
 	if val := GetServerUrl(); val != "" {
 		return val

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,14 @@ func GetServerUrl() string {
 	return ""
 }
 
+// GetServerUrlOrApiIonos calls GetServerUrl and returns https://api.ionos.com if empty
+func GetServerUrlOrApiIonos() string {
+	if val := GetServerUrl(); val != "" {
+		return val
+	}
+	return constants.DefaultApiURL
+}
+
 func GetConfigFile() string {
 	if fn := constants.ArgConfig; viper.IsSet(fn) {
 		return viper.GetString(fn)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,9 +42,9 @@ func TestRead(t *testing.T) {
 			name:     "should return an error when the file has invalid permissions",
 			filename: "bad-permissions.json",
 			data:     `{"key":"value"}`,
-			perm:     0700,
+			perm:     0777,
 			wantErr:  true,
-			errMsg:   "expected 600, got 700",
+			errMsg:   "expected 600, got 777",
 		},
 		{
 			name:     "should return an error when the file has invalid json",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,6 +20,12 @@ const (
 	FlagLocation        = "location"
 	FlagLocationShort   = "l"
 	FlagOffset          = "offset"
+	// DescAuthenticationOrder explains auth order. Embed this in any auth-related commands
+	DescAuthenticationOrder = `ionosctl uses a layered approach for authentication, prioritizing sources in this order:
+  1. Global flags
+  2. Environment variables
+  3. Config file entries
+Within each layer, a token takes precedence over a username and password combination. For instance, if a token and a username/password pair are both defined in environment variables, ionosctl will prioritize the token. However, higher layers can override the use of a token from a lower layer. For example, username and password environment variables will supersede a token found in the config file.`
 	FlagMaxResults      = "max-results"
 	FlagMaxResultsShort = "M"
 	FlagCidr            = "cidr"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -149,4 +149,7 @@ const (
 	CfgPassword  = "userdata.password"
 
 	CLIHttpUserAgent = "cli-user-agent"
+
+	FlagProvenance      = "provenance"
+	FlagProvenanceShort = "p"
 )


### PR DESCRIPTION
Introduces a command for debugging authentication:

Valid credentials - Username is printed. In case of Token auth, the JWT is parsed and Users API used to find the username.
```
 % i cfg whoami   
alex[...]@[...].com
```

No credentials provided:
```
 % i whoami    
Note: Authentication failed! None of the authentication layers had a token, or both username & password set.
Authentication layers, in order of priority:
  [1] Global Flags (--token)
  [2] Environment Variables (IONOS_TOKEN, IONOS_USERNAME, IONOS_PASSWORD)
  [3] Config file settings (userdata.token, userdata.name, userdata.password)
```

Invalid credentials - shows used layer and whether using token or username & password:
```
 % i whoami
Note: Authentication failed!
Authentication layers, in order of priority:
  [1] Global Flags (--token)
* [2] Environment Variables (IONOS_TOKEN, IONOS_USERNAME, IONOS_PASSWORD) (USED)
    - Using token for authentication.
    - Using https://api.ionos.com as the API URL.
  [3] Config file settings (userdata.token, userdata.name, userdata.password)
```

Valid credentials and `--provenance`:
```
 % i cfg whoami -p  
Authentication layers, in order of priority:
  [1] Global Flags (--token)
* [2] Environment Variables (IONOS_TOKEN, IONOS_USERNAME, IONOS_PASSWORD) (USED)
    - Using username and password for authentication.
    - Using https://api.ionos.com as the API URL.
  [3] Config file settings (userdata.token, userdata.name, userdata.password)
```



