### PR TITLE
doc: rename Private Cross Connect to Cross Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Changed
 
 * Changed how `request targets` are printed for better readability
+* In help text & documentation, `Private Cross Connect` has been renamed to `Cross Connect`, and an alias of `cc` has been added to the `pcc` command
 
 ## [v6.7.0] (October 2023)
 

--- a/commands/cloudapi-v6/examples.go
+++ b/commands/cloudapi-v6/examples.go
@@ -224,7 +224,7 @@ ionosctl label add --resource-type datacenter --datacenter-id DATACENTER_ID --la
 	deleteBackupUnitExample = `ionosctl backupunit delete --backupunit-id BACKUPUNIT_ID`
 
 	/*
-		Private Cross-Connect Example
+		Cross-Connect Example
 	*/
 	listPccsExample     = `ionosctl pcc list`
 	getPccExample       = `ionosctl pcc get --pcc-id PCC_ID`

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -124,7 +124,7 @@ func LanCmd() *core.Command {
 		Verb:      "create",
 		Aliases:   []string{"c"},
 		ShortDesc: "Create a LAN",
-		LongDesc: `Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Private Cross-Connect Id can be set.
+		LongDesc: `Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Cross-Connect Id can be set.
 
 NOTE: IP Failover is configured after LAN creation using an update command.
 
@@ -144,7 +144,7 @@ Required values to run command:
 	})
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed LAN", "The name of the LAN")
 	create.AddBoolFlag(cloudapiv6.ArgPublic, cloudapiv6.ArgPublicShort, cloudapiv6.DefaultPublic, "Indicates if the LAN faces the public Internet (true) or not (false). E.g.: --public=true, --public=false")
-	create.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Private Cross-Connect the LAN will connect to")
+	create.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Cross-Connect the LAN will connect to")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
@@ -162,7 +162,7 @@ Required values to run command:
 		Verb:      "update",
 		Aliases:   []string{"u", "up"},
 		ShortDesc: "Update a LAN",
-		LongDesc: `Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Private Cross-Connect.
+		LongDesc: `Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Cross-Connect.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -184,7 +184,7 @@ Required values to run command:
 		return completer.LansIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the LAN")
