### PR TITLE
enhancement: CI run integration tests only on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   test:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     outputs:
       package-name: ${{ env.package-name }}
@@ -40,19 +40,15 @@ jobs:
         env:
           IONOS_USERNAME: ${{ secrets.IONOS_USERNAME }}
           IONOS_PASSWORD: ${{ secrets.IONOS_PASSWORD }}
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            make test
-          fi
+        run: make test
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run only unit tests on Windows
         env:
           IONOS_USERNAME: ${{ secrets.IONOS_USERNAME }}
           IONOS_PASSWORD: ${{ secrets.IONOS_PASSWORD }}
-        run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            make utest
-          fi
+        run: make utest
+        if: matrix.os == 'windows-latest'
 
       - name: Build
         run: make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     outputs:
       package-name: ${{ env.package-name }}
@@ -36,11 +36,23 @@ jobs:
         run: make gofmt_check
         if: matrix.os == 'ubuntu-latest'
 
-      - name: Run tests
+      - name: Run all tests on Ubuntu
         env:
           IONOS_USERNAME: ${{ secrets.IONOS_USERNAME }}
           IONOS_PASSWORD: ${{ secrets.IONOS_PASSWORD }}
-        run: make test
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            make test
+          fi
+
+      - name: Run only unit tests on Windows
+        env:
+          IONOS_USERNAME: ${{ secrets.IONOS_USERNAME }}
+          IONOS_PASSWORD: ${{ secrets.IONOS_PASSWORD }}
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            make utest
+          fi
 
       - name: Build
         run: make build


### PR DESCRIPTION
Changes  Windows CI to run only the unit test suite. Ubuntu still runs all tests.

Running two concurrent integration test suites is a waste of resources considering that there is no difference in OS behaviour for these tests.