### PR TITLE
fix: --no-headers ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixed
 
 * Fixed `ResourceId` and `ResourceType` columns not being printed in `label` subcommands
+* Fixed `--no-headers` flag value being ignored - now treated as a global flag
 
 ## Changed
 

--- a/commands/certmanager/apiversion.go
+++ b/commands/certmanager/apiversion.go
@@ -39,7 +39,6 @@ func CertGetApiVersionCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allAPIVersionCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "n", false, "Response delete all certificates")
 
 	return cmd
 }

--- a/commands/certmanager/certificates.go
+++ b/commands/certmanager/certificates.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/services/certmanager/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go-cert-manager"
@@ -32,8 +31,6 @@ func CertCmd() *core.Command {
 			TraverseChildren: true,
 		},
 	}
-
-	certCmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	certCmd.AddCommand(CertGetCmd())
 	certCmd.AddCommand(CertCreateCmd())

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -82,7 +82,6 @@ func BackupunitCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -103,7 +102,6 @@ func BackupunitCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -121,7 +121,6 @@ Required values to run command:
 	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listCdroms.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	listCdroms.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -151,7 +150,6 @@ Required values to run command:
 	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.AttachedCdromsIds(viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgDataCenterId)), viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	getCdromCmd.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	getCdromCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/console.go
+++ b/commands/cloudapi-v6/console.go
@@ -57,7 +57,6 @@ func ServerConsoleCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	return consoleCmd
 }

--- a/commands/cloudapi-v6/contract.go
+++ b/commands/cloudapi-v6/contract.go
@@ -98,7 +98,6 @@ func ContractCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceLimits, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"CORES", "RAM", "HDD", "SSD", "DAS", "IPS", "K8S", "NLB", "NAT"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	return contractCmd
 }

--- a/commands/cloudapi-v6/cpu.go
+++ b/commands/cloudapi-v6/cpu.go
@@ -64,7 +64,6 @@ func CpuCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocationId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -87,7 +87,6 @@ You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -108,7 +107,6 @@ You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -102,7 +102,6 @@ func FirewallruleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -139,7 +138,6 @@ func FirewallruleCmd() *core.Command {
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -91,7 +91,6 @@ func FlowlogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -127,7 +126,6 @@ func FlowlogCmd() *core.Command {
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -95,7 +95,6 @@ func GroupCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -116,7 +115,6 @@ func GroupCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -118,7 +118,6 @@ func ImageCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -139,7 +138,6 @@ func ImageCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	update := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
@@ -165,7 +163,6 @@ func ImageCmd() *core.Command {
 
 	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Image update to be executed")
 	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Image update [seconds]")
-	update.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	addPropertiesFlags := func(command *core.Command) {
@@ -212,7 +209,6 @@ func ImageCmd() *core.Command {
 
 	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Image update to be executed")
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Image update [seconds]")
-	deleteCmd.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -76,7 +76,6 @@ func IpblockCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -97,7 +96,6 @@ func IpblockCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/ipconsumer.go
+++ b/commands/cloudapi-v6/ipconsumer.go
@@ -70,7 +70,6 @@ func IpconsumerCmd() *core.Command {
 	_ = listResources.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listResources.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	listResources.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	listResources.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -71,7 +71,6 @@ func IpfailoverCmd() *core.Command {
 	_ = listCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LansIds(viper.GetString(core.GetFlagName(listCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	listCmd.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	listCmd.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	listCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -99,7 +99,6 @@ func K8sClusterCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sClustersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -122,7 +121,6 @@ func K8sClusterCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Cluster to be in ACTIVE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Cluster to be in ACTIVE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/k8s_kubeconfig.go
+++ b/commands/cloudapi-v6/k8s_kubeconfig.go
@@ -44,7 +44,6 @@ func K8sKubeconfigCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	return k8sCmd
 }

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -83,7 +83,6 @@ func K8sNodeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -116,7 +115,6 @@ func K8sNodeCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Node to be in ACTIVE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Node to be in ACTIVE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -101,7 +101,6 @@ func K8sNodePoolCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -129,7 +128,6 @@ func K8sNodePoolCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified NodePool to be in ACTIVE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for NodePool to be in ACTIVE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -73,7 +73,6 @@ func K8sNodePoolLanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -84,7 +84,6 @@ func LabelCmd() *core.Command {
 		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
 	})
 	list.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to list labels from", core.RequiredFlagOption())
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
@@ -132,7 +131,6 @@ func LabelCmd() *core.Command {
 		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
 	})
 	get.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to get labels from", core.RequiredFlagOption())
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -150,7 +148,6 @@ func LabelCmd() *core.Command {
 		InitClient: true,
 	})
 	getByUrn.AddStringFlag(cloudapiv6.ArgLabelUrn, "", "", "URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>]", core.RequiredFlagOption())
-	getByUrn.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	getByUrn.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -86,7 +86,6 @@ func LanCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -112,7 +111,6 @@ func LanCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LansIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -83,7 +83,6 @@ func LoadBalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -109,7 +108,6 @@ func LoadBalancerCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LoadbalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/location.go
+++ b/commands/cloudapi-v6/location.go
@@ -73,7 +73,6 @@ func LocationCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -94,7 +93,6 @@ func LocationCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocationId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	locationCmd.AddCommand(CpuCmd())
 

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -82,7 +82,6 @@ func NatgatewayCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -110,7 +109,6 @@ func NatgatewayCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified NAT Gateway to be in AVAILABLE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -70,7 +70,6 @@ func NatgatewayFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -104,7 +103,6 @@ func NatgatewayFlowLogCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/natgateway_lan.go
+++ b/commands/cloudapi-v6/natgateway_lan.go
@@ -73,7 +73,6 @@ Required values to run command:
 	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -91,7 +91,6 @@ func NatgatewayRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -121,7 +120,6 @@ func NatgatewayRuleCmd() *core.Command {
 		return completer.NatGatewayRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -85,7 +85,6 @@ func NetworkloadbalancerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -113,7 +112,6 @@ func NetworkloadbalancerCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Network Load Balancer to be in AVAILABLE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -70,7 +70,6 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -104,7 +103,6 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -93,7 +93,6 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -123,7 +122,6 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -83,7 +83,6 @@ func NlbRuleTargetCmd() *core.Command {
 			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
 		), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 

--- a/commands/cloudapi-v6/nic.go
+++ b/commands/cloudapi-v6/nic.go
@@ -97,7 +97,6 @@ func NicCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.NICsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -127,7 +126,6 @@ func NicCmd() *core.Command {
 		return completer.NicsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
 			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -84,7 +84,6 @@ func PccCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -105,7 +104,6 @@ func PccCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -543,7 +541,6 @@ func PeersCmd() *core.Command {
 	_ = listPeers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listPeers.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	return peerCmd
 }

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -85,7 +85,6 @@ func RequestCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -106,7 +105,6 @@ func RequestCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRequestId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.RequestsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/resource.go
+++ b/commands/cloudapi-v6/resource.go
@@ -60,7 +60,6 @@ func ResourceCmd() *core.Command {
 		CmdRun:     RunResourceList,
 		InitClient: true,
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
@@ -87,7 +86,6 @@ func ResourceCmd() *core.Command {
 	_ = getRsc.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ResourcesIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	getRsc.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	return resourceCmd
 }

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -68,7 +68,6 @@ func UserS3keyCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
@@ -95,7 +94,6 @@ func UserS3keyCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgS3KeyId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.S3KeyIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgUserId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -99,7 +99,6 @@ func ServerCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -127,7 +126,6 @@ func ServerCmd() *core.Command {
 	})
 	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Server to be in AVAILABLE state")
 	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for waiting for Server to be in AVAILABLE state [seconds]")
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/share.go
+++ b/commands/cloudapi-v6/share.go
@@ -73,7 +73,6 @@ func ShareCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
@@ -100,7 +99,6 @@ func ShareCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.GroupResourcesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -75,7 +75,6 @@ func SnapshotCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -96,7 +95,6 @@ func SnapshotCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -134,7 +132,6 @@ Required values to run command:
 	})
 	create.AddBoolFlag(cloudapiv6.ArgSecAuthProtection, "", false, "Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false")
 	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot creation to be executed")
-	create.AddBoolFlag(constants.ArgNoHeaders, "", false, "Don't print column headers")
 	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot creation [seconds]")
 	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
 
@@ -159,7 +156,6 @@ Required values to run command:
 		CmdRun:     RunSnapshotUpdate,
 		InitClient: true,
 	})
-	update.AddBoolFlag(constants.ArgNoHeaders, "", false, "Don't print column headers")
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Snapshot")
 	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Snapshot")
 	update.AddSetFlag(cloudapiv6.ArgLicenceType, "", "", constants.EnumLicenceType, "Licence Type of the Snapshot")
@@ -212,7 +208,6 @@ Required values to run command:
 	restore.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot restore to be executed")
 	restore.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot restore [seconds]")
 	restore.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
-	restore.AddBoolFlag(constants.ArgNoHeaders, "", false, "Don't print column headers")
 
 	/*
 		Delete Command
@@ -237,7 +232,6 @@ Required values to run command:
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Snapshots.")
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
-	deleteCmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "Don't print column headers")
 
 	return snapshotCmd
 }

--- a/commands/cloudapi-v6/template.go
+++ b/commands/cloudapi-v6/template.go
@@ -70,7 +70,6 @@ func TemplateCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.TemplatesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -91,7 +90,6 @@ func TemplateCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTemplateId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.TemplatesIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	return templateCmd
 }

--- a/commands/cloudapi-v6/token.go
+++ b/commands/cloudapi-v6/token.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/jsontabwriter"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/tabheaders"
@@ -57,7 +56,6 @@ func ServerTokenCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 	return tokenCmd
 }

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -78,7 +78,6 @@ func UserCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Command
@@ -99,7 +98,6 @@ func UserCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -608,7 +606,6 @@ func GroupUserCmd() *core.Command {
 	_ = listUsers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listUsers.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Add User Command

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -95,7 +95,6 @@ func VolumeCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
@@ -121,7 +120,6 @@ func VolumeCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
@@ -1003,7 +1001,6 @@ Required values to run command:
 	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
 	})
-	listVolumes.AddBoolFlag(constants.ArgNoHeaders, "", false, cloudapiv6.ArgNoHeadersDescription)
 
 	/*
 		Get Volume Command

--- a/commands/container-registry/container-registry.go
+++ b/commands/container-registry/container-registry.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/commands/container-registry/registry"
 	"github.com/ionos-cloud/ionosctl/v6/commands/container-registry/repository"
 	"github.com/ionos-cloud/ionosctl/v6/commands/container-registry/token"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -23,10 +22,6 @@ func ContainerRegistryCmd() *core.Command {
 			TraverseChildren: true,
 		},
 	}
-
-	contregCmd.Command.PersistentFlags().Bool(
-		constants.ArgNoHeaders, false, "When using text output, don't print headers",
-	)
 
 	contregCmd.AddCommand(registry.RegistryCmd())
 	contregCmd.AddCommand(token.TokenCmd())

--- a/commands/container-registry/registry/registries.go
+++ b/commands/container-registry/registry/registries.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/services/container-registry/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go-container-registry"
@@ -39,8 +38,6 @@ func RegistryCmd() *core.Command {
 		},
 	}
 
-	regCmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
-
 	regCmd.AddCommand(RegListCmd())
 	regCmd.AddCommand(RegPostCmd())
 	regCmd.AddCommand(RegGetCmd())
@@ -52,7 +49,7 @@ func RegistryCmd() *core.Command {
 }
 
 func RegsIds() []string {
-	//client, _ := config.GetClient()
+	// client, _ := config.GetClient()
 	svc := resources.NewRegistriesService(client.Must(), context.Background())
 	regs, _, _ := svc.List("")
 	return functional.Map(

--- a/commands/container-registry/token/post.go
+++ b/commands/container-registry/token/post.go
@@ -34,9 +34,11 @@ func TokenPostCmd() *core.Command {
 		},
 	)
 
+	// This line is only used to override the help text for `--no-headers`!
 	cmd.Command.PersistentFlags().Bool(
 		constants.ArgNoHeaders, true, "Use --no-headers=false to show column headers",
 	)
+
 	cmd.AddStringFlag(FlagName, "", "", "Name of the Token", core.RequiredFlagOption())
 	cmd.AddStringFlag(FlagExpiryDate, "", "", "Expiry date of the Token")
 	cmd.AddStringFlag(FlagStatus, "", "", "Status of the Token")
@@ -76,6 +78,10 @@ func PreCmdPostToken(c *core.PreCommandConfig) error {
 }
 
 func CmdPostToken(c *core.CommandConfig) error {
+	if !viper.IsSet(constants.ArgNoHeaders) {
+		viper.Set(constants.ArgNoHeaders, true) // Change default to work as for `token create`
+	}
+
 	var err error
 
 	id, err := c.Command.Command.Flags().GetString("registry-id")

--- a/commands/container-registry/token/put.go
+++ b/commands/container-registry/token/put.go
@@ -34,10 +34,12 @@ func TokenReplaceCmd() *core.Command {
 		},
 	)
 
-	cmd.AddStringFlag(FlagName, "", "", "Name of the Token", core.RequiredFlagOption())
+	// This line is only used to override the help text for `--no-headers`!
 	cmd.Command.PersistentFlags().Bool(
 		constants.ArgNoHeaders, true, "Use --no-headers=false to show column headers",
 	)
+
+	cmd.AddStringFlag(FlagName, "", "", "Name of the Token", core.RequiredFlagOption())
 	cmd.AddStringFlag(FlagRegId, "r", "", "Registry ID")
 	_ = cmd.Command.RegisterFlagCompletionFunc(
 		FlagRegId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -74,6 +76,10 @@ func TokenReplaceCmd() *core.Command {
 }
 
 func CmdPutToken(c *core.CommandConfig) error {
+	if !viper.IsSet(constants.ArgNoHeaders) {
+		viper.Set(constants.ArgNoHeaders, true) // Change default to work as for `token create`
+	}
+
 	var err error
 
 	regId, err := c.Command.Command.Flags().GetString(FlagRegId)

--- a/commands/container-registry/token/tokens.go
+++ b/commands/container-registry/token/tokens.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/functional"
 
 	scope "github.com/ionos-cloud/ionosctl/v6/commands/container-registry/token/scopes"
-	"github.com/ionos-cloud/ionosctl/v6/pkg/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/core"
 	"github.com/ionos-cloud/ionosctl/v6/services/container-registry/resources"
 	ionoscloud "github.com/ionos-cloud/sdk-go-container-registry"
@@ -44,10 +43,6 @@ func TokenCmd() *core.Command {
 			TraverseChildren: true,
 		},
 	}
-
-	tokenCmd.Command.PersistentFlags().Bool(
-		constants.ArgNoHeaders, false, "When using text output, don't print headers",
-	)
 
 	tokenCmd.AddCommand(TokenListCmd())
 	tokenCmd.AddCommand(TokenPostCmd())

--- a/commands/dataplatform/cluster/cluster.go
+++ b/commands/dataplatform/cluster/cluster.go
@@ -38,7 +38,6 @@ func ClusterCmd() *core.Command {
 	_ = clusterCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	clusterCmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	clusterCmd.AddCommand(ClusterListCmd())
 	clusterCmd.AddCommand(ClusterCreateCmd())

--- a/commands/dataplatform/nodepool/nodepool.go
+++ b/commands/dataplatform/nodepool/nodepool.go
@@ -27,7 +27,6 @@ func NodepoolCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	cmd.AddCommand(NodepoolListCmd())
 	cmd.AddCommand(NodepoolCreateCmd())

--- a/commands/dbaas/mongo/cluster/cluster.go
+++ b/commands/dbaas/mongo/cluster/cluster.go
@@ -41,7 +41,6 @@ func ClusterCmd() *core.Command {
 	_ = clusterCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	clusterCmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	clusterCmd.AddCommand(ClusterListCmd())
 	clusterCmd.AddCommand(ClusterCreateCmd())

--- a/commands/dbaas/mongo/cluster/delete.go
+++ b/commands/dbaas/mongo/cluster/delete.go
@@ -87,7 +87,6 @@ ionosctl db m c d --all --name <name>`,
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all mongo clusters")
 	cmd.AddBoolFlag(constants.FlagName, "", false, "When deleting all clusters, filter the clusters by a name")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", nil, tabheaders.ColsMessage(allCols))

--- a/commands/dbaas/mongo/logs/list.go
+++ b/commands/dbaas/mongo/logs/list.go
@@ -110,7 +110,6 @@ func LogsListCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", nil, tabheaders.ColsMessage(allCols))
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp

--- a/commands/dbaas/mongo/snapshot/list.go
+++ b/commands/dbaas/mongo/snapshot/list.go
@@ -60,7 +60,6 @@ func SnapshotsListCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", nil, tabheaders.ColsMessage(allCols))
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp

--- a/commands/dbaas/mongo/templates/list.go
+++ b/commands/dbaas/mongo/templates/list.go
@@ -59,7 +59,6 @@ func TemplatesListCmd() *core.Command {
 		InitClient: true,
 	})
 
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", allCols, tabheaders.ColsMessage(allCols))
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp

--- a/commands/dbaas/mongo/user/list.go
+++ b/commands/dbaas/mongo/user/list.go
@@ -84,7 +84,6 @@ ionosctl dbaas mongo user list --cluster-id <cluster-id>`,
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", nil, tabheaders.ColsMessage(allCols))
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp

--- a/commands/dbaas/mongo/user/user.go
+++ b/commands/dbaas/mongo/user/user.go
@@ -35,7 +35,6 @@ func UserCmd() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	cmd.AddCommand(UserListCmd())
 	cmd.AddCommand(UserCreateCmd())

--- a/commands/dbaas/postgres/api-version.go
+++ b/commands/dbaas/postgres/api-version.go
@@ -48,6 +48,7 @@ func APIVersionCmd() *core.Command {
 		CmdRun:     RunAPIVersionList,
 		InitClient: true,
 	})
+	_ = list // Actually used - added through "NewCommand" func. TODO: This is confusing!
 
 	/*
 		Get Command
@@ -64,6 +65,7 @@ func APIVersionCmd() *core.Command {
 		CmdRun:     RunAPIVersionGet,
 		InitClient: true,
 	})
+	_ = get // Actually used - added through "NewCommand" func. TODO: This is confusing!
 
 	return apiversionCmd
 }

--- a/commands/dbaas/postgres/api-version.go
+++ b/commands/dbaas/postgres/api-version.go
@@ -48,7 +48,6 @@ func APIVersionCmd() *core.Command {
 		CmdRun:     RunAPIVersionList,
 		InitClient: true,
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -65,7 +64,6 @@ func APIVersionCmd() *core.Command {
 		CmdRun:     RunAPIVersionGet,
 		InitClient: true,
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return apiversionCmd
 }

--- a/commands/dbaas/postgres/backup.go
+++ b/commands/dbaas/postgres/backup.go
@@ -47,7 +47,6 @@ func BackupCmd() *core.Command {
 		CmdRun:     RunBackupList,
 		InitClient: true,
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -68,7 +67,6 @@ func BackupCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return backupCmd
 }
@@ -153,7 +151,6 @@ func ClusterBackupCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allBackupCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return clusterBackupCmd
 }

--- a/commands/dbaas/postgres/backup.go
+++ b/commands/dbaas/postgres/backup.go
@@ -47,6 +47,7 @@ func BackupCmd() *core.Command {
 		CmdRun:     RunBackupList,
 		InitClient: true,
 	})
+	_ = list // Actually used - added through "NewCommand" func. TODO: This is confusing!
 
 	/*
 		Get Command

--- a/commands/dbaas/postgres/cluster.go
+++ b/commands/dbaas/postgres/cluster.go
@@ -54,7 +54,6 @@ func ClusterCmd() *core.Command {
 		InitClient: true,
 	})
 	list.AddStringFlag(dbaaspg.ArgName, dbaaspg.ArgNameShort, "", "Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive")
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
 	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
@@ -85,7 +84,6 @@ func ClusterCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Create Command

--- a/commands/dbaas/postgres/logs.go
+++ b/commands/dbaas/postgres/logs.go
@@ -71,7 +71,6 @@ func LogsCmd() *core.Command {
 	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return clusterCmd
 }

--- a/commands/dbaas/postgres/version.go
+++ b/commands/dbaas/postgres/version.go
@@ -47,6 +47,7 @@ func PgsqlVersionCmd() *core.Command {
 		CmdRun:     RunPgsqlVersionList,
 		InitClient: true,
 	})
+	_ = list // Actually used - added through "NewCommand" func. TODO: This is confusing!
 
 	/*
 		Get Command

--- a/commands/dbaas/postgres/version.go
+++ b/commands/dbaas/postgres/version.go
@@ -47,7 +47,6 @@ func PgsqlVersionCmd() *core.Command {
 		CmdRun:     RunPgsqlVersionList,
 		InitClient: true,
 	})
-	list.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	/*
 		Get Command
@@ -68,7 +67,6 @@ func PgsqlVersionCmd() *core.Command {
 	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return pgsqlcompleter.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	get.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return pgsqlversionCmd
 }

--- a/commands/dns/record/record.go
+++ b/commands/dns/record/record.go
@@ -48,7 +48,6 @@ func RecordCommand() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	cmd.AddCommand(RecordsGetCmd())
 	cmd.AddCommand(ZonesRecordsDeleteCmd())

--- a/commands/dns/zone/zone.go
+++ b/commands/dns/zone/zone.go
@@ -43,7 +43,6 @@ func ZoneCommand() *core.Command {
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return allCols, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.Command.PersistentFlags().Bool(constants.ArgNoHeaders, false, "When using text output, don't print headers")
 
 	cmd.AddCommand(ZonesGetCmd())
 	cmd.AddCommand(ZonesDeleteCmd())

--- a/commands/root.go
+++ b/commands/root.go
@@ -36,10 +36,11 @@ var (
 			TraverseChildren: true,
 		},
 	}
-	Output  string
-	Quiet   bool
-	Force   bool
-	Verbose bool
+	Output    string
+	Quiet     bool
+	Force     bool
+	Verbose   bool
+	NoHeaders bool
 
 	cfgFile string
 
@@ -129,6 +130,9 @@ func init() {
 		"Print step-by-step process when running command",
 	)
 	_ = viper.BindPFlag(constants.ArgVerbose, rootPFlagSet.Lookup(constants.ArgVerbose))
+
+	rootPFlagSet.Bool(constants.ArgNoHeaders, false, "Don't print table headers when table output is used")
+	_ = viper.BindPFlag(constants.ArgNoHeaders, rootPFlagSet.Lookup(constants.ArgNoHeaders))
 
 	// Add SubCommands to RootCmd
 	addCommands()

--- a/commands/token/get.go
+++ b/commands/token/get.go
@@ -35,7 +35,6 @@ func TokenGetCmd() *core.Command {
 	})
 	cmd.AddStringFlag(authservice.ArgToken, authservice.ArgTokenShort, "", authservice.Token, core.RequiredFlagOption())
 	cmd.AddIntFlag(authservice.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the token information is displayed")
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return cmd
 }

--- a/commands/token/list.go
+++ b/commands/token/list.go
@@ -26,7 +26,6 @@ func TokenListCmd() *core.Command {
 		InitClient: true,
 	})
 	cmd.AddIntFlag(authservice.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the tokens are listed")
-	cmd.AddBoolFlag(constants.ArgNoHeaders, "", false, "When using text output, don't print headers")
 
 	return cmd
 }

--- a/docs/subcommands/Application-Load-Balancer/create.md
+++ b/docs/subcommands/Application-Load-Balancer/create.md
@@ -48,6 +48,7 @@ Required values to run command:
       --ips strings            Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.
       --listener-lan int       ID of the listening (inbound) LAN. (default 2)
   -n, --name string            The name of the Application Load Balancer. (default "Unnamed Application Load Balancer")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --private-ips strings    Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Application-Load-Balancer/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/delete.md
@@ -48,6 +48,7 @@ Required values to run command:
   -D, --depth int32                         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -t, --timeout int                         Timeout option for Request for Application Load Balancer deletion [seconds] (default 300)

--- a/docs/subcommands/Application-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/create.md
@@ -57,6 +57,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -n, --name string                         The name of the Application Load Balancer FlowLog. (default "Unnamed ALB Flow Log")
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -b, --s3bucket string                     S3 bucket name of an existing IONOS Cloud S3 bucket. (required)

--- a/docs/subcommands/Application-Load-Balancer/flowlog/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/delete.md
@@ -56,6 +56,7 @@ Required values to run command:
   -i, --flowlog-id string                   The unique FlowLog Id (required)
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -t, --timeout int                         Timeout option for Request for Application Load Balancer FlowLog deletion [seconds] (default 300)

--- a/docs/subcommands/Application-Load-Balancer/flowlog/get.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/get.md
@@ -53,6 +53,7 @@ Required values to run command:
   -i, --flowlog-id string                   The unique FlowLog Id (required)
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -v, --verbose                             Print step-by-step process when running command

--- a/docs/subcommands/Application-Load-Balancer/flowlog/list.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/list.md
@@ -53,6 +53,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -M, --max-results int32                   The maximum number of elements to return
+      --no-headers                          Don't print table headers when table output is used
       --order-by string                     Limits results to those containing a matching value for a specific property
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output

--- a/docs/subcommands/Application-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/update.md
@@ -58,6 +58,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -n, --name string                         The name of the Application Load Balancer FlowLog.
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -b, --s3bucket string                     S3 bucket name of an existing IONOS Cloud S3 bucket.

--- a/docs/subcommands/Application-Load-Balancer/get.md
+++ b/docs/subcommands/Application-Load-Balancer/get.md
@@ -45,6 +45,7 @@ Required values to run command:
   -D, --depth int32                         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -t, --timeout int                         Timeout option for waiting for Application Load Balancer to be in AVAILABLE state [seconds] (default 300)

--- a/docs/subcommands/Application-Load-Balancer/list.md
+++ b/docs/subcommands/Application-Load-Balancer/list.md
@@ -46,6 +46,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Application-Load-Balancer/rule/create.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/create.md
@@ -59,6 +59,7 @@ Required values to run command:
       --listener-ip ip                      Listening (inbound) IP. It must be assigned to the listener NIC of Application Load Balancer. (required)
       --listener-port int                   Listening (inbound) port number; valid range is 1 to 65535. (required) (default 8080)
   -n, --name string                         The name of the Application Load Balancer forwarding rule. (default "Unnamed Forwarding Rule")
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -p, --protocol string                     Balancing protocol. (default "HTTP")
   -q, --quiet                               Quiet output

--- a/docs/subcommands/Application-Load-Balancer/rule/delete.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/delete.md
@@ -55,6 +55,7 @@ Required values to run command:
   -D, --depth int32                         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -i, --rule-id string                      The unique ForwardingRule Id (required)

--- a/docs/subcommands/Application-Load-Balancer/rule/get.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/get.md
@@ -52,6 +52,7 @@ Required values to run command:
   -D, --depth int32                         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -i, --rule-id string                      The unique ForwardingRule Id (required)

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/add.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/add.md
@@ -65,6 +65,7 @@ Required values to run command:
   -m, --message string                      The response message of the request; mandatory for STATIC actions. (default "Application Down")
   -n, --name string                         The unique name of the Application Load Balancer HTTP rule. (required)
       --negate                              Specifies whether the condition is negated or not
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -Q, --query                               Default is false; valid only for REDIRECT actions.
   -q, --quiet                               Quiet output

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/list.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/list.md
@@ -53,6 +53,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -M, --max-results int32                   The maximum number of elements to return
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
       --rule-id string                      The unique ForwardingRule Id (required)

--- a/docs/subcommands/Application-Load-Balancer/rule/httprule/remove.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/httprule/remove.md
@@ -57,6 +57,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -n, --name string                         A name of that Application Load Balancer Http Rule (required)
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
       --rule-id string                      The unique ForwardingRule Id (required)

--- a/docs/subcommands/Application-Load-Balancer/rule/list.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/list.md
@@ -53,6 +53,7 @@ Required values to run command:
   -f, --force                               Force command to execute without user input
   -h, --help                                Print usage
   -M, --max-results int32                   The maximum number of elements to return
+      --no-headers                          Don't print table headers when table output is used
       --order-by string                     Limits results to those containing a matching value for a specific property
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output

--- a/docs/subcommands/Application-Load-Balancer/rule/update.md
+++ b/docs/subcommands/Application-Load-Balancer/rule/update.md
@@ -58,6 +58,7 @@ Required values to run command:
       --listener-ip ip                      Listening (inbound) IP.
       --listener-port int                   Listening (inbound) port number; valid range is 1 to 65535. (default 8080)
   -n, --name string                         The name of the Application Load Balancer forwarding rule.
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
   -q, --quiet                               Quiet output
   -i, --rule-id string                      The unique ForwardingRule Id (required)

--- a/docs/subcommands/Application-Load-Balancer/update.md
+++ b/docs/subcommands/Application-Load-Balancer/update.md
@@ -50,6 +50,7 @@ Required values to run command:
       --ips strings                         Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.
       --listener-lan int                    ID of the listening (inbound) LAN.
   -n, --name string                         The name of the Application Load Balancer. (default "Application Load Balancer")
+      --no-headers                          Don't print table headers when table output is used
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
       --private-ips strings                 Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.
   -q, --quiet                               Quiet output

--- a/docs/subcommands/Authentication/token/delete.md
+++ b/docs/subcommands/Authentication/token/delete.md
@@ -39,6 +39,7 @@ Required values to run command:
   -E, --expired           Delete the Tokens that are currently expired (required)
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -t, --token string      The contents of a Token (required)

--- a/docs/subcommands/Authentication/token/generate.md
+++ b/docs/subcommands/Authentication/token/generate.md
@@ -32,6 +32,7 @@ Use this command to generate a new Token. Only the JSON Web Token, associated wi
       --contract int     Users with multiple contracts can provide the contract number, for which the token is generated
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Authentication/token/get.md
+++ b/docs/subcommands/Authentication/token/get.md
@@ -36,7 +36,7 @@ Required values to run command:
       --contract int      Users with multiple contracts must provide the contract number, for which the token information is displayed
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
-      --no-headers        When using text output, don't print headers
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -t, --token string      The contents of a Token (required)

--- a/docs/subcommands/Authentication/token/list.md
+++ b/docs/subcommands/Authentication/token/list.md
@@ -32,7 +32,7 @@ Use this command to retrieve a complete list of Tokens under your account, to li
       --contract int     Users with multiple contracts must provide the contract number, for which the tokens are listed
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Authentication/token/parse.md
+++ b/docs/subcommands/Authentication/token/parse.md
@@ -36,6 +36,7 @@ Required values to run:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -p, --privileges       Use to see the privileges that the user using this Token benefits from
   -q, --quiet            Quiet output

--- a/docs/subcommands/CLI Setup/version.md
+++ b/docs/subcommands/CLI Setup/version.md
@@ -21,6 +21,7 @@ The `ionosctl version` command displays the current version of the ionosctl soft
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
       --updates          Check for latest updates for CLI

--- a/docs/subcommands/Certificate-Manager/add.md
+++ b/docs/subcommands/Certificate-Manager/add.md
@@ -36,7 +36,7 @@ Use this command to add a Certificate.
   -c, --config string                   Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
       --private-key string              Specify the private key (required either this or --private-key-path)
       --private-key-path string         Specify the private key from a file (required either this or --private-key)

--- a/docs/subcommands/Certificate-Manager/api/version.md
+++ b/docs/subcommands/Certificate-Manager/api/version.md
@@ -31,7 +31,7 @@ Use this command to retrieve API Version.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-  -n, --no-headers       Response delete all certificates
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Certificate-Manager/delete.md
+++ b/docs/subcommands/Certificate-Manager/delete.md
@@ -33,7 +33,7 @@ Use this command to delete a Certificate by ID.
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
-      --no-headers              When using text output, don't print headers
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -q, --quiet                   Quiet output
   -v, --verbose                 Print step-by-step process when running command

--- a/docs/subcommands/Certificate-Manager/get.md
+++ b/docs/subcommands/Certificate-Manager/get.md
@@ -34,7 +34,7 @@ Use this command to retrieve a Certificate by ID.
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
-      --no-headers              When using text output, don't print headers
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -q, --quiet                   Quiet output
   -v, --verbose                 Print step-by-step process when running command

--- a/docs/subcommands/Certificate-Manager/list.md
+++ b/docs/subcommands/Certificate-Manager/list.md
@@ -31,7 +31,7 @@ Use this command to retrieve all Certificates.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Certificate-Manager/update.md
+++ b/docs/subcommands/Certificate-Manager/update.md
@@ -33,7 +33,7 @@ Use this change a certificate's name.
   -c, --config string             Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                     Force command to execute without user input
   -h, --help                      Print usage
-      --no-headers                When using text output, don't print headers
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
   -v, --verbose                   Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/config/location.md
+++ b/docs/subcommands/Compute Engine/config/location.md
@@ -35,6 +35,7 @@ Print your config file's path
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/config/login.md
+++ b/docs/subcommands/Compute Engine/config/login.md
@@ -54,6 +54,7 @@ Within each layer, a token takes precedence over a username and password combina
   -c, --config string     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -p, --password string   Password to authenticate. Will be used to generate a token
   -q, --quiet             Quiet output

--- a/docs/subcommands/Compute Engine/config/logout.md
+++ b/docs/subcommands/Compute Engine/config/logout.md
@@ -37,6 +37,7 @@ Within each layer, a token takes precedence over a username and password combina
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/config/whoami.md
+++ b/docs/subcommands/Compute Engine/config/whoami.md
@@ -39,6 +39,7 @@ Within each layer, a token takes precedence over a username and password combina
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -p, --provenance       If set, the command prints the layers of authentication sources, their order of priority, and which one was used. It also tells you if a token or username and password are being used for authentication.
   -q, --quiet            Quiet output

--- a/docs/subcommands/Compute Engine/contract/get.md
+++ b/docs/subcommands/Compute Engine/contract/get.md
@@ -38,7 +38,7 @@ Use this command to get information about the Contract Resources on your account
   -D, --depth int32              Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
-      --no-headers               When using text output, don't print headers
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --resource-limits string   Specify Resource Limits to see details about it

--- a/docs/subcommands/Compute Engine/datacenter/create.md
+++ b/docs/subcommands/Compute Engine/datacenter/create.md
@@ -45,6 +45,7 @@ You can wait for the Request to be executed using `--wait-for-request` option.
   -h, --help                 Print usage
   -l, --location string      Location for the Data Center (default "de/txl")
   -n, --name string          Name of the Data Center (default "Unnamed Data Center")
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -t, --timeout int          Timeout option for Request for Data Center creation [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/datacenter/delete.md
+++ b/docs/subcommands/Compute Engine/datacenter/delete.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for Data Center deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/datacenter/get.md
+++ b/docs/subcommands/Compute Engine/datacenter/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/datacenter/list.md
+++ b/docs/subcommands/Compute Engine/datacenter/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/datacenter/update.md
+++ b/docs/subcommands/Compute Engine/datacenter/update.md
@@ -47,6 +47,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -n, --name string            Name of the Data Center
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for Data Center update [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/firewallrule/create.md
+++ b/docs/subcommands/Compute Engine/firewallrule/create.md
@@ -57,6 +57,7 @@ Required values to run command:
       --ip-version string      The IP version for the Firewall Rule. Can be one of: IPv4, IPv6 (default "IPv4")
   -n, --name string            The name for the Firewall Rule (default "Unnamed Rule")
       --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --port-range-end int     Define the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports (default 1)
       --port-range-start int   Define the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports (default 1)

--- a/docs/subcommands/Compute Engine/firewallrule/delete.md
+++ b/docs/subcommands/Compute Engine/firewallrule/delete.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --nic-id string            The unique NIC Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --server-id string         The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/firewallrule/get.md
+++ b/docs/subcommands/Compute Engine/firewallrule/get.md
@@ -48,7 +48,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --nic-id string            The unique NIC Id (required)
-      --no-headers               When using text output, don't print headers
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --server-id string         The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/firewallrule/list.md
+++ b/docs/subcommands/Compute Engine/firewallrule/list.md
@@ -53,7 +53,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
       --nic-id string          The unique NIC Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/firewallrule/update.md
+++ b/docs/subcommands/Compute Engine/firewallrule/update.md
@@ -56,6 +56,7 @@ Required values to run command:
       --ip-version string        The IP version for the Firewall Rule. Can be one of: IPv4, IPv6 (default "IPv4")
   -n, --name string              The name for the Firewall Rule
       --nic-id string            The unique NIC Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
       --port-range-end int       Redefine the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports (default 1)
       --port-range-start int     Redefine the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports (default 1)

--- a/docs/subcommands/Compute Engine/flowlog/create.md
+++ b/docs/subcommands/Compute Engine/flowlog/create.md
@@ -54,6 +54,7 @@ Required values to run command:
   -h, --help                   Print usage
   -n, --name string            The name for the FlowLog (default "Unnamed FlowLog")
       --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)

--- a/docs/subcommands/Compute Engine/flowlog/delete.md
+++ b/docs/subcommands/Compute Engine/flowlog/delete.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/flowlog/get.md
+++ b/docs/subcommands/Compute Engine/flowlog/get.md
@@ -48,7 +48,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --nic-id string          The unique NIC Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/flowlog/list.md
+++ b/docs/subcommands/Compute Engine/flowlog/list.md
@@ -53,7 +53,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
       --nic-id string          The unique NIC Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/group/create.md
+++ b/docs/subcommands/Compute Engine/group/create.md
@@ -53,6 +53,7 @@ Use this command to create a new Group and set Group privileges. You can specify
       --manage-dbaas          Privilege for a group to manage DBaaS related functionality
       --manage-registry       Privilege for group accessing container registry related functionality
   -n, --name string           Name for the Group (default "Unnamed Group")
+      --no-headers            Don't print table headers when table output is used
   -o, --output string         Desired output format [text|json|api-json] (default "text")
   -q, --quiet                 Quiet output
       --reserve-ip            The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false

--- a/docs/subcommands/Compute Engine/group/delete.md
+++ b/docs/subcommands/Compute Engine/group/delete.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -i, --group-id string    The unique Group Id (required)
   -h, --help               Print usage
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -t, --timeout int        Timeout option for Request for Group deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/group/get.md
+++ b/docs/subcommands/Compute Engine/group/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
   -i, --group-id string   The unique Group Id (required)
   -h, --help              Print usage
-      --no-headers        When using text output, don't print headers
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -v, --verbose           Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/group/list.md
+++ b/docs/subcommands/Compute Engine/group/list.md
@@ -44,7 +44,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/group/resource/list.md
+++ b/docs/subcommands/Compute Engine/group/resource/list.md
@@ -49,6 +49,7 @@ Required values to run command:
       --group-id string     The unique Group Id (required)
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/group/update.md
+++ b/docs/subcommands/Compute Engine/group/update.md
@@ -60,6 +60,7 @@ Required values to run command:
       --manage-dbaas          Privilege for a group to manage DBaaS related functionality
       --manage-registry       Privilege for group accessing container registry related functionality
   -n, --name string           Name for the Group
+      --no-headers            Don't print table headers when table output is used
   -o, --output string         Desired output format [text|json|api-json] (default "text")
   -q, --quiet                 Quiet output
       --reserve-ip            The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false

--- a/docs/subcommands/Compute Engine/group/user/add.md
+++ b/docs/subcommands/Compute Engine/group/user/add.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
       --group-id string   The unique Group Id (required)
   -h, --help              Print usage
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -i, --user-id string    The unique User Id (required)

--- a/docs/subcommands/Compute Engine/group/user/list.md
+++ b/docs/subcommands/Compute Engine/group/user/list.md
@@ -52,7 +52,7 @@ Available Filters:
       --group-id string     The unique Group Id (required)
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/group/user/remove.md
+++ b/docs/subcommands/Compute Engine/group/user/remove.md
@@ -50,6 +50,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
       --group-id string   The unique Group Id (required)
   -h, --help              Print usage
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -i, --user-id string    The unique User Id (required)

--- a/docs/subcommands/Compute Engine/image/delete.md
+++ b/docs/subcommands/Compute Engine/image/delete.md
@@ -44,7 +44,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
   -i, --image-id string    The unique Image Id (required)
-      --no-headers         When using text output, don't print headers
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -t, --timeout int        Timeout option for Request for Image update [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/image/get.md
+++ b/docs/subcommands/Compute Engine/image/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
   -i, --image-id string   The unique Image Id (required)
-      --no-headers        When using text output, don't print headers
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -v, --verbose           Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/image/list.md
+++ b/docs/subcommands/Compute Engine/image/list.md
@@ -49,7 +49,7 @@ Available Filters:
       --licence-type string   The licence type of the Image (DEPRECATED: incompatible with --max-results. Use --filters --order-by --max-results options instead!)
   -l, --location string       The location of the Image (DEPRECATED: incompatible with --max-results. Use --filters --order-by --max-results options instead!)
   -M, --max-results int32     The maximum number of elements to return
-      --no-headers            When using text output, don't print headers
+      --no-headers            Don't print table headers when table output is used
       --order-by string       Limits results to those containing a matching value for a specific property
   -o, --output string         Desired output format [text|json|api-json] (default "text")
   -q, --quiet                 Quiet output

--- a/docs/subcommands/Compute Engine/image/update.md
+++ b/docs/subcommands/Compute Engine/image/update.md
@@ -55,7 +55,7 @@ Required values to run command:
   -n, --name string              Name of the Image
       --nic-hot-plug             'Hot-Plug' NIC (default true)
       --nic-hot-unplug           'Hot-Unplug' NIC
-      --no-headers               When using text output, don't print headers
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --ram-hot-plug             'Hot-Plug' RAM (default true)

--- a/docs/subcommands/Compute Engine/image/upload.md
+++ b/docs/subcommands/Compute Engine/image/upload.md
@@ -59,6 +59,7 @@ Required values to run command:
   -n, --name string              Name of the Image
       --nic-hot-plug             'Hot-Plug' NIC (default true)
       --nic-hot-unplug           'Hot-Unplug' NIC
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --ram-hot-plug             'Hot-Plug' RAM (default true)

--- a/docs/subcommands/Compute Engine/ipblock/create.md
+++ b/docs/subcommands/Compute Engine/ipblock/create.md
@@ -42,6 +42,7 @@ You can wait for the Request to be executed using `--wait-for-request` option.
   -h, --help               Print usage
   -l, --location string    Location of the IpBlock (default "de/txl")
   -n, --name string        Name of the IpBlock. If not set, it will automatically be set
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
       --size int           Size of the IpBlock (default 2)

--- a/docs/subcommands/Compute Engine/ipblock/delete.md
+++ b/docs/subcommands/Compute Engine/ipblock/delete.md
@@ -46,6 +46,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -i, --ipblock-id string   The unique IpBlock Id (required)
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for Request for IpBlock deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/ipblock/get.md
+++ b/docs/subcommands/Compute Engine/ipblock/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -i, --ipblock-id string   The unique IpBlock Id (required)
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/ipblock/list.md
+++ b/docs/subcommands/Compute Engine/ipblock/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/ipblock/update.md
+++ b/docs/subcommands/Compute Engine/ipblock/update.md
@@ -46,6 +46,7 @@ Required values to run command:
   -h, --help                Print usage
   -i, --ipblock-id string   The unique IpBlock Id (required)
   -n, --name string         Name of the IpBlock
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for Request for IpBlock update [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/ipconsumer/list.md
+++ b/docs/subcommands/Compute Engine/ipconsumer/list.md
@@ -44,7 +44,7 @@ Required values to run command:
   -h, --help                Print usage
       --ipblock-id string   The unique IpBlock Id (required)
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/ipfailover/add.md
+++ b/docs/subcommands/Compute Engine/ipfailover/add.md
@@ -56,6 +56,7 @@ Required values to run command:
       --ip ip                  IP address to be added to IP Failover Group (required)
       --lan-id string          The unique LAN Id (required)
       --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/ipfailover/list.md
+++ b/docs/subcommands/Compute Engine/ipfailover/list.md
@@ -46,7 +46,7 @@ Required values to run command:
   -h, --help                   Print usage
       --lan-id string          The unique LAN Id (required)
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/ipfailover/remove.md
+++ b/docs/subcommands/Compute Engine/ipfailover/remove.md
@@ -51,6 +51,7 @@ Required values to run command:
       --ip ip                  Allocated IP (required)
       --lan-id string          The unique LAN Id (required)
       --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/label/add.md
+++ b/docs/subcommands/Compute Engine/label/add.md
@@ -43,6 +43,7 @@ Required values to run command:
       --ipblock-id string      The unique IpBlock Id
       --label-key string       The unique Label Key (required)
       --label-value string     The unique Label Value (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --resource-type string   Type of resource to add labels to. Can be one of: datacenter, volume, server, snapshot, ipblock (required)

--- a/docs/subcommands/Compute Engine/label/get.md
+++ b/docs/subcommands/Compute Engine/label/get.md
@@ -41,7 +41,7 @@ Required values to run command:
   -h, --help                   Print usage
       --ipblock-id string      The unique IpBlock Id
       --label-key string       The unique Label Key (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --resource-type string   Type of resource to get labels from. Can be one of: datacenter, volume, server, snapshot, ipblock (required)

--- a/docs/subcommands/Compute Engine/label/get/by/urn.md
+++ b/docs/subcommands/Compute Engine/label/get/by/urn.md
@@ -29,7 +29,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --label-urn string   URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>] (required)
-      --no-headers         When using text output, don't print headers
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -v, --verbose            Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/label/list.md
+++ b/docs/subcommands/Compute Engine/label/list.md
@@ -41,7 +41,7 @@ Available Filters:
   -h, --help                   Print usage
       --ipblock-id string      The unique IpBlock Id
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/label/remove.md
+++ b/docs/subcommands/Compute Engine/label/remove.md
@@ -42,6 +42,7 @@ Required values to run command:
   -h, --help                   Print usage
       --ipblock-id string      The unique IpBlock Id
       --label-key string       The unique Label Key (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --resource-type string   Type of resource to remove labels from. Can be one of: datacenter, volume, server, snapshot, ipblock (required)

--- a/docs/subcommands/Compute Engine/lan/create.md
+++ b/docs/subcommands/Compute Engine/lan/create.md
@@ -49,6 +49,7 @@ Required values to run command:
   -h, --help                   Print usage
       --ipv6-cidr string       The /64 IPv6 Cidr as defined in RFC 4291. It needs to be within the Datacenter IPv6 Cidr Block range. It can also be set to "AUTO" or "DISABLE". (default "DISABLE")
   -n, --name string            The name of the LAN (default "Unnamed LAN")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --pcc-id string          The unique Id of the Cross-Connect the LAN will connect to
   -p, --public                 Indicates if the LAN faces the public Internet (true) or not (false). E.g.: --public=true, --public=false

--- a/docs/subcommands/Compute Engine/lan/delete.md
+++ b/docs/subcommands/Compute Engine/lan/delete.md
@@ -48,6 +48,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --lan-id string          The unique LAN Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for LAN deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/lan/get.md
+++ b/docs/subcommands/Compute Engine/lan/get.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --lan-id string          The unique LAN Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/lan/list.md
+++ b/docs/subcommands/Compute Engine/lan/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/lan/update.md
+++ b/docs/subcommands/Compute Engine/lan/update.md
@@ -49,6 +49,7 @@ Required values to run command:
       --ipv6-cidr string       The /64 IPv6 Cidr as defined in RFC 4291. It needs to be within the Datacenter IPv6 Cidr Block range. It can also be set to "AUTO" or "DISABLE". NOTE: Using an explicit Cidr to update the resource is not fully supported yet. (default "DISABLE")
   -i, --lan-id string          The unique LAN Id (required)
   -n, --name string            The name of the LAN
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --pcc-id string          The unique Id of the Cross-Connect the LAN will connect to
       --public                 Public option for LAN. E.g.: --public=true, --public=false

--- a/docs/subcommands/Compute Engine/loadbalancer/create.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/create.md
@@ -47,6 +47,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -n, --name string            Name of the Load Balancer (default "Load Balancer")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for Load Balancer creation [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/loadbalancer/delete.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/delete.md
@@ -48,6 +48,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
   -i, --loadbalancer-id string   The unique Load Balancer Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
   -t, --timeout int              Timeout option for Request for Load Balancer deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/loadbalancer/get.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/get.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
   -i, --loadbalancer-id string   The unique Load Balancer Id (required)
-      --no-headers               When using text output, don't print headers
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
   -v, --verbose                  Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/loadbalancer/list.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/attach.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/attach.md
@@ -54,6 +54,7 @@ Required values to run command:
   -h, --help                     Print usage
       --loadbalancer-id string   The unique Load Balancer Id (required)
   -i, --nic-id string            The unique NIC Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --server-id string         The unique Server Id on which NIC is build on. Not required, but it helps in autocompletion

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/detach.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/detach.md
@@ -55,6 +55,7 @@ Required values to run command:
   -h, --help                     Print usage
       --loadbalancer-id string   The unique Load Balancer Id (required)
   -i, --nic-id string            The unique NIC Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
   -t, --timeout int              Timeout option for Request for NIC detachment [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/get.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/get.md
@@ -52,6 +52,7 @@ Required values to run the command:
   -h, --help                     Print usage
       --loadbalancer-id string   The unique Load Balancer Id (required)
   -i, --nic-id string            The unique NIC Id (required)
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
   -v, --verbose                  Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/loadbalancer/nic/list.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/nic/list.md
@@ -52,6 +52,7 @@ Required values to run command:
   -h, --help                     Print usage
       --loadbalancer-id string   The unique Load Balancer Id (required)
   -M, --max-results int32        The maximum number of elements to return
+      --no-headers               Don't print table headers when table output is used
       --order-by string          Limits results to those containing a matching value for a specific property
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output

--- a/docs/subcommands/Compute Engine/loadbalancer/update.md
+++ b/docs/subcommands/Compute Engine/loadbalancer/update.md
@@ -50,6 +50,7 @@ Required values to run command:
       --ip ip                    The IP of the Load Balancer
   -i, --loadbalancer-id string   The unique Load Balancer Id (required)
   -n, --name string              Name of the Load Balancer
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
   -t, --timeout int              Timeout option for Request for Load Balancer update [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/location/cpu/list.md
+++ b/docs/subcommands/Compute Engine/location/cpu/list.md
@@ -44,7 +44,7 @@ Required values to run command:
   -h, --help                 Print usage
       --location-id string   The unique Location Id (required)
   -M, --max-results int32    The maximum number of elements to return
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/location/get.md
+++ b/docs/subcommands/Compute Engine/location/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -i, --location-id string   The unique Location Id (required)
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/location/list.md
+++ b/docs/subcommands/Compute Engine/location/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/nic/create.md
+++ b/docs/subcommands/Compute Engine/nic/create.md
@@ -55,6 +55,7 @@ Required values to run a command:
       --ipv6-ips strings       IPv6 IPs assigned to the NIC. They need to be within the NIC IPv6 Cidr Block.
       --lan-id int             The LAN ID the NIC will sit on. If the LAN ID does not exist it will be created (default 1)
   -n, --name string            The name of the NIC (default "Internet Access")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/nic/delete.md
+++ b/docs/subcommands/Compute Engine/nic/delete.md
@@ -49,6 +49,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/nic/get.md
+++ b/docs/subcommands/Compute Engine/nic/get.md
@@ -46,7 +46,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --nic-id string          The unique NIC Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/nic/list.md
+++ b/docs/subcommands/Compute Engine/nic/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/nic/update.md
+++ b/docs/subcommands/Compute Engine/nic/update.md
@@ -60,6 +60,7 @@ Required values to run command:
       --lan-id int             The LAN ID the NIC sits on (default 1)
   -n, --name string            The name of the NIC
   -i, --nic-id string          The unique NIC Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/pcc/create.md
+++ b/docs/subcommands/Compute Engine/pcc/create.md
@@ -40,6 +40,7 @@ Use this command to create a Cross-Connect. You can specify the name and the des
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          The name for the Cross-Connect (default "Unnamed PrivateCrossConnect")
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -t, --timeout int          Timeout option for Request for Cross-Connect creation [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/pcc/delete.md
+++ b/docs/subcommands/Compute Engine/pcc/delete.md
@@ -43,6 +43,7 @@ Required values to run command:
   -D, --depth int32        Controls the detail depth of the response objects. Max depth is 10.
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -i, --pcc-id string      The unique Cross-Connect Id (required)
   -q, --quiet              Quiet output

--- a/docs/subcommands/Compute Engine/pcc/get.md
+++ b/docs/subcommands/Compute Engine/pcc/get.md
@@ -42,7 +42,7 @@ Required values to run command:
   -D, --depth int32      Controls the detail depth of the response objects. Max depth is 10.
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -i, --pcc-id string    The unique Cross-Connect Id (required)
   -q, --quiet            Quiet output

--- a/docs/subcommands/Compute Engine/pcc/list.md
+++ b/docs/subcommands/Compute Engine/pcc/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/pcc/peers/list.md
+++ b/docs/subcommands/Compute Engine/pcc/peers/list.md
@@ -41,7 +41,7 @@ Required values to run command:
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
       --pcc-id string    The unique Cross-Connect Id (required)
   -q, --quiet            Quiet output

--- a/docs/subcommands/Compute Engine/pcc/update.md
+++ b/docs/subcommands/Compute Engine/pcc/update.md
@@ -44,6 +44,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          The name for the Cross-Connect
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -i, --pcc-id string        The unique Cross-Connect Id (required)
   -q, --quiet                Quiet output

--- a/docs/subcommands/Compute Engine/request/get.md
+++ b/docs/subcommands/Compute Engine/request/get.md
@@ -42,7 +42,7 @@ Required values to run command:
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -i, --request-id string   The unique Request Id (required)

--- a/docs/subcommands/Compute Engine/request/list.md
+++ b/docs/subcommands/Compute Engine/request/list.md
@@ -47,7 +47,7 @@ Available Filters:
       --latest int          Show latest N Requests. If it is not set, all Requests will be printed (DEPRECATED: Use --filters --order-by --max-results options instead!)
   -M, --max-results int32   The maximum number of elements to return
       --method string       Show only the Requests with this method. E.g CREATE, UPDATE, DELETE (DEPRECATED: Use --filters --order-by --max-results options instead!)
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/request/wait.md
+++ b/docs/subcommands/Compute Engine/request/wait.md
@@ -44,6 +44,7 @@ Required values to run command:
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -i, --request-id string   The unique Request Id (required)

--- a/docs/subcommands/Compute Engine/resource/get.md
+++ b/docs/subcommands/Compute Engine/resource/get.md
@@ -41,7 +41,7 @@ Required values to run command:
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The ID of the specific Resource to retrieve information about

--- a/docs/subcommands/Compute Engine/resource/list.md
+++ b/docs/subcommands/Compute Engine/resource/list.md
@@ -39,7 +39,7 @@ Use this command to get a full list of existing Resources. To sort list by Resou
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/server/cdrom/attach.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/attach.md
@@ -54,6 +54,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/cdrom/detach.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/detach.md
@@ -55,6 +55,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/cdrom/get.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/get.md
@@ -52,7 +52,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/cdrom/list.md
+++ b/docs/subcommands/Compute Engine/server/cdrom/list.md
@@ -57,7 +57,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/server/console/get.md
+++ b/docs/subcommands/Compute Engine/server/console/get.md
@@ -50,7 +50,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/create.md
+++ b/docs/subcommands/Compute Engine/server/create.md
@@ -91,6 +91,7 @@ You can wait for the Request to be executed using `--wait-for-request` option. Y
       --image-id string            [CUBE Server] The Image Id or snapshot Id to be used as for the Direct Attached Storage
   -l, --licence-type string        [CUBE Server] Licence Type of the Direct Attached Storage. Can be one of: LINUX, RHEL, WINDOWS, WINDOWS2016, UNKNOWN, OTHER (default "LINUX")
   -n, --name string                Name of the Server (default "Unnamed Server")
+      --no-headers                 Don't print table headers when table output is used
   -o, --output string              Desired output format [text|json|api-json] (default "text")
   -p, --password string            [CUBE Server] Initial image password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9
   -q, --quiet                      Quiet output

--- a/docs/subcommands/Compute Engine/server/delete.md
+++ b/docs/subcommands/Compute Engine/server/delete.md
@@ -49,6 +49,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/get.md
+++ b/docs/subcommands/Compute Engine/server/get.md
@@ -44,7 +44,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/list.md
+++ b/docs/subcommands/Compute Engine/server/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/server/reboot.md
+++ b/docs/subcommands/Compute Engine/server/reboot.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/resume.md
+++ b/docs/subcommands/Compute Engine/server/resume.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/start.md
+++ b/docs/subcommands/Compute Engine/server/start.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/stop.md
+++ b/docs/subcommands/Compute Engine/server/stop.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/suspend.md
+++ b/docs/subcommands/Compute Engine/server/suspend.md
@@ -40,6 +40,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/token/get.md
+++ b/docs/subcommands/Compute Engine/server/token/get.md
@@ -50,7 +50,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/update.md
+++ b/docs/subcommands/Compute Engine/server/update.md
@@ -60,6 +60,7 @@ Required values to run command:
   -f, --force                      Force command to execute without user input
   -h, --help                       Print usage
   -n, --name string                Name of the Server
+      --no-headers                 Don't print table headers when table output is used
   -o, --output string              Desired output format [text|json|api-json] (default "text")
   -q, --quiet                      Quiet output
       --ram string                 The amount of memory for the Server. Size must be specified in multiples of 256. e.g. --ram 256 or --ram 256MB

--- a/docs/subcommands/Compute Engine/server/volume/attach.md
+++ b/docs/subcommands/Compute Engine/server/volume/attach.md
@@ -52,6 +52,7 @@ Required values to run command:
       --datacenter-id string   The unique Data Center Id (required)
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/volume/detach.md
+++ b/docs/subcommands/Compute Engine/server/volume/detach.md
@@ -54,6 +54,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/volume/get.md
+++ b/docs/subcommands/Compute Engine/server/volume/get.md
@@ -51,6 +51,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --server-id string       The unique Server Id (required)

--- a/docs/subcommands/Compute Engine/server/volume/list.md
+++ b/docs/subcommands/Compute Engine/server/volume/list.md
@@ -57,7 +57,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/share/create.md
+++ b/docs/subcommands/Compute Engine/share/create.md
@@ -39,6 +39,7 @@ Required values to run a command:
   -f, --force                Force command to execute without user input
       --group-id string      The unique Group Id (required)
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The unique Resource Id (required)

--- a/docs/subcommands/Compute Engine/share/delete.md
+++ b/docs/subcommands/Compute Engine/share/delete.md
@@ -39,6 +39,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
       --group-id string      The unique Group Id (required)
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The unique Resource Id (required)

--- a/docs/subcommands/Compute Engine/share/get.md
+++ b/docs/subcommands/Compute Engine/share/get.md
@@ -38,7 +38,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
       --group-id string      The unique Group Id (required)
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The unique Resource Id (required)

--- a/docs/subcommands/Compute Engine/share/list.md
+++ b/docs/subcommands/Compute Engine/share/list.md
@@ -39,7 +39,7 @@ Required values to run command:
       --group-id string     The unique Group Id (required)
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/share/update.md
+++ b/docs/subcommands/Compute Engine/share/update.md
@@ -41,6 +41,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
       --group-id string      The unique Group Id (required)
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --resource-id string   The unique Resource Id (required)

--- a/docs/subcommands/Compute Engine/snapshot/create.md
+++ b/docs/subcommands/Compute Engine/snapshot/create.md
@@ -49,7 +49,7 @@ Required values to run command:
   -h, --help                   Print usage
       --licence-type string    Licence Type of the Snapshot. Can be one of: LINUX, RHEL, WINDOWS, WINDOWS2016, UNKNOWN, OTHER (default "LINUX")
   -n, --name string            Name of the Snapshot (default "Unnamed Snapshot")
-      --no-headers             Don't print column headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
       --sec-auth-protection    Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false

--- a/docs/subcommands/Compute Engine/snapshot/delete.md
+++ b/docs/subcommands/Compute Engine/snapshot/delete.md
@@ -43,7 +43,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           Don't print column headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --snapshot-id string   The unique Snapshot Id (required)

--- a/docs/subcommands/Compute Engine/snapshot/get.md
+++ b/docs/subcommands/Compute Engine/snapshot/get.md
@@ -42,7 +42,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --snapshot-id string   The unique Snapshot Id (required)

--- a/docs/subcommands/Compute Engine/snapshot/list.md
+++ b/docs/subcommands/Compute Engine/snapshot/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/snapshot/restore.md
+++ b/docs/subcommands/Compute Engine/snapshot/restore.md
@@ -45,7 +45,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             Don't print column headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --snapshot-id string     The unique Snapshot Id (required)

--- a/docs/subcommands/Compute Engine/snapshot/update.md
+++ b/docs/subcommands/Compute Engine/snapshot/update.md
@@ -55,7 +55,7 @@ Required values to run command:
   -n, --name string              Name of the Snapshot
       --nic-hot-plug             This volume is capable of NIC hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false
       --nic-hot-unplug           This volume is capable of NIC hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false
-      --no-headers               Don't print column headers
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --ram-hot-plug             This volume is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false

--- a/docs/subcommands/Compute Engine/targetgroup/create.md
+++ b/docs/subcommands/Compute Engine/targetgroup/create.md
@@ -47,6 +47,7 @@ You can wait for the Request to be executed using `--wait-for-request` or `-w` o
       --method string        [HTTP Health Check] The method for the HTTP health check. (default "GET")
   -n, --name string          The name of the target group. (default "Unnamed Target Group")
       --negate               [HTTP Health Check] Negate for the HTTP health check.
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
       --path string          [HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /. (default "/.")
   -p, --protocol string      Balancing protocol (default "HTTP")

--- a/docs/subcommands/Compute Engine/targetgroup/delete.md
+++ b/docs/subcommands/Compute Engine/targetgroup/delete.md
@@ -43,6 +43,7 @@ Required values to run command:
   -D, --depth int32             Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -q, --quiet                   Quiet output
   -i, --targetgroup-id string   The unique Target Group Id (required)

--- a/docs/subcommands/Compute Engine/targetgroup/get.md
+++ b/docs/subcommands/Compute Engine/targetgroup/get.md
@@ -42,6 +42,7 @@ Required values to run command:
   -D, --depth int32             Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -q, --quiet                   Quiet output
   -i, --targetgroup-id string   The unique Target Group Id (required)

--- a/docs/subcommands/Compute Engine/targetgroup/list.md
+++ b/docs/subcommands/Compute Engine/targetgroup/list.md
@@ -40,6 +40,7 @@ Use this command to get a list of Target Groups.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/targetgroup/target/add.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/add.md
@@ -56,6 +56,7 @@ Required values to run command:
   -h, --help                    Print usage
       --ip ip                   The IP of the balanced target VM. (required)
   -m, --maintenance-enabled     Maintenance mode prevents the target from receiving balanced traffic.
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -P, --port int                The port of the balanced target service; valid range is 1 to 65535. (required) (default 8080)
   -q, --quiet                   Quiet output

--- a/docs/subcommands/Compute Engine/targetgroup/target/list.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/list.md
@@ -43,6 +43,7 @@ Use this command to get a list of Target Groups Targets.
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -q, --quiet                   Quiet output
   -i, --targetgroup-id string   The unique Target Group Id (required)

--- a/docs/subcommands/Compute Engine/targetgroup/target/remove.md
+++ b/docs/subcommands/Compute Engine/targetgroup/target/remove.md
@@ -51,6 +51,7 @@ Required values to run command:
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --ip ip                   IP of a balanced target VM (required)
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
   -P, --port int                Port of the balanced target service. (range: 1 to 65535) (required) (default 8080)
   -q, --quiet                   Quiet output

--- a/docs/subcommands/Compute Engine/targetgroup/update.md
+++ b/docs/subcommands/Compute Engine/targetgroup/update.md
@@ -51,6 +51,7 @@ Required values to run command:
       --method string           [HTTP Health Check] The method for the HTTP health check. (default "GET")
   -n, --name string             The name of the target group. (default "Updated Target Group")
       --negate                  [HTTP Health Check] Negate for the HTTP health check.
+      --no-headers              Don't print table headers when table output is used
   -o, --output string           Desired output format [text|json|api-json] (default "text")
       --path string             [HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /. (default "/.")
   -p, --protocol string         Balancing protocol (default "HTTP")

--- a/docs/subcommands/Compute Engine/template/get.md
+++ b/docs/subcommands/Compute Engine/template/get.md
@@ -42,7 +42,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --template-id string   The unique Template Id (required)

--- a/docs/subcommands/Compute Engine/template/list.md
+++ b/docs/subcommands/Compute Engine/template/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Compute Engine/volume/create.md
+++ b/docs/subcommands/Compute Engine/volume/create.md
@@ -59,6 +59,7 @@ Required values to run command:
   -n, --name string                Name of the Volume (default "Unnamed Volume")
       --nic-hot-plug               It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false
       --nic-hot-unplug             It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false
+      --no-headers                 Don't print table headers when table output is used
   -o, --output string              Desired output format [text|json|api-json] (default "text")
   -p, --password string            Initial password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9
   -q, --quiet                      Quiet output

--- a/docs/subcommands/Compute Engine/volume/delete.md
+++ b/docs/subcommands/Compute Engine/volume/delete.md
@@ -47,6 +47,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for Volume deletion [seconds] (default 60)

--- a/docs/subcommands/Compute Engine/volume/get.md
+++ b/docs/subcommands/Compute Engine/volume/get.md
@@ -44,7 +44,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Compute Engine/volume/list.md
+++ b/docs/subcommands/Compute Engine/volume/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Compute Engine/volume/update.md
+++ b/docs/subcommands/Compute Engine/volume/update.md
@@ -55,6 +55,7 @@ Required values to run command:
   -n, --name string              Name of the Volume
       --nic-hot-plug             It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false
       --nic-hot-unplug           It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false
+      --no-headers               Don't print table headers when table output is used
   -o, --output string            Desired output format [text|json|api-json] (default "text")
   -q, --quiet                    Quiet output
       --ram-hot-plug             It is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false

--- a/docs/subcommands/Container-Registry/locations.md
+++ b/docs/subcommands/Container-Registry/locations.md
@@ -37,7 +37,7 @@ List all managed container registries locations for your account
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Container-Registry/names.md
+++ b/docs/subcommands/Container-Registry/names.md
@@ -36,7 +36,7 @@ Check if a Registry Name is available
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
       --name string      Name to check availability for (required)
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Container-Registry/registry/create.md
+++ b/docs/subcommands/Container-Registry/registry/create.md
@@ -47,7 +47,7 @@ Create a registry to hold container images or OCI compliant artifacts
   -h, --help                                       Print usage
       --location string                            Specify the location of the registry (required)
   -n, --name string                                Specify the name of the registry (required)
-      --no-headers                                 When using text output, don't print headers
+      --no-headers                                 Don't print table headers when table output is used
   -o, --output string                              Desired output format [text|json|api-json] (default "text")
   -q, --quiet                                      Quiet output
   -v, --verbose                                    Print step-by-step process when running command

--- a/docs/subcommands/Container-Registry/registry/delete.md
+++ b/docs/subcommands/Container-Registry/registry/delete.md
@@ -44,7 +44,7 @@ Delete a Registry.
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --registry-id string   Specify the Registry ID (required)

--- a/docs/subcommands/Container-Registry/registry/get.md
+++ b/docs/subcommands/Container-Registry/registry/get.md
@@ -43,7 +43,7 @@ Get Properties of a single Registry
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -i, --registry-id string   Registry ID (required)

--- a/docs/subcommands/Container-Registry/registry/list.md
+++ b/docs/subcommands/Container-Registry/registry/list.md
@@ -44,7 +44,7 @@ List all managed container registries for your account
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
   -n, --name string      Response filter to list only the Registries that contain the specified name in the DisplayName field. The value is case insensitive
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Container-Registry/registry/replace.md
+++ b/docs/subcommands/Container-Registry/registry/replace.md
@@ -47,7 +47,7 @@ Create/replace a registry to hold container images or OCI compliant artifacts
   -h, --help                                       Print usage
       --location string                            Specify the location of the registry (required)
   -n, --name string                                Specify the name of the registry (required)
-      --no-headers                                 When using text output, don't print headers
+      --no-headers                                 Don't print table headers when table output is used
   -o, --output string                              Desired output format [text|json|api-json] (default "text")
   -q, --quiet                                      Quiet output
   -i, --registry-id string                         Specify the Registry ID (required)

--- a/docs/subcommands/Container-Registry/registry/update.md
+++ b/docs/subcommands/Container-Registry/registry/update.md
@@ -45,7 +45,7 @@ Update the "garbageCollectionSchedule" time and days of the week for runs of a r
       --garbage-collection-schedule-days strings   Specify the garbage collection schedule days
       --garbage-collection-schedule-time string    Specify the garbage collection schedule time of day
   -h, --help                                       Print usage
-      --no-headers                                 When using text output, don't print headers
+      --no-headers                                 Don't print table headers when table output is used
   -o, --output string                              Desired output format [text|json|api-json] (default "text")
   -q, --quiet                                      Quiet output
   -i, --registry-id string                         Specify the Registry ID (required)

--- a/docs/subcommands/Container-Registry/repository.md
+++ b/docs/subcommands/Container-Registry/repository.md
@@ -36,7 +36,7 @@ Delete all repository contents. The registry V2 API allows manifests and blobs t
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          Name of the repository to delete
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/delete.md
+++ b/docs/subcommands/Container-Registry/token/delete.md
@@ -45,7 +45,7 @@ Delete a token from a registry
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/get.md
+++ b/docs/subcommands/Container-Registry/token/get.md
@@ -43,7 +43,7 @@ Use this command to retrieve information about a single token of a container reg
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/list.md
+++ b/docs/subcommands/Container-Registry/token/list.md
@@ -44,7 +44,7 @@ List all tokens for your container registry
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/scope/add.md
+++ b/docs/subcommands/Container-Registry/token/scope/add.md
@@ -45,7 +45,7 @@ Use this command to add scopes to a token of a container registry.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          Scope name (required)
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID (required)

--- a/docs/subcommands/Container-Registry/token/scope/delete.md
+++ b/docs/subcommands/Container-Registry/token/scope/delete.md
@@ -44,7 +44,7 @@ Use this command to delete a token scope of a container registry. If a name is p
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/scope/list.md
+++ b/docs/subcommands/Container-Registry/token/scope/list.md
@@ -43,7 +43,7 @@ Use this command to list all scopes of a token of a container registry.
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/Container-Registry/token/update.md
+++ b/docs/subcommands/Container-Registry/token/update.md
@@ -45,7 +45,7 @@ Use this command to update a token's properties. You can update the token's expi
       --expiry-time string   Time until the Token expires (ex: 1y2d)
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -r, --registry-id string   Registry ID

--- a/docs/subcommands/DNS/record/create.md
+++ b/docs/subcommands/DNS/record/create.md
@@ -40,7 +40,7 @@ Create a record. Wiki: https://docs.ionos.com/dns-as-a-service/readme/api-how-to
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
   -n, --name \*          The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
       --priority int32   Priority value is between 0 and 65535. Priority is mandatory for MX, SRV and URI record types and ignored for all other types.
   -q, --quiet            Quiet output

--- a/docs/subcommands/DNS/record/delete.md
+++ b/docs/subcommands/DNS/record/delete.md
@@ -48,7 +48,7 @@ Here, PARTIAL_NAME is a part of the name of the DNS record you want to delete. I
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -r, --record string    The ID, or full name of the DNS record. Required together with --zone. Can also provide partial names, but must narrow down to a single record result if not using --all. If using it, will however delete all records that match.

--- a/docs/subcommands/DNS/record/get.md
+++ b/docs/subcommands/DNS/record/get.md
@@ -37,7 +37,7 @@ Retrieve a record
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
       --record string    The ID or name of the DNS record

--- a/docs/subcommands/DNS/record/list.md
+++ b/docs/subcommands/DNS/record/list.md
@@ -39,7 +39,7 @@ Retrieve all records
   -h, --help                Print usage
       --max-results int32   The maximum number of elements to return
       --name string         Filter used to fetch only the records that contain specified record name
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --offset int32        The first element (of the total list of elements) to include in the response. Use together with limit for pagination
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/DNS/record/update.md
+++ b/docs/subcommands/DNS/record/update.md
@@ -40,7 +40,7 @@ Partially modify a record's properties. This command uses a combination of GET a
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
   -n, --name \*          The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
       --priority int32   Priority value is between 0 and 65535. Priority is mandatory for MX, SRV and URI record types and ignored for all other types.
   -q, --quiet            Quiet output

--- a/docs/subcommands/DNS/zone/create.md
+++ b/docs/subcommands/DNS/zone/create.md
@@ -40,7 +40,7 @@ Create a zone
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          The name of the DNS zone, e.g. foo.com
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/DNS/zone/delete.md
+++ b/docs/subcommands/DNS/zone/delete.md
@@ -38,7 +38,7 @@ Delete a zone
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/DNS/zone/get.md
+++ b/docs/subcommands/DNS/zone/get.md
@@ -37,7 +37,7 @@ Retrieve a zone
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/DNS/zone/list.md
+++ b/docs/subcommands/DNS/zone/list.md
@@ -39,7 +39,7 @@ Retrieve zones
   -h, --help                Print usage
       --max-results int32   Pagination limit
       --name string         Filter used to fetch only the zones that contain the specified zone name
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --offset int32        Pagination offset
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/DNS/zone/update.md
+++ b/docs/subcommands/DNS/zone/update.md
@@ -40,7 +40,7 @@ Partially modify a zone's properties. This command uses a combination of GET and
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -n, --name string          The new name of the DNS zone, e.g. foo.com
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
   -v, --verbose              Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/api/versions.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/api/versions.md
@@ -41,6 +41,7 @@ Get Mongo API swagger files
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -56,7 +56,7 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of your cluster (required)
-      --no-headers                When using text output, don't print headers
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
       --ram string                Custom RAM: multiples of 1024. e.g. --ram 1024 or --ram 1024MB or --ram 4GB (required and only settable for enterprise edition) (default "2GB")

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/delete.md
@@ -46,7 +46,7 @@ Delete a Mongo Cluster by ID
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --name                When deleting all clusters, filter the clusters by a name
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/get.md
@@ -44,7 +44,7 @@ Get a Mongo Cluster by ID
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/list.md
@@ -45,7 +45,7 @@ Use this command to retrieve a list of Mongo Clusters provisioned under your acc
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
   -n, --name string         Response filter to list only the Mongo Clusters that contain the specified name in the DisplayName field. The value is case insensitive
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/restore.md
@@ -49,7 +49,7 @@ Snapshots are stored in an IONOS S3 Object Storage bucket in the same region as 
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
       --snapshot-id string   The unique ID of the snapshot you want to restore. (required)

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
@@ -55,7 +55,7 @@ Update a Mongo Cluster by ID
       --maintenance-day string    Day for Maintenance. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: Saturday
       --maintenance-time string   Time for the Maintenance. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59
   -n, --name string               The name of your cluster
-      --no-headers                When using text output, don't print headers
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
       --ram string                Custom RAM: multiples of 1024. e.g. --ram 1024 or --ram 1024MB or --ram 4GB (required and only settable for enterprise edition)

--- a/docs/subcommands/Database-as-a-Service/mongo/logs/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/logs/list.md
@@ -42,7 +42,7 @@ List (and optionally filter) the logs of your Mongo Cluster. Use --cols message 
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           The maximal number of log lines to return. If the limit is reached then log lines will be cut at the end (respecting the scan direction). Must be between 1 - 5000 (default 100)
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
       --start duration      The start time, as a duration. This should be negative, i.e. -720h. Valid: h, m, s

--- a/docs/subcommands/Database-as-a-Service/mongo/snapshot/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/snapshot/list.md
@@ -44,7 +44,7 @@ List the snapshots of your Mongo Cluster
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/snapshot/restore.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/snapshot/restore.md
@@ -47,6 +47,7 @@ Snapshots are stored in an IONOS S3 Object Storage bucket in the same region as 
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output
       --snapshot-id string   The unique ID of the snapshot you want to restore. (required)

--- a/docs/subcommands/Database-as-a-Service/mongo/templates/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/templates/list.md
@@ -44,7 +44,7 @@ Retrieves a list of valid templates. These templates can be used to create Mongo
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Database-as-a-Service/mongo/user/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/create.md
@@ -45,7 +45,7 @@ Create MongoDB users.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -n, --name string         The authentication username (required)
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -p, --password string     The authentication password (required)
   -q, --quiet               Quiet output

--- a/docs/subcommands/Database-as-a-Service/mongo/user/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/delete.md
@@ -47,7 +47,7 @@ Delete a MongoDB user
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --name string         The authentication username
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/mongo/user/get.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/get.md
@@ -45,7 +45,7 @@ Get a MongoDB user
   -d, --database string     The authentication database
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
       --user string         The authentication username

--- a/docs/subcommands/Database-as-a-Service/mongo/user/list.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/user/list.md
@@ -46,7 +46,7 @@ Retrieves a list of MongoDB users. You can either list users of a certain cluste
   -f, --force                 Force command to execute without user input
   -h, --help                  Print usage
   -M, --max-results int32     The maximum number of elements to return
-      --no-headers            When using text output, don't print headers
+      --no-headers            Don't print table headers when table output is used
       --offset int32          Skip a certain number of results
   -o, --output string         Desired output format [text|json|api-json] (default "text")
   -q, --quiet                 Quiet output

--- a/docs/subcommands/Database-as-a-Service/postgres/api/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/api/version/get.md
@@ -43,7 +43,7 @@ Use this command to get the current version of DBaaS PostgreSQL API.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/api/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/api/version/list.md
@@ -43,7 +43,7 @@ Use this command to retrieve all available DBaaS PostgreSQL API versions.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/backup/get.md
@@ -48,7 +48,7 @@ Required values to run command:
   -c, --config string      Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
-      --no-headers         When using text output, don't print headers
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -v, --verbose            Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/backup/list.md
@@ -43,7 +43,7 @@ Use this command to retrieve a list of PostgreSQL Cluster Backups.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/backup/list.md
@@ -44,7 +44,7 @@ Use this command to retrieve a list of PostgreSQL Cluster Backups from a specifi
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/create.md
@@ -63,6 +63,7 @@ Required values to run command:
   -d, --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur
   -T, --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59
   -n, --name string               The friendly name of your cluster (default "UnnamedCluster")
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
       --ram string                The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB (default "3GB")

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/delete.md
@@ -50,6 +50,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -n, --name string         Delete all Clusters after filtering based on name. It does not require an exact match. Can be used with --all flag
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for Cluster to be completely removed[seconds] (default 1200)

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/get.md
@@ -48,7 +48,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for Cluster to be in AVAILABLE state [seconds] (default 1200)

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/list.md
@@ -44,7 +44,7 @@ Use this command to retrieve a list of PostgreSQL Clusters provisioned under you
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
   -n, --name string      Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/restore.md
@@ -50,6 +50,7 @@ Required values to run command:
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -R, --recovery-time string   If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely

--- a/docs/subcommands/Database-as-a-Service/postgres/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/cluster/update.md
@@ -56,6 +56,7 @@ Required values to run command:
   -d, --maintenance-day string    Day of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur
   -T, --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59
   -n, --name string               The friendly name of your cluster
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
       --ram string                The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB

--- a/docs/subcommands/Database-as-a-Service/postgres/logs/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/logs/list.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -l, --limit int           The maximal number of log lines to return. If the limit is reached then log lines will be cut at the end (respecting the scan direction). Minimum: 1. Maximum: 5000 (default 100)
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -S, --since string        The start time for the query using a time delta since the current moment: 2h - 2 hours ago, 20m - 20 minutes ago. Only hours and minutes are supported, and not at the same time. If both start-time and since are set, start-time will be used.

--- a/docs/subcommands/Database-as-a-Service/postgres/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/version/get.md
@@ -48,7 +48,7 @@ Required values to run command:
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Database-as-a-Service/postgres/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/version/list.md
@@ -43,7 +43,7 @@ Use this command to retrieve all available DBaaS PostgreSQL versions.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Managed-Backup/create.md
+++ b/docs/subcommands/Managed-Backup/create.md
@@ -53,6 +53,7 @@ Required values to run a command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
   -n, --name string        Alphanumeric name you want to assign to the BackupUnit (required)
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -p, --password string    Alphanumeric password you want to assign to the BackupUnit (required)
   -q, --quiet              Quiet output

--- a/docs/subcommands/Managed-Backup/delete.md
+++ b/docs/subcommands/Managed-Backup/delete.md
@@ -44,6 +44,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for BackupUnit deletion [seconds] (default 60)

--- a/docs/subcommands/Managed-Backup/get.md
+++ b/docs/subcommands/Managed-Backup/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -D, --depth int32            Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Managed-Backup/get/sso/url.md
+++ b/docs/subcommands/Managed-Backup/get/sso/url.md
@@ -36,6 +36,7 @@ Required values to run command:
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/Managed-Backup/list.md
+++ b/docs/subcommands/Managed-Backup/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Managed-Backup/update.md
+++ b/docs/subcommands/Managed-Backup/update.md
@@ -44,6 +44,7 @@ Required values to run command:
   -e, --email string           The e-mail address you want to update for the BackupUnit
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -p, --password string        Alphanumeric password you want to update for the BackupUnit
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Managed-Kubernetes/cluster/create.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/create.md
@@ -43,6 +43,7 @@ You can wait for the Cluster to be in "ACTIVE" state using `--wait-for-state` fl
   -h, --help                  Print usage
       --k8s-version string    The K8s version for the Cluster. If not set, the default one will be used
   -n, --name string           The name for the K8s Cluster (default "UnnamedCluster")
+      --no-headers            Don't print table headers when table output is used
   -o, --output string         Desired output format [text|json|api-json] (default "text")
   -q, --quiet                 Quiet output
       --s3bucket string       S3 Bucket name configured for K8s usage

--- a/docs/subcommands/Managed-Kubernetes/cluster/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/delete.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for waiting for Request [seconds] (default 600)

--- a/docs/subcommands/Managed-Kubernetes/cluster/get.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/get.md
@@ -43,7 +43,7 @@ Required values to run command:
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -t, --timeout int         Timeout option for waiting for Cluster to be in ACTIVE state [seconds] (default 600)

--- a/docs/subcommands/Managed-Kubernetes/cluster/list.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Managed-Kubernetes/cluster/update.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/update.md
@@ -50,6 +50,7 @@ Required values to run command:
       --maintenance-day string    The day of the week for Maintenance Window has the English day format as following: Monday or Saturday
       --maintenance-time string   The time for Maintenance Window has the HH:mm:ss format as following: 08:00:00
   -n, --name string               The name for the K8s Cluster
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
       --s3bucket string           S3 Bucket name configured for K8s usage. It will overwrite the previous value

--- a/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
+++ b/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
@@ -41,7 +41,7 @@ Required values to run command:
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Managed-Kubernetes/node/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/node/delete.md
@@ -46,6 +46,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
       --node-id string       The unique K8s Node Id (required)
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/Managed-Kubernetes/node/get.md
+++ b/docs/subcommands/Managed-Kubernetes/node/get.md
@@ -45,7 +45,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -i, --node-id string       The unique K8s Node Id (required)
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/Managed-Kubernetes/node/list.md
+++ b/docs/subcommands/Managed-Kubernetes/node/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -M, --max-results int32    The maximum number of elements to return
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
       --nodepool-id string   The unique K8s Node Pool Id (required)
       --order-by string      Limits results to those containing a matching value for a specific property
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/Managed-Kubernetes/node/recreate.md
+++ b/docs/subcommands/Managed-Kubernetes/node/recreate.md
@@ -47,6 +47,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -i, --node-id string       The unique K8s Node Id (required)
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/Managed-Kubernetes/nodepool/create.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/create.md
@@ -63,6 +63,7 @@ Required values to run a command (for Private Kubernetes Cluster):
   -L, --labels stringToString        Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE (default [])
       --lan-ids ints                 Collection of LAN Ids of existing LANs to be attached to worker Nodes
   -n, --name string                  The name for the K8s NodePool (default "UnnamedNodePool")
+      --no-headers                   Don't print table headers when table output is used
       --node-count int               The number of worker Nodes that the Node Pool should contain. Min 1, Max: Determined by the resource availability (default 1)
   -o, --output string                Desired output format [text|json|api-json] (default "text")
   -q, --quiet                        Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
@@ -45,6 +45,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
+      --no-headers           Don't print table headers when table output is used
   -i, --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/get.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/get.md
@@ -44,7 +44,7 @@ Required values to run command:
   -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -i, --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
@@ -51,6 +51,7 @@ Required values to run a command:
   -h, --help                 Print usage
   -i, --lan-id int           The unique LAN Id of existing LANs to be attached to worker Nodes (required)
       --network strings      Slice of IPv4 or IPv6 CIDRs to be routed via the interface. Must contain same number of arguments as --gateway-ip flag
+      --no-headers           Don't print table headers when table output is used
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -M, --max-results int32    The maximum number of elements to return
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
@@ -47,6 +47,7 @@ Required values to run command:
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
   -i, --lan-id int           The unique LAN Id of existing LANs to be detached from worker Nodes (required)
+      --no-headers           Don't print table headers when table output is used
       --nodepool-id string   The unique K8s Node Pool Id (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/Managed-Kubernetes/nodepool/update.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/update.md
@@ -61,6 +61,7 @@ Required values to run command:
       --maintenance-time string      The time for Maintenance Window has the HH:mm:ss format as following: 08:00:00
       --max-node-count int           The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count (default 1)
       --min-node-count int           The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count (default 1)
+      --no-headers                   Don't print table headers when table output is used
       --node-count int               The number of worker Nodes that the NodePool should contain (default 1)
   -i, --nodepool-id string           The unique K8s Node Pool Id (required)
   -o, --output string                Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/Managed-Kubernetes/version/get.md
+++ b/docs/subcommands/Managed-Kubernetes/version/get.md
@@ -35,6 +35,7 @@ Use this command to retrieve the current default Kubernetes version for Clusters
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Managed-Kubernetes/version/list.md
+++ b/docs/subcommands/Managed-Kubernetes/version/list.md
@@ -35,6 +35,7 @@ Use this command to retrieve all available Kubernetes versions.
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/create.md
@@ -47,7 +47,7 @@ The cluster will be provisioned in the datacenter matching the provided datacent
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur (required)
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59 (required)
   -n, --name string               The name of your cluster
-      --no-headers                When using text output, don't print headers
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
   -t, --timeout int               Timeout option for Request [seconds] (default 60)

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/delete.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/delete.md
@@ -45,7 +45,7 @@ Delete a Dataplatform Cluster by ID
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/get.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/get.md
@@ -44,7 +44,7 @@ Get a Dataplatform Cluster by ID
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/kubeconfig.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/kubeconfig.md
@@ -44,7 +44,7 @@ Get a Dataplatform Cluster's Kubeconfig by ID
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/list.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/list.md
@@ -44,7 +44,7 @@ List Dataplatform Clusters
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
   -n, --name string      Response filter to list only the clusters which include the specified name. case insensitive
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -v, --verbose          Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/cluster/update.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/cluster/update.md
@@ -50,7 +50,7 @@ Modifies the specified DataPlatformCluster by its distinct cluster ID. The field
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur (required)
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59 (required)
   -n, --name string               The name of the cluster
-      --no-headers                When using text output, don't print headers
+      --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")
   -q, --quiet                     Quiet output
   -v, --verbose                   Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/create.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/create.md
@@ -54,7 +54,7 @@ The following requests allows to alter the existing resources, add or remove new
       --maintenance-day string       Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur
       --maintenance-time string      Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59
   -n, --name string                  The name of your nodepool (required)
-      --no-headers                   When using text output, don't print headers
+      --no-headers                   Don't print table headers when table output is used
       --node-count int32             The number of nodes that make up the node pool (required)
   -o, --output string                Desired output format [text|json|api-json] (default "text")
   -q, --quiet                        Quiet output

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/delete.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/delete.md
@@ -45,7 +45,7 @@ Delete a Dataplatform Cluster by ID
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -i, --nodepool-id string   The unique ID of the nodepool (required)
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/get.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/get.md
@@ -44,7 +44,7 @@ Get Dataplatform Nodepool by cluster and nodepool id
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
-      --no-headers           When using text output, don't print headers
+      --no-headers           Don't print table headers when table output is used
   -i, --nodepool-id string   The unique ID of the nodepool. Must conform to the UUID format
   -o, --output string        Desired output format [text|json|api-json] (default "text")
   -q, --quiet                Quiet output

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/list.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/list.md
@@ -45,7 +45,7 @@ List Dataplatform Nodepools of a certain cluster
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
   -v, --verbose             Print step-by-step process when running command

--- a/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/update.md
+++ b/docs/subcommands/Managed-Stackable-Data-Platform/nodepool/update.md
@@ -50,7 +50,7 @@ The following requests allows to alter the existing resources of the cluster
   -L, --labels stringToString        Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE (default [])
       --maintenance-day string       Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur (required)
       --maintenance-time string      Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59 (required)
-      --no-headers                   When using text output, don't print headers
+      --no-headers                   Don't print table headers when table output is used
   -n, --node-count int32             The number of nodes that make up the node pool (required)
   -i, --nodepool-id string           The UUID of the cluster the nodepool belongs to
   -o, --output string                Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/NAT-Gateway/create.md
+++ b/docs/subcommands/NAT-Gateway/create.md
@@ -48,6 +48,7 @@ Required values to run command:
   -h, --help                   Print usage
       --ips strings            Collection of public reserved IP addresses of the NAT Gateway (required)
   -n, --name string            Name of the NAT Gateway (default "NAT Gateway")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway creation [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/delete.md
+++ b/docs/subcommands/NAT-Gateway/delete.md
@@ -48,6 +48,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway deletion [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/flowlog/create.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/create.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                   Print usage
   -n, --name string            The name for the FlowLog (default "Unnamed FlowLog")
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)

--- a/docs/subcommands/NAT-Gateway/flowlog/delete.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/delete.md
@@ -56,6 +56,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway FlowLog deletion [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/flowlog/get.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/get.md
@@ -53,7 +53,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/NAT-Gateway/flowlog/list.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/list.md
@@ -58,7 +58,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
       --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/NAT-Gateway/flowlog/update.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/update.md
@@ -58,6 +58,7 @@ Required values to run command:
   -h, --help                   Print usage
   -n, --name string            Name of the NAT Gateway FlowLog
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket

--- a/docs/subcommands/NAT-Gateway/get.md
+++ b/docs/subcommands/NAT-Gateway/get.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -i, --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/lan/add.md
+++ b/docs/subcommands/NAT-Gateway/lan/add.md
@@ -52,6 +52,7 @@ Required values to run command:
       --ips strings            Collection of Gateway IPs. If not set, it will automatically reserve public IPs
   -i, --lan-id int             The unique LAN Id (required) (default 1)
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway Lan addition [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/lan/list.md
+++ b/docs/subcommands/NAT-Gateway/lan/list.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -v, --verbose                Print step-by-step process when running command

--- a/docs/subcommands/NAT-Gateway/lan/remove.md
+++ b/docs/subcommands/NAT-Gateway/lan/remove.md
@@ -50,6 +50,7 @@ Required values to run command:
   -h, --help                   Print usage
   -i, --lan-id int             The unique LAN Id (required) (default 1)
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway Lan deletion [seconds] (default 60)

--- a/docs/subcommands/NAT-Gateway/list.md
+++ b/docs/subcommands/NAT-Gateway/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/NAT-Gateway/rule/create.md
+++ b/docs/subcommands/NAT-Gateway/rule/create.md
@@ -57,6 +57,7 @@ Required values to run command:
       --ip ip                  Public IP address of the NAT Gateway Rule (required)
   -n, --name string            Name of the NAT Gateway Rule (default "Unnamed Rule")
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --port-range-end int     Target port range end associated with the NAT Gateway Rule (default 1)
       --port-range-start int   Target port range start associated with the NAT Gateway Rule (default 1)

--- a/docs/subcommands/NAT-Gateway/rule/delete.md
+++ b/docs/subcommands/NAT-Gateway/rule/delete.md
@@ -55,6 +55,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --rule-id string         The unique Rule Id (required)

--- a/docs/subcommands/NAT-Gateway/rule/get.md
+++ b/docs/subcommands/NAT-Gateway/rule/get.md
@@ -52,7 +52,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -i, --rule-id string         The unique Rule Id (required)

--- a/docs/subcommands/NAT-Gateway/rule/list.md
+++ b/docs/subcommands/NAT-Gateway/rule/list.md
@@ -58,7 +58,7 @@ Required values to run command:
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
       --natgateway-id string   The unique NatGateway Id (required)
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/NAT-Gateway/rule/update.md
+++ b/docs/subcommands/NAT-Gateway/rule/update.md
@@ -56,6 +56,7 @@ Required values to run command:
       --ip ip                  Public IP address of the NAT Gateway Rule
   -n, --name string            Name of the NAT Gateway Rule
       --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --port-range-end int     Target port range end associated with the NAT Gateway Rule (default 1)
       --port-range-start int   Target port range start associated with the NAT Gateway Rule (default 1)

--- a/docs/subcommands/NAT-Gateway/update.md
+++ b/docs/subcommands/NAT-Gateway/update.md
@@ -49,6 +49,7 @@ Required values to run command:
       --ips strings            Collection of public reserved IP addresses of the NAT Gateway. This will overwrite the current values
   -n, --name string            Name of the NAT Gateway
   -i, --natgateway-id string   The unique NatGateway Id (required)
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for NAT Gateway update [seconds] (default 60)

--- a/docs/subcommands/Network-Load-Balancer/create.md
+++ b/docs/subcommands/Network-Load-Balancer/create.md
@@ -48,6 +48,7 @@ Required values to run command:
       --ips strings            Collection of IP addresses of the Network Load Balancer
       --listener-lan int       Id of the listening LAN (default 2)
   -n, --name string            Name of the Network Load Balancer (default "Network Load Balancer")
+      --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --private-ips strings    Collection of private IP addresses with subnet mask of the Network Load Balancer
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Network-Load-Balancer/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/delete.md
@@ -48,6 +48,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
   -i, --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -t, --timeout int                     Timeout option for Request for Network Load Balancer deletion [seconds] (default 300)

--- a/docs/subcommands/Network-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/create.md
@@ -57,6 +57,7 @@ Required values to run command:
   -h, --help                            Print usage
   -n, --name string                     The name for the FlowLog (default "Unnamed FlowLog")
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -b, --s3bucket string                 S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)

--- a/docs/subcommands/Network-Load-Balancer/flowlog/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/delete.md
@@ -56,6 +56,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -t, --timeout int                     Timeout option for Request for Network Load Balancer FlowLog deletion [seconds] (default 300)

--- a/docs/subcommands/Network-Load-Balancer/flowlog/get.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/get.md
@@ -53,7 +53,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -v, --verbose                         Print step-by-step process when running command

--- a/docs/subcommands/Network-Load-Balancer/flowlog/list.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/list.md
@@ -58,7 +58,7 @@ Required values to run command:
   -h, --help                            Print usage
   -M, --max-results int32               The maximum number of elements to return
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
       --order-by string                 Limits results to those containing a matching value for a specific property
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output

--- a/docs/subcommands/Network-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/update.md
@@ -58,6 +58,7 @@ Required values to run command:
   -h, --help                            Print usage
   -n, --name string                     Name of the Network Load Balancer FlowLog
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -b, --s3bucket string                 S3 Bucket name of an existing IONOS Cloud S3 Bucket

--- a/docs/subcommands/Network-Load-Balancer/get.md
+++ b/docs/subcommands/Network-Load-Balancer/get.md
@@ -45,7 +45,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
   -i, --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -t, --timeout int                     Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds] (default 300)

--- a/docs/subcommands/Network-Load-Balancer/list.md
+++ b/docs/subcommands/Network-Load-Balancer/list.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
   -M, --max-results int32      The maximum number of elements to return
-      --no-headers             When using text output, don't print headers
+      --no-headers             Don't print table headers when table output is used
       --order-by string        Limits results to those containing a matching value for a specific property
   -o, --output string          Desired output format [text|json|api-json] (default "text")
   -q, --quiet                  Quiet output

--- a/docs/subcommands/Network-Load-Balancer/rule/create.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/create.md
@@ -61,6 +61,7 @@ Required values to run command:
       --listener-port string            Listening port number. Range: 1 to 65535 (required)
   -n, --name string                     The name for the Forwarding Rule (default "Unnamed Forwarding Rule")
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
       --retries int                     [Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535 (default 3)

--- a/docs/subcommands/Network-Load-Balancer/rule/delete.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/delete.md
@@ -55,6 +55,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -i, --rule-id string                  The unique ForwardingRule Id (required)

--- a/docs/subcommands/Network-Load-Balancer/rule/get.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/get.md
@@ -52,7 +52,7 @@ Required values to run command:
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
   -i, --rule-id string                  The unique ForwardingRule Id (required)

--- a/docs/subcommands/Network-Load-Balancer/rule/list.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/list.md
@@ -58,7 +58,7 @@ Required values to run command:
   -h, --help                            Print usage
   -M, --max-results int32               The maximum number of elements to return
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
       --order-by string                 Limits results to those containing a matching value for a specific property
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output

--- a/docs/subcommands/Network-Load-Balancer/rule/target/add.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/add.md
@@ -62,6 +62,7 @@ Required values to run command:
       --ip ip                           IP of a balanced target VM (required)
       --maintenance                     [Health Check]  Maintenance specifies if a target VM should be marked as down, even if it is not
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -P, --port string                     Port of the balanced target service. Range: 1 to 65535 (required)
   -q, --quiet                           Quiet output

--- a/docs/subcommands/Network-Load-Balancer/rule/target/list.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/list.md
@@ -53,7 +53,7 @@ Required values to run command:
   -h, --help                            Print usage
   -M, --max-results int32               The maximum number of elements to return
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
-      --no-headers                      When using text output, don't print headers
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
       --rule-id string                  The unique ForwardingRule Id (required)

--- a/docs/subcommands/Network-Load-Balancer/rule/target/remove.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/target/remove.md
@@ -58,6 +58,7 @@ Required values to run command:
   -h, --help                            Print usage
       --ip ip                           IP of a balanced target VM (required)
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -P, --port string                     Port of the balanced target service. Range: 1 to 65535 (required)
   -q, --quiet                           Quiet output

--- a/docs/subcommands/Network-Load-Balancer/rule/update.md
+++ b/docs/subcommands/Network-Load-Balancer/rule/update.md
@@ -60,6 +60,7 @@ Required values to run command:
       --listener-port string            Listening port number. Range: 1 to 65535 (required)
   -n, --name string                     The name for the Forwarding Rule
       --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
   -q, --quiet                           Quiet output
       --retries int                     [Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535 (default 3)

--- a/docs/subcommands/Network-Load-Balancer/update.md
+++ b/docs/subcommands/Network-Load-Balancer/update.md
@@ -50,6 +50,7 @@ Required values to run command:
       --listener-lan int                Id of the listening LAN (default 2)
   -n, --name string                     Name of the Network Load Balancer (default "Network Load Balancer")
   -i, --networkloadbalancer-id string   The unique NetworkLoadBalancer Id (required)
+      --no-headers                      Don't print table headers when table output is used
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
       --private-ips strings             Collection of private IP addresses with subnet mask of the Network Load Balancer
   -q, --quiet                           Quiet output

--- a/docs/subcommands/User-Management/create.md
+++ b/docs/subcommands/User-Management/create.md
@@ -48,6 +48,7 @@ Required values to run a command:
       --force-secure-auth   Indicates if secure (two-factor) authentication should be forced for the User
   -h, --help                Print usage
       --last-name string    The last name for the User (required)
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -p, --password string     The password for the User (must be at least 5 characters long) (required)
   -q, --quiet               Quiet output

--- a/docs/subcommands/User-Management/delete.md
+++ b/docs/subcommands/User-Management/delete.md
@@ -41,6 +41,7 @@ Required values to run command:
   -D, --depth int32      Controls the detail depth of the response objects. Max depth is 10.
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -i, --user-id string   The unique User Id (required)

--- a/docs/subcommands/User-Management/get.md
+++ b/docs/subcommands/User-Management/get.md
@@ -40,7 +40,7 @@ Required values to run command:
   -D, --depth int32      Controls the detail depth of the response objects. Max depth is 10.
   -f, --force            Force command to execute without user input
   -h, --help             Print usage
-      --no-headers       When using text output, don't print headers
+      --no-headers       Don't print table headers when table output is used
   -o, --output string    Desired output format [text|json|api-json] (default "text")
   -q, --quiet            Quiet output
   -i, --user-id string   The unique User Id (required)

--- a/docs/subcommands/User-Management/list.md
+++ b/docs/subcommands/User-Management/list.md
@@ -45,7 +45,7 @@ Available Filters:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
       --order-by string     Limits results to those containing a matching value for a specific property
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/User-Management/s3key/create.md
+++ b/docs/subcommands/User-Management/s3key/create.md
@@ -52,6 +52,7 @@ Required values to run command:
   -D, --depth int32        Controls the detail depth of the response objects. Max depth is 10.
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -t, --timeout int        Timeout option for Request for User S3Key creation [seconds] (default 60)

--- a/docs/subcommands/User-Management/s3key/delete.md
+++ b/docs/subcommands/User-Management/s3key/delete.md
@@ -50,6 +50,7 @@ Required values to run command:
   -D, --depth int32        Controls the detail depth of the response objects. Max depth is 10.
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
   -i, --s3key-id string    The unique User S3Key Id (required)

--- a/docs/subcommands/User-Management/s3key/get.md
+++ b/docs/subcommands/User-Management/s3key/get.md
@@ -49,7 +49,7 @@ Required values to run command:
   -D, --depth int32       Controls the detail depth of the response objects. Max depth is 10.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
-      --no-headers        When using text output, don't print headers
+      --no-headers        Don't print table headers when table output is used
   -o, --output string     Desired output format [text|json|api-json] (default "text")
   -q, --quiet             Quiet output
   -i, --s3key-id string   The unique User S3Key Id (required)

--- a/docs/subcommands/User-Management/s3key/list.md
+++ b/docs/subcommands/User-Management/s3key/list.md
@@ -49,7 +49,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
   -M, --max-results int32   The maximum number of elements to return
-      --no-headers          When using text output, don't print headers
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output
       --user-id string      The unique User Id (required)

--- a/docs/subcommands/User-Management/s3key/update.md
+++ b/docs/subcommands/User-Management/s3key/update.md
@@ -52,6 +52,7 @@ Required values to run command:
   -D, --depth int32        Controls the detail depth of the response objects. Max depth is 10.
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
+      --no-headers         Don't print table headers when table output is used
   -o, --output string      Desired output format [text|json|api-json] (default "text")
   -q, --quiet              Quiet output
       --s3key-active       Enable or disable an User S3Key. E.g.: --s3key-active=true, --s3key-active=false

--- a/docs/subcommands/User-Management/update.md
+++ b/docs/subcommands/User-Management/update.md
@@ -45,6 +45,7 @@ Required values to run command:
       --force-secure-auth   Indicates if secure (two-factor) authentication should be forced for the User. E.g.: --force-secure-auth=true, --force-secure-auth=false
   -h, --help                Print usage
       --last-name string    The last name for the User
+      --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -p, --password string     The password for the User (must be at least 5 characters long)
   -q, --quiet               Quiet output

--- a/pkg/jsontabwriter/jsontabwriter.go
+++ b/pkg/jsontabwriter/jsontabwriter.go
@@ -184,7 +184,7 @@ func writeTableToText(table []map[string]interface{}, cols []string) string {
 		return ""
 	}
 
-	if !viper.IsSet(constants.ArgNoHeaders) {
+	if !viper.GetBool(constants.ArgNoHeaders) {
 		fmt.Fprintln(w, strings.Join(updatedCols, "\t"))
 	}
 


### PR DESCRIPTION
Viper would fail retrieving the `--no-headers` value due to it:
1. not having a root level flag,
2. binding to the sub-command level `--no-headers` flags instead and using their values

Hence always headers would be shown no matter if the flag was set or not.

Note: Now `--no-headers` will work on all commands, regardless if they might have had `--no-headers` added manually or not