### PR TITLE
enhancement: image id completer descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [T.B.D]
+### Added
+* Added completer descriptions for `--image-id` flag.
+  * Only relevant images are now completed (e.g. HDD images for `volume create --image-id`).
+  * Completed images will also be ordered so that private (user-uploaded) images are shown first.
+
 ### Fixed
 * Fixed 404 on firewallrule delete command: flag values not properly sent to API
 * Fixed `password` or `sshkey-path` being required for private images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [T.B.D]
 ### Fixed
 * Fixed 404 on firewallrule delete command: flag values not properly sent to API
+* Fixed `password` or `sshkey-path` being required for private images
 
 ## [v6.6.10] (September 2023)
 ### Fixed

--- a/commands/cloudapi-v6/completer/custom_ids.go
+++ b/commands/cloudapi-v6/completer/custom_ids.go
@@ -11,25 +11,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
 )
 
-func ImagesIdsCustom(params resources.ListQueryParams) []string {
-	imageSvc := resources.NewImageService(client.Must(), context.Background())
-	images, _, err := imageSvc.List(params)
-	if err != nil {
-		return nil
-	}
-	imgsIds := make([]string, 0)
-	if items, ok := images.Images.GetItemsOk(); ok && items != nil {
-		for _, item := range *items {
-			if itemId, ok := item.GetIdOk(); ok && itemId != nil {
-				imgsIds = append(imgsIds, *itemId)
-			}
-		}
-	} else {
-		return nil
-	}
-	return imgsIds
-}
-
 func ServersIdsCustom(datacenterId string, params resources.ListQueryParams) []string {
 	serverSvc := resources.NewServerService(client.Must(), context.Background())
 	servers, _, err := serverSvc.List(datacenterId, params)

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -156,7 +156,9 @@ func ImageCmd() *core.Command {
 	})
 	update.AddUUIDFlag(cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption())
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
+		return completer.ImageIds(func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+			return request.Filter("public", "false")
+		}), cobra.ShellCompDirectiveNoFileComp
 	})
 
 	update.Command.Flags().SortFlags = false // Hot Plugs generate a lot of flags to scroll through, put them at the end
@@ -202,7 +204,9 @@ func ImageCmd() *core.Command {
 	})
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption())
 	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
+		return completer.ImageIds(func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+			return request.Filter("public", "false")
+		}), cobra.ShellCompDirectiveNoFileComp
 	})
 	deleteCmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all non-public images")
 

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -227,7 +227,16 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "[CUBE Server] The Image Alias to use instead of Image Id for the Direct Attached Storage")
 	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "[CUBE Server] The Image Id or snapshot Id to be used as for the Direct Attached Storage")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
+		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+			// Completer for HDD images that are in the same location as the datacenter
+			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
+			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+				return ionoscloud.ApiImagesGetRequest{}
+			}
+
+			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
+		}), cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(constants.ArgPassword, constants.ArgPasswordShort, "", "[CUBE Server] Initial image password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9")
 	create.AddStringSliceFlag(cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, []string{""}, "[CUBE Server] Absolute paths for the SSH Keys of the Direct Attached Storage")

--- a/commands/cloudapi-v6/server_test.go
+++ b/commands/cloudapi-v6/server_test.go
@@ -277,39 +277,6 @@ func TestPreRunServerCreateCube(t *testing.T) {
 	})
 }
 
-func TestPreRunServerCreateCubeImgId(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
-}
-
-func TestPreRunServerCreateCubeImgErr(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.Error(t, err)
-	})
-}
-
 func TestPreRunServerCreateCubeErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -319,23 +286,6 @@ func TestPreRunServerCreateCubeErr(t *testing.T) {
 		viper.Set(constants.ArgQuiet, false)
 		err := PreRunServerCreate(cfg)
 		assert.Error(t, err)
-	})
-}
-
-func TestPreRunServerCreateCubeImg(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
 	})
 }
 

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -175,7 +175,19 @@ Required values to run command:
 	})
 	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "The Image Id or Snapshot Id to be used as template for the new Volume. A password or SSH Key need to be set")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
+		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+			// Completer for HDD images that are in the same location as the datacenter
+			fmt.Println("Looking for image IDs")
+			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
+			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+				return ionoscloud.ApiImagesGetRequest{}
+			}
+
+			fmt.Printf("Dc ID: %s\n", viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)))
+
+			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
+		}), cobra.ShellCompDirectiveNoFileComp
 	})
 
 	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "The Image Alias to set instead of Image Id. A password or SSH Key need to be set")

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -177,14 +177,11 @@ Required values to run command:
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
 			// Completer for HDD images that are in the same location as the datacenter
-			fmt.Println("Looking for image IDs")
 			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
 				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
 			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
 				return ionoscloud.ApiImagesGetRequest{}
 			}
-
-			fmt.Printf("Dc ID: %s\n", viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)))
 
 			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
 		}), cobra.ShellCompDirectiveNoFileComp

--- a/commands/cloudapi-v6/volume_test.go
+++ b/commands/cloudapi-v6/volume_test.go
@@ -272,22 +272,6 @@ func TestPreRunVolumeCreate(t *testing.T) {
 	})
 }
 
-func TestPreRunVolumeCreateImg(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testVolumeVar})
-		err := PreRunVolumeCreate(cfg)
-		assert.NoError(t, err)
-	})
-}
-
 func TestPreRunVolumeCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)


### PR DESCRIPTION
Add completer descriptions for `--image-id` flag.

Completed images are now relevant (i.e. only HDD images from the same location as the selected datacenter are completed for `volume create --image-id`).

Completed images will also be ordered so that private (user-uploaded) images are shown first.

```
 % i volume create --datacenter-id 5b155c2a-a580-41fe-8fd3-6c0562889d04 --image-id  <TAB>
Completing completions
2c27b1a4-4d5d-11ee-a519-1ed9fe6a7252  --  LINUX HDD public [rocky:latest,rocky:9] (rocky-9.2-genericcloud-20230513) from fr/par
2eefbc0c-5f7c-11ed-9aa6-0e69f8b5a652  --  LINUX HDD public [ubuntu:20.04] (ubuntu-20.04-server-cloudimg-amd64-20220824) from fr/par
2f6abdf0-d9c6-11ed-b4c9-46b39ba06ae6  --  LINUX HDD public [alma:9,alma:latest] (almalinux-9-GenericCloud-20221118) from fr/par
349b40f3-5601-11ee-a9da-86dc62105b4b  --  WINDOWS2016 HDD public [windows:2019] (windows-2019-server-2023-09) from fr/par
3e88fa7c-64c6-11ed-a0d5-42ebffc1611d  --  LINUX HDD public [debian:11] (debian-11-genericcloud-amd64-20220911-1135) from fr/par
4a851b21-5600-11ee-a9da-86dc62105b4b  --  WINDOWS2016 HDD public [windows:2016] (windows-2016-server-2023-09) from fr/par
57df76ca-febd-11ed-86e8-2e7f0689c849  --  LINUX HDD public [ubuntu:latest,ubuntu:22.04] (ubuntu-22.04-server-cloudimg-amd64-20230518) from fr/par
5ec642d7-a6bb-11ed-9e9f-e60bb43016ef  --  LINUX HDD public [centos:7,centos:latest] (CentOS-7-GenericCloud-2211) from fr/par
```