### PR TITLE
fix: password, sshkey-path not required for private images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [T.B.D]
 ### Fixed
 * Fixed 404 on firewallrule delete command: flag values not properly sent to API
+* Fixed `password` or `sshkey-path` being required for private images
 
 ## [v6.6.10] (September 2023)
 ### Fixed

--- a/commands/cloudapi-v6/server_test.go
+++ b/commands/cloudapi-v6/server_test.go
@@ -277,39 +277,6 @@ func TestPreRunServerCreateCube(t *testing.T) {
 	})
 }
 
-func TestPreRunServerCreateCubeImgId(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
-}
-
-func TestPreRunServerCreateCubeImgErr(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.Error(t, err)
-	})
-}
-
 func TestPreRunServerCreateCubeErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -319,23 +286,6 @@ func TestPreRunServerCreateCubeErr(t *testing.T) {
 		viper.Set(constants.ArgQuiet, false)
 		err := PreRunServerCreate(cfg)
 		assert.Error(t, err)
-	})
-}
-
-func TestPreRunServerCreateCubeImg(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
 	})
 }
 

--- a/commands/cloudapi-v6/volume_test.go
+++ b/commands/cloudapi-v6/volume_test.go
@@ -272,22 +272,6 @@ func TestPreRunVolumeCreate(t *testing.T) {
 	})
 }
 
-func TestPreRunVolumeCreateImg(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testVolumeVar})
-		err := PreRunVolumeCreate(cfg)
-		assert.NoError(t, err)
-	})
-}
-
 func TestPreRunVolumeCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)


### PR DESCRIPTION
Using private images for `volume create` is impossible since `ionosctl` forces the user to set `--sshkey-path` or `--password` for all types of images. However, the API expects these to not be set if using private images.

This PR changes the prerun to take private HDD images into account for `volume create`