### PR TITLE
fix: default depth of 2 for requests list

### DIFF
--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -61,7 +61,7 @@ func RequestCmd() *core.Command {
 		return []string{"POST", "PUT", "DELETE", "PATCH", "CREATE", "UPDATE"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, int32(2), cloudapiv6.ArgDepthDescription)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsFilters(), cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
It is confusing for the user why the status column is missing. If the user is unaware of the existance of `--depth` flag he might not understand why these columns are blank.

Before:
```
 % i request list -M 1
RequestId                              CreatedDate                     Method   Status   Message   Targets
aa723d65-f963-46ec-9685-0481af014ede   2023-09-13 15:18:42 +0000 UTC   POST                        
```

After:
```
 % i request list -M 1
RequestId                              CreatedDate                     Method   Status   Message                                  Targets
aa723d65-f963-46ec-9685-0481af014ede   2023-09-13 15:18:42 +0000 UTC   POST     DONE     Request has been successfully executed   datacenter, ,6308abd0-443f-4980-bc24-8c977e737b76, 
```