-	update.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Private Cross-Connect the LAN will connect to")
+	update.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Cross-Connect the LAN will connect to")
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -46,6 +46,7 @@ func PccCmd() *core.Command {
 	pccCmd := &core.Command{
 		Command: &cobra.Command{
 			Use:              "pcc",
+			Aliases:          []string{"cc"},
 			Short:            "Cross-Connect Operations",
 			Long:             "The sub-commands of `ionosctl pcc` allow you to list, get, create, update, delete Cross-Connect. To add Cross-Connect to a Lan, check the `ionosctl lan update` command.",
 			TraverseChildren: true,

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -46,8 +46,8 @@ func PccCmd() *core.Command {
 	pccCmd := &core.Command{
 		Command: &cobra.Command{
 			Use:              "pcc",
-			Short:            "Private Cross-Connect Operations",
-			Long:             "The sub-commands of `ionosctl pcc` allow you to list, get, create, update, delete Private Cross-Connect. To add Private Cross-Connect to a Lan, check the `ionosctl lan update` command.",
+			Short:            "Cross-Connect Operations",
+			Long:             "The sub-commands of `ionosctl pcc` allow you to list, get, create, update, delete Cross-Connect. To add Cross-Connect to a Lan, check the `ionosctl lan update` command.",
 			TraverseChildren: true,
 		},
 	}
@@ -66,8 +66,8 @@ func PccCmd() *core.Command {
 		Resource:   "pcc",
 		Verb:       "list",
 		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Private Cross-Connects",
-		LongDesc:   "Use this command to get a list of existing Private Cross-Connects available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.PccsFiltersUsage(),
+		ShortDesc:  "List Cross-Connects",
+		LongDesc:   "Use this command to get a list of existing Cross-Connects available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.PccsFiltersUsage(),
 		Example:    listPccsExample,
 		PreCmdRun:  PreRunPccList,
 		CmdRun:     RunPccList,
@@ -93,8 +93,8 @@ func PccCmd() *core.Command {
 		Resource:   "pcc",
 		Verb:       "get",
 		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Private Cross-Connect",
-		LongDesc:   "Use this command to retrieve details about a specific Private Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
+		ShortDesc:  "Get a Cross-Connect",
+		LongDesc:   "Use this command to retrieve details about a specific Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
 		Example:    getPccExample,
 		PreCmdRun:  PreRunPccId,
 		CmdRun:     RunPccGet,
@@ -115,17 +115,17 @@ func PccCmd() *core.Command {
 		Resource:   "pcc",
 		Verb:       "create",
 		Aliases:    []string{"c"},
-		ShortDesc:  "Create a Private Cross-Connect",
-		LongDesc:   "Use this command to create a Private Cross-Connect. You can specify the name and the description for the Private Cross-Connect.",
+		ShortDesc:  "Create a Cross-Connect",
+		LongDesc:   "Use this command to create a Cross-Connect. You can specify the name and the description for the Cross-Connect.",
 		Example:    createPccExample,
 		PreCmdRun:  core.NoPreRun,
 		CmdRun:     RunPccCreate,
 		InitClient: true,
 	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed PrivateCrossConnect", "The name for the Private Cross-Connect")
-	create.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Private Cross-Connect")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Private Cross-Connect creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Private Cross-Connect creation [seconds]")
+	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed PrivateCrossConnect", "The name for the Cross-Connect")
+	create.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect")
+	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect creation to be executed")
+	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect creation [seconds]")
 	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -136,8 +136,8 @@ func PccCmd() *core.Command {
 		Resource:  "pcc",
 		Verb:      "update",
 		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Private Cross-Connect",
-		LongDesc: `Use this command to update details about a specific Private Cross-Connect. Name and description can be updated.
+		ShortDesc: "Update a Cross-Connect",
+		LongDesc: `Use this command to update details about a specific Cross-Connect. Name and description can be updated.
 
 Required values to run command:
 
@@ -147,14 +147,14 @@ Required values to run command:
 		CmdRun:     RunPccUpdate,
 		InitClient: true,
 	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the Private Cross-Connect")
-	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Private Cross-Connect")
+	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the Cross-Connect")
+	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect")
 	update.AddUUIDFlag(cloudapiv6.ArgPccId, cloudapiv6.ArgIdShort, "", cloudapiv6.PccId, core.RequiredFlagOption())
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Private Cross-Connect update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Private Cross-Connect update [seconds]")
+	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect update to be executed")
+	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect update [seconds]")
 	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -165,8 +165,8 @@ Required values to run command:
 		Resource:  "pcc",
 		Verb:      "delete",
 		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Private Cross-Connect",
-		LongDesc: `Use this command to delete a Private Cross-Connect.
+		ShortDesc: "Delete a Cross-Connect",
+		LongDesc: `Use this command to delete a Cross-Connect.
 
 Required values to run command:
 
@@ -180,9 +180,9 @@ Required values to run command:
 	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Private Cross-Connect deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Private Cross-Connects.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Private Cross-Connect deletion [seconds]")
+	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect deletion to be executed")
+	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Cross-Connects.")
+	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
 	pccCmd.AddCommand(PeersCmd())
@@ -244,7 +244,7 @@ func RunPccGet(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Private cross connect with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
+		"Cross Connect with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
 
 	u, resp, err := c.CloudApiV6Services.Pccs().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), queryParams)
 	if resp != nil {
@@ -287,7 +287,7 @@ func RunPccCreate(c *core.CommandConfig) error {
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the private cross connect: Name: %v, Description: %v", name, description))
+		"Properties set for creating the Cross Connect: Name: %v, Description: %v", name, description))
 
 	u, resp, err := c.CloudApiV6Services.Pccs().Create(newUser, queryParams)
 	if resp != nil && utils.GetId(resp) != "" {
@@ -367,12 +367,12 @@ func RunPccDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete private cross-connect", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete Cross-Connect", viper.GetBool(constants.ArgForce)) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Private cross connect with id: %v...", pccId))
+		"Starting deleting Cross Connect with id: %v...", pccId))
 
 	resp, err := c.CloudApiV6Services.Pccs().Delete(pccId, queryParams)
 	if resp != nil && utils.GetId(resp) != "" {
@@ -386,7 +386,7 @@ func RunPccDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Private Cross Connect successfully deleted"))
+	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Cross Connect successfully deleted"))
 	return nil
 }
 
@@ -465,7 +465,7 @@ func DeleteAllPccs(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the private cross-connects", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Cross-Connects", viper.GetBool(constants.ArgForce)) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -501,7 +501,7 @@ func DeleteAllPccs(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Private Cross Connects successfully deleted"))
+	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Cross Connects successfully deleted"))
 	return nil
 }
 
@@ -510,8 +510,8 @@ func PeersCmd() *core.Command {
 	peerCmd := &core.Command{
 		Command: &cobra.Command{
 			Use:              "peers",
-			Short:            "Private Cross-Connect Peers Operations",
-			Long:             "The sub-command of `ionosctl pcc peers` allows you to get a list of Peers from a Private Cross-Connect.",
+			Short:            "Cross-Connect Peers Operations",
+			Long:             "The sub-command of `ionosctl pcc peers` allows you to get a list of Peers from a Cross-Connect.",
 			TraverseChildren: true,
 		},
 	}
@@ -531,8 +531,8 @@ func PeersCmd() *core.Command {
 		Resource:   "peers",
 		Verb:       "list",
 		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "Get a list of Peers from a Private Cross-Connect",
-		LongDesc:   "Use this command to get a list of Peers from a Private Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
+		ShortDesc:  "Get a list of Peers from a Cross-Connect",
+		LongDesc:   "Use this command to get a list of Peers from a Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
 		Example:    listPccPeersExample,
 		PreCmdRun:  PreRunPccId,
 		CmdRun:     RunPccPeersList,
@@ -549,7 +549,7 @@ func PeersCmd() *core.Command {
 
 func RunPccPeersList(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting Peers from Private Cross-Connect with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
+		"Getting Peers from Cross-Connect with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
 
 	u, resp, err := c.CloudApiV6Services.Pccs().GetPeers(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)))
 	if resp != nil {

--- a/docs/subcommands/Compute Engine/lan/create.md
+++ b/docs/subcommands/Compute Engine/lan/create.md
@@ -26,7 +26,7 @@ For `create` command:
 
 ## Description
 
-Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Private Cross-Connect Id can be set.
+Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Cross-Connect Id can be set.
 
 NOTE: IP Failover is configured after LAN creation using an update command.
 
@@ -50,7 +50,7 @@ Required values to run command:
       --ipv6-cidr string       The /64 IPv6 Cidr as defined in RFC 4291. It needs to be within the Datacenter IPv6 Cidr Block range. It can also be set to "AUTO" or "DISABLE". (default "DISABLE")
   -n, --name string            The name of the LAN (default "Unnamed LAN")
   -o, --output string          Desired output format [text|json|api-json] (default "text")
-      --pcc-id string          The unique Id of the Private Cross-Connect the LAN will connect to
+      --pcc-id string          The unique Id of the Cross-Connect the LAN will connect to
   -p, --public                 Indicates if the LAN faces the public Internet (true) or not (false). E.g.: --public=true, --public=false
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for LAN creation [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/lan/update.md
+++ b/docs/subcommands/Compute Engine/lan/update.md
@@ -26,7 +26,7 @@ For `update` command:
 
 ## Description
 
-Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Private Cross-Connect.
+Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Cross-Connect.
 
 You can wait for the Request to be executed using `--wait-for-request` option.
 
@@ -50,7 +50,7 @@ Required values to run command:
   -i, --lan-id string          The unique LAN Id (required)
   -n, --name string            The name of the LAN
   -o, --output string          Desired output format [text|json|api-json] (default "text")
-      --pcc-id string          The unique Id of the Private Cross-Connect the LAN will connect to
+      --pcc-id string          The unique Id of the Cross-Connect the LAN will connect to
       --public                 Public option for LAN. E.g.: --public=true, --public=false
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for LAN update [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/pcc/create.md
+++ b/docs/subcommands/Compute Engine/pcc/create.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a Private Cross-Connect"
+description: "Create a Cross-Connect"
 ---
 
 # PccCreate
@@ -20,7 +20,7 @@ For `create` command:
 
 ## Description
 
-Use this command to create a Private Cross-Connect. You can specify the name and the description for the Private Cross-Connect.
+Use this command to create a Cross-Connect. You can specify the name and the description for the Cross-Connect.
 
 ## Options
 
@@ -30,15 +30,15 @@ Use this command to create a Private Cross-Connect. You can specify the name and
                              Available columns: [PccId Name Description State] (default [PccId,Name,Description,State])
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
-  -d, --description string   The description for the Private Cross-Connect
+  -d, --description string   The description for the Cross-Connect
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-  -n, --name string          The name for the Private Cross-Connect (default "Unnamed PrivateCrossConnect")
+  -n, --name string          The name for the Cross-Connect (default "Unnamed PrivateCrossConnect")
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
-  -t, --timeout int          Timeout option for Request for Private Cross-Connect creation [seconds] (default 60)
+  -t, --timeout int          Timeout option for Request for Cross-Connect creation [seconds] (default 60)
   -v, --verbose              Print step-by-step process when running command
-  -w, --wait-for-request     Wait for the Request for Private Cross-Connect creation to be executed
+  -w, --wait-for-request     Wait for the Request for Cross-Connect creation to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Compute Engine/pcc/create.md
+++ b/docs/subcommands/Compute Engine/pcc/create.md
@@ -12,6 +12,12 @@ ionosctl pcc create [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `create` command:
 
 ```text

--- a/docs/subcommands/Compute Engine/pcc/delete.md
+++ b/docs/subcommands/Compute Engine/pcc/delete.md
@@ -1,5 +1,5 @@
 ---
-description: "Delete a Private Cross-Connect"
+description: "Delete a Cross-Connect"
 ---
 
 # PccDelete
@@ -20,7 +20,7 @@ For `delete` command:
 
 ## Description
 
-Use this command to delete a Private Cross-Connect.
+Use this command to delete a Cross-Connect.
 
 Required values to run command:
 
@@ -29,7 +29,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -a, --all                Delete all Private Cross-Connects.
+  -a, --all                Delete all Cross-Connects.
   -u, --api-url string     Override default host url (default "https://api.ionos.com")
       --cols strings       Set of columns to be printed on output 
                            Available columns: [PccId Name Description State] (default [PccId,Name,Description,State])
@@ -38,11 +38,11 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
   -o, --output string      Desired output format [text|json|api-json] (default "text")
-  -i, --pcc-id string      The unique Private Cross-Connect Id (required)
+  -i, --pcc-id string      The unique Cross-Connect Id (required)
   -q, --quiet              Quiet output
-  -t, --timeout int        Timeout option for Request for Private Cross-Connect deletion [seconds] (default 60)
+  -t, --timeout int        Timeout option for Request for Cross-Connect deletion [seconds] (default 60)
   -v, --verbose            Print step-by-step process when running command
-  -w, --wait-for-request   Wait for the Request for Private Cross-Connect deletion to be executed
+  -w, --wait-for-request   Wait for the Request for Cross-Connect deletion to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Compute Engine/pcc/delete.md
+++ b/docs/subcommands/Compute Engine/pcc/delete.md
@@ -12,6 +12,12 @@ ionosctl pcc delete [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `delete` command:
 
 ```text

--- a/docs/subcommands/Compute Engine/pcc/get.md
+++ b/docs/subcommands/Compute Engine/pcc/get.md
@@ -12,6 +12,12 @@ ionosctl pcc get [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `get` command:
 
 ```text

--- a/docs/subcommands/Compute Engine/pcc/get.md
+++ b/docs/subcommands/Compute Engine/pcc/get.md
@@ -1,5 +1,5 @@
 ---
-description: "Get a Private Cross-Connect"
+description: "Get a Cross-Connect"
 ---
 
 # PccGet
@@ -20,7 +20,7 @@ For `get` command:
 
 ## Description
 
-Use this command to retrieve details about a specific Private Cross-Connect.
+Use this command to retrieve details about a specific Cross-Connect.
 
 Required values to run command:
 
@@ -38,7 +38,7 @@ Required values to run command:
   -h, --help             Print usage
       --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json|api-json] (default "text")
-  -i, --pcc-id string    The unique Private Cross-Connect Id (required)
+  -i, --pcc-id string    The unique Cross-Connect Id (required)
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command
 ```

--- a/docs/subcommands/Compute Engine/pcc/list.md
+++ b/docs/subcommands/Compute Engine/pcc/list.md
@@ -12,6 +12,12 @@ ionosctl pcc list [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `list` command:
 
 ```text

--- a/docs/subcommands/Compute Engine/pcc/list.md
+++ b/docs/subcommands/Compute Engine/pcc/list.md
@@ -1,5 +1,5 @@
 ---
-description: "List Private Cross-Connects"
+description: "List Cross-Connects"
 ---
 
 # PccList
@@ -20,7 +20,7 @@ For `list` command:
 
 ## Description
 
-Use this command to get a list of existing Private Cross-Connects available on your account.
+Use this command to get a list of existing Cross-Connects available on your account.
 
 You can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.
 Available Filters:

--- a/docs/subcommands/Compute Engine/pcc/peers/list.md
+++ b/docs/subcommands/Compute Engine/pcc/peers/list.md
@@ -12,6 +12,12 @@ ionosctl pcc peers list [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `list` command:
 
 ```text

--- a/docs/subcommands/Compute Engine/pcc/peers/list.md
+++ b/docs/subcommands/Compute Engine/pcc/peers/list.md
@@ -1,5 +1,5 @@
 ---
-description: "Get a list of Peers from a Private Cross-Connect"
+description: "Get a list of Peers from a Cross-Connect"
 ---
 
 # PccPeersList
@@ -20,7 +20,7 @@ For `list` command:
 
 ## Description
 
-Use this command to get a list of Peers from a Private Cross-Connect.
+Use this command to get a list of Peers from a Cross-Connect.
 
 Required values to run command:
 
@@ -37,7 +37,7 @@ Required values to run command:
   -h, --help             Print usage
       --no-headers       When using text output, don't print headers
   -o, --output string    Desired output format [text|json|api-json] (default "text")
-      --pcc-id string    The unique Private Cross-Connect Id (required)
+      --pcc-id string    The unique Cross-Connect Id (required)
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command
 ```

--- a/docs/subcommands/Compute Engine/pcc/update.md
+++ b/docs/subcommands/Compute Engine/pcc/update.md
@@ -1,5 +1,5 @@
 ---
-description: "Update a Private Cross-Connect"
+description: "Update a Cross-Connect"
 ---
 
 # PccUpdate
@@ -20,7 +20,7 @@ For `update` command:
 
 ## Description
 
-Use this command to update details about a specific Private Cross-Connect. Name and description can be updated.
+Use this command to update details about a specific Cross-Connect. Name and description can be updated.
 
 Required values to run command:
 
@@ -34,16 +34,16 @@ Required values to run command:
                              Available columns: [PccId Name Description State] (default [PccId,Name,Description,State])
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
-  -d, --description string   The description for the Private Cross-Connect
+  -d, --description string   The description for the Cross-Connect
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-  -n, --name string          The name for the Private Cross-Connect
+  -n, --name string          The name for the Cross-Connect
   -o, --output string        Desired output format [text|json|api-json] (default "text")
-  -i, --pcc-id string        The unique Private Cross-Connect Id (required)
+  -i, --pcc-id string        The unique Cross-Connect Id (required)
   -q, --quiet                Quiet output
-  -t, --timeout int          Timeout option for Request for Private Cross-Connect update [seconds] (default 60)
+  -t, --timeout int          Timeout option for Request for Cross-Connect update [seconds] (default 60)
   -v, --verbose              Print step-by-step process when running command
-  -w, --wait-for-request     Wait for the Request for Private Cross-Connect update to be executed
+  -w, --wait-for-request     Wait for the Request for Cross-Connect update to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Compute Engine/pcc/update.md
+++ b/docs/subcommands/Compute Engine/pcc/update.md
@@ -12,6 +12,12 @@ ionosctl pcc update [flags]
 
 ## Aliases
 
+For `pcc` command:
+
+```text
+[cc]
+```
+
 For `update` command:
 
 ```text

--- a/services/cloudapi-v6/constants.go
+++ b/services/cloudapi-v6/constants.go
@@ -226,7 +226,7 @@ const (
 	ResourceId                = "The unique Resource Id"
 	S3KeyId                   = "The unique User S3Key Id"
 	BackupUnitId              = "The unique BackupUnit Id"
-	PccId                     = "The unique Private Cross-Connect Id"
+	PccId                     = "The unique Cross-Connect Id"
 	K8sClusterId              = "The unique K8s Cluster Id"
 	K8sNodePoolId             = "The unique K8s Node Pool Id"
 	K8sNodeId                 = "The unique K8s Node Id"


### PR DESCRIPTION
Rename Private Cross Connect to Cross Connect and adds an alias of `cc` to the `pcc` command