### PR TITLE
fix: If diff in generated docs, display 'make docs' rather than actually running this directive

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check for differences
         run: |
           if ! git diff --quiet; then
-            echo "There are differences in the generated documentation. Run `make docs` to fix."
+            echo "There are differences in the generated documentation. Run 'make docs' to fix."
             git diff
             exit 1
           fi


### PR DESCRIPTION
If  the `Docs` workflow detects differences in the generated documentation, the call-to-action message should tell the user to run `make docs`. However in the past this would actually cause this directive to run, and the output would be something like:

Before:
```
There are differences in the generated documentation. Run --- Purging docs ---
rm -rf docs/subcommands
touch docs/summary.md
rm docs/summary.md
--- Regenerating docs --- to fix.
```

After:
```
There are differences in the generated documentation. Run 'make docs' to fix.
```