### PR TITLE
fix: doc rand defaults

### DIFF
--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -53,8 +53,8 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries). Minimum of 3 for enterprise edition (default 1)
       --lan-id string             The numeric LAN ID with which you connect your cluster (required)
   -l, --location string           The physical location where the cluster will be created. (defaults to the location of the connected datacenter)
-      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Friday")
-      --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "12:00:00")
+      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
+      --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of your cluster (required)
       --no-headers                When using text output, don't print headers
   -o, --output string             Desired output format [text|json] (default "text")

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -53,8 +53,8 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries). Minimum of 3 for enterprise edition (default 1)
       --lan-id string             The numeric LAN ID with which you connect your cluster (required)
   -l, --location string           The physical location where the cluster will be created. (defaults to the location of the connected datacenter)
-      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Monday")
-      --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "15:00:00")
+      --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Friday")
+      --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "12:00:00")
   -n, --name string               The name of your cluster (required)
       --no-headers                When using text output, don't print headers
   -o, --output string             Desired output format [text|json] (default "text")

--- a/pkg/doc/doc.go
+++ b/pkg/doc/doc.go
@@ -178,7 +178,7 @@ func determineSubdir(name string, nonComputeNamespaces map[string]string) string
 func writeDoc(cmd *core.Command, w io.Writer) error {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("Panic occurred for command path: %s\n", cmd.Command.CommandPath())
+			fmt.Printf("Panic occurred for command path %s: %+v\n", cmd.Command.CommandPath(), r)
 		}
 	}()
 

--- a/pkg/doc/flag.go
+++ b/pkg/doc/flag.go
@@ -1,0 +1,28 @@
+package doc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FlagDefaultHandler is a Strategy for handling pflag default values while generating docs
+type FlagDefaultHandler func(flagDescription, defaultValue string) string
+
+// MaintenanceHandler is a concrete strategy for --maintenance-day
+func MaintenanceHandler(flagDescription, defaultValue string) string {
+	fmt.Printf("Using MaintenanceHandler for %s, %s!! \n", flagDescription, defaultValue)
+	panic(fmt.Sprintf("Using MaintenanceHandler for %s, %s!! \n", flagDescription, defaultValue))
+	if strings.Contains(flagDescription, "Defaults to a random day") {
+		return "Mon-Fri 10:00-16:00"
+	}
+	return defaultValue
+}
+
+func getStrategyForFlag(flagName string) FlagDefaultHandler {
+	switch flagName {
+	case "--maintenance-day", "--maintenance-time":
+		return MaintenanceHandler
+	default:
+		return nil
+	}
+}

--- a/pkg/doc/flag.go
+++ b/pkg/doc/flag.go
@@ -1,7 +1,6 @@
 package doc
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -10,17 +9,15 @@ type FlagDefaultHandler func(flagDescription, defaultValue string) string
 
 // MaintenanceHandler is a concrete strategy for --maintenance-day
 func MaintenanceHandler(flagDescription, defaultValue string) string {
-	fmt.Printf("Using MaintenanceHandler for %s, %s!! \n", flagDescription, defaultValue)
-	panic(fmt.Sprintf("Using MaintenanceHandler for %s, %s!! \n", flagDescription, defaultValue))
 	if strings.Contains(flagDescription, "Defaults to a random day") {
-		return "Mon-Fri 10:00-16:00"
+		return "Random (Mon-Fri 10:00-16:00)"
 	}
 	return defaultValue
 }
 
 func getStrategyForFlag(flagName string) FlagDefaultHandler {
 	switch flagName {
-	case "--maintenance-day", "--maintenance-time":
+	case "maintenance-day", "maintenance-time":
 		return MaintenanceHandler
 	default:
 		return nil


### PR DESCRIPTION
Add a strategy pattern handler for generating docs based on pflag defaults.

For DBaaS Mongo there was a random value generated for `--maintenance-day` and `--maintenance-time` which would always fial the doc diff checker workflow, because of differences in the generated value. 

Now, for flags `--maintenance-day` and `--maintenance-time` which contain `"Defaults to a random day"` in their flag description (as dictated by the new strategy implemented here), the generated flag value in the documentation will always be `"Random (Mon-Fri 10:00-16:00)"`
