### PR TITLE
fix: delete firewallrules 404, 405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [T.B.D]
+### Fixed
+* Fixed 404 on firewallrule delete command: flag values not properly sent to API
+
 ## [v6.6.10] (September 2023)
 ### Fixed
 * Fixed #359: `image update` using unset flags.

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -511,13 +511,13 @@ func RunFirewallRuleDelete(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	datacenterId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgDataCenterId))
-	serverId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgServerId))
-	nicId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgNicId))
+	datacenterId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
+	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
+	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 	fruleId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirewallRuleId))
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		if err := DeleteAllFirewallRuses(c); err != nil {
+		if err := DeleteAllFirewallRules(c); err != nil {
 			return err
 		}
 
@@ -625,16 +625,16 @@ func getFirewallRulePropertiesSet(c *core.CommandConfig) resources.FirewallRuleP
 	return properties
 }
 
-func DeleteAllFirewallRuses(c *core.CommandConfig) error {
+func DeleteAllFirewallRules(c *core.CommandConfig) error {
 	listQueryParams, err := query.GetListQueryParams(c)
 	if err != nil {
 		return err
 	}
 
 	queryParams := listQueryParams.QueryParams
-	datacenterId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgDataCenterId))
-	serverId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgServerId))
-	nicId := viper.GetString(core.GetFlagName(c.Resource, cloudapiv6.ArgNicId))
+	datacenterId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
+	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
+	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, datacenterId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Server ID: %v", serverId))

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -328,8 +328,8 @@ func PreRunDcServerNicIds(c *core.PreCommandConfig) error {
 
 func PreRunFirewallDelete(c *core.PreCommandConfig) error {
 	return core.CheckRequiredFlagsSets(c.Command, c.NS,
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId},
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgAll},
+		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgFirewallRuleId},
+		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgAll},
 	)
 }
 
@@ -383,7 +383,7 @@ func RunFirewallRuleGet(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Firewall Rule with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirewallRuleId))))
+		"Getting Firewall Rule with id: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirewallRuleId))))
 
 	firewallRule, resp, err := c.CloudApiV6Services.FirewallRules().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),


### PR DESCRIPTION
Fixes two issues with `firewallrule delete`:
1. `--firewallrule-id` was not required, resulting in a 405 if not set (`DELETE` not allowed) - since the endpoint missed the ID if unset
2. The IDs were not properly extracted from the flags, resulting in a 404 - since the endpoint missed all IDs whether set by the user ot not