### PR TITLE
fix #359: image patch 

### DIFF
--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -147,7 +147,7 @@ func ImageCmd() *core.Command {
 		command.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Image")
 		command.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Image")
 		command.AddSetFlag(cloudapiv6.ArgLicenceType, "", "UNKNOWN", constants.EnumLicenceType, "The OS type of this image")
-		command.AddSetFlag("cloud-init", "", "V1", []string{"V1", "NONE"}, "Cloud init compatibility")
+		command.AddSetFlag(constants.FlagCloudInit, "", "V1", []string{"V1", "NONE"}, "Cloud init compatibility")
 		command.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", true, "'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
 		command.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", true, "'Hot-Plug' RAM")
 		command.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", true, "'Hot-Plug' NIC")
@@ -350,9 +350,17 @@ func DeleteAllNonPublicImages(c *core.CommandConfig) error {
 }
 
 // returns an ImageProperties object which reflects the currently set flags
-func getDesiredImageAfterPatch(c *core.CommandConfig) resources.ImageProperties {
+func getDesiredImageAfterPatch(c *core.CommandConfig, useUnsetFlags bool) resources.ImageProperties {
 	input := resources.ImageProperties{}
-	c.Command.Command.Flags().VisitAll(func(flag *pflag.Flag) {
+
+	// flagTraverser is a reference to the pflag function that traverses the flags.
+	// The specific function (either `Visit` or `VisitAll`) is determined by the `useUnsetFlags` argument.
+	flagTraverser := c.Command.Command.Flags().Visit
+	if useUnsetFlags {
+		flagTraverser = c.Command.Command.Flags().VisitAll
+	}
+
+	flagTraverser(func(flag *pflag.Flag) {
 		val := flag.Value.String()
 		if val == "" {
 			return
@@ -417,7 +425,7 @@ func RunImageUpdate(c *core.CommandConfig) error {
 	}
 	queryParams := listQueryParams.QueryParams
 
-	input := getDesiredImageAfterPatch(c)
+	input := getDesiredImageAfterPatch(c, false)
 	img, resp, err := c.CloudApiV6Services.Images().Update(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)),
 		input,
@@ -638,7 +646,7 @@ func RunImageUpload(c *core.CommandConfig) error {
 		return fmt.Errorf("failed updating image with given properties, but uploading to FTP sucessful: %w", err)
 	}
 
-	properties := getDesiredImageAfterPatch(c)
+	properties := getDesiredImageAfterPatch(c, true)
 	imgs, err := updateImagesAfterUpload(c, diffImgs, properties)
 	if err != nil {
 		return fmt.Errorf("failed updating image with given properties, but uploading to FTP sucessful: %w", err)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,6 +54,8 @@ const (
 	FlagTtl         = "ttl"
 	FlagPriority    = "priority"
 	FlagType        = "type"
+
+	FlagCloudInit = "cloud-init"
 )
 
 // Flag descriptions. Prefixed with "Desc" for easy find and replace


### PR DESCRIPTION
Fixes #359. `image update` shouldn't look at values of unset flags.

This PR uses `pflag.Visit` and `pflag.VisitAll`. In the case of `image upload`, we actually want the unset flags to act as default values for the image, and as such, in this case we use `VisitAll`.