### PR TITLE
fix: `label` add URN, fix ResourceId, ResourceType cols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [v6.7.1] (???)
 
+## Added
+
+* Added `URN` column in `label` subcommands
+
+## Fixed
+
+* Fixed `ResourceId` and `ResourceType` columns not being printed in `label` subcommands
+
 ## Changed
 
 * Changed how `request targets` are printed for better readability

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -17,13 +17,14 @@ import (
 
 var (
 	allLabelJSONPaths = map[string]string{
+		"URN":          "id",
 		"Key":          "properties.key",
 		"Value":        "properties.value",
 		"ResourceType": "properties.resourceType",
 		"ResourceId":   "properties.resourceId",
 	}
 
-	defaultLabelCols = []string{"Key", "Value", "ResourceType", "ResourceId"}
+	defaultLabelCols = []string{"URN", "Key", "Value", "ResourceType", "ResourceId"}
 )
 
 func LabelCmd() *core.Command {
@@ -37,10 +38,10 @@ func LabelCmd() *core.Command {
 		},
 	}
 	globalFlags := labelCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultLabelResourceCols, tabheaders.ColsMessage(defaultLabelResourceCols))
+	globalFlags.StringSliceP(constants.ArgCols, "", defaultLabelCols, tabheaders.ColsMessage(defaultLabelCols))
 	_ = viper.BindPFlag(core.GetFlagName(labelCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
 	_ = labelCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultLabelResourceCols, cobra.ShellCompDirectiveNoFileComp
+		return defaultLabelCols, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	var (

--- a/commands/cloudapi-v6/labelresource.go
+++ b/commands/cloudapi-v6/labelresource.go
@@ -18,15 +18,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	allLabelResourceJSONPaths = map[string]string{
-		"Key":   "properties.key",
-		"Value": "properties.value",
-	}
-
-	defaultLabelResourceCols = []string{"Key", "Value"}
-)
-
 func RunDataCenterLabelsList(c *core.CommandConfig) error {
 	listQueryParams, err := query.GetListQueryParams(c)
 	if err != nil {
@@ -43,8 +34,8 @@ func RunDataCenterLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allLabelResourceJSONPaths, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("items", allLabelJSONPaths, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -70,8 +61,8 @@ func RunDataCenterLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -99,8 +90,8 @@ func RunDataCenterLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -238,8 +229,8 @@ func RunServerLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allLabelResourceJSONPaths, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("items", allLabelJSONPaths, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -266,8 +257,8 @@ func RunServerLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -296,8 +287,8 @@ func RunServerLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -444,8 +435,8 @@ func RunVolumeLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allLabelResourceJSONPaths, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("items", allLabelJSONPaths, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -472,8 +463,8 @@ func RunVolumeLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -502,8 +493,8 @@ func RunVolumeLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -640,8 +631,8 @@ func RunIpBlockLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allLabelResourceJSONPaths, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("items", allLabelJSONPaths, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -668,8 +659,8 @@ func RunIpBlockLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -697,8 +688,8 @@ func RunIpBlockLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -832,8 +823,8 @@ func RunSnapshotLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allLabelResourceJSONPaths, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("items", allLabelJSONPaths, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -860,8 +851,8 @@ func RunSnapshotLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}
@@ -889,8 +880,8 @@ func RunSnapshotLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allLabelResourceJSONPaths, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelResourceCols, cols))
+	out, err := jsontabwriter.GenerateOutput("", allLabelJSONPaths, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds missing columns for `label` resource:

```
% i label ls
URN                                                             Key                 Value     ResourceType   ResourceId
urn:label:k8snodepool:UUID:managedexternally   managedexternally   DSAAS     k8snodepool    UUID
urn:label:server:UUID:k8snodepool              k8snodepool            server         UUID
urn:label:volume:UUID:k8snodepool              k8snodepool           volume         UUID
```