### PR TITLE
chore: [no ci] add mockgen notice to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 .PHONY: mocks
 mocks:
 	@echo "--- Update mocks ---"
-	@echo "--- Ensure gomock is up to date. `go install github.com/golang/mock/mockgen@v1.6.0` ---"
+	@echo "--- Ensure gomock is up to date. Run: 'go install github.com/golang/mock/mockgen@v1.6.0' ---"
 	@tools/mocks.sh && echo "DONE"
 
 .PHONY: docs generate-docs

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:
 .PHONY: mocks
 mocks:
 	@echo "--- Update mocks ---"
+	@echo "--- Ensure gomock is up to date. `go install github.com/golang/mock/mockgen@v1.6.0` ---"
 	@tools/mocks.sh && echo "DONE"
 
 .PHONY: docs generate-docs


### PR DESCRIPTION
Generating mocks with an out of date `mockgen` tool would result in lots of unreadable errors/panics seemingly originated from go's std lib. I added this notice so that you don't need to dig through scripts/tools to rule out possibly responsible faults.