### PR TITLE
fix: backupunit prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [v6.7.1] (???)
+## [v6.7.2] (November 2023)
+
+## Fixed
+- Fixed `backupunit list` columns
+- Fixed `backupunit get-sso-url` characters being treated as format placeholders
+
+## [v6.7.1] (October 2023)
 
 ## Added
 

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -248,7 +248,7 @@ func RunBackupUnitList(c *core.CommandConfig) error {
 	}
 
 	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.BackupUnit, backupUnits.BackupUnits,
-		tabheaders.GetHeadersAllDefault(defaultAlbRuleHttpRuleCols, cols))
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols))
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func RunBackupUnitGetSsoUrl(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
+	fmt.Fprintf(c.Command.Command.OutOrStdout(), "%s", out)
 
 	return nil
 }


### PR DESCRIPTION
Fixes ` backupunit list` missing columns and `get-sso-url` `%` elements being treated as placeholder strings

i.e.

```
{
  "ssoUrl" : "https://backup.ionos.com/api/2/idp/external-login#ott=T1RUAQAAAH76SwAAAAAAaK8qvEA1TyeIFlqYI1z-VQ%3D%3D&targetURI=https://backup.ionos.com/bc"
}
```

would be converted to

```
BackupUnitSsoUrl
https://backup.ionos.com/api/2/idp/external-login#ott=T1RUAQAAAH76SwAAAAAAaK8qvEA1TyeIFlqYI1z-VQ%!D(MISSING)%!D(MISSING)&targetURI=https://backup.ionos.com/bc
```
