### PR TITLE
refactor: move --force flag 

### DIFF
--- a/commands/certmanager/certmanager_integration_test.go
+++ b/commands/certmanager/certmanager_integration_test.go
@@ -74,21 +74,24 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			assert.NoError(t, err)
 
 			caPEM := new(bytes.Buffer)
-			pem.Encode(caPEM, &pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: caBytes,
-			})
+			pem.Encode(
+				caPEM, &pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: caBytes,
+				},
+			)
 
 			caPrivKeyPEM := new(bytes.Buffer)
-			pem.Encode(caPrivKeyPEM, &pem.Block{
-				Type:  "RSA PRIVATE KEY",
-				Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-			})
+			pem.Encode(
+				caPrivKeyPEM, &pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+				},
+			)
 
 			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
 			viper.Set(constants.ArgQuiet, false)
 			viper.Set(constants.ArgVerbose, false)
-			viper.Set(constants.ArgForce, true)
 
 			c := CertCreateCmd()
 			c.Command.Flags().Set(FlagCertName, "___test___certificate___test___")
@@ -119,6 +122,7 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			assert.NoError(t, err)
 
 			d := CertDeleteCmd()
+			d.Command.Flags().Set(constants.ArgForce, "true")
 			d.Command.Flags().Set(FlagCertId, id)
 			err = d.Command.Execute()
 			assert.NoError(t, err)
@@ -137,16 +141,20 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			assert.NoError(t, err)
 
 			caPEM := new(bytes.Buffer)
-			pem.Encode(caPEM, &pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: caBytes,
-			})
+			pem.Encode(
+				caPEM, &pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: caBytes,
+				},
+			)
 
 			caPrivKeyPEM := new(bytes.Buffer)
-			pem.Encode(caPrivKeyPEM, &pem.Block{
-				Type:  "RSA PRIVATE KEY",
-				Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-			})
+			pem.Encode(
+				caPrivKeyPEM, &pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+				},
+			)
 			certPath := filepath.Join(".", "cert.pem")
 			//os.Create(certPath)
 			err = os.WriteFile(certPath, caPEM.Bytes(), 0777)
@@ -160,7 +168,6 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
 			viper.Set(constants.ArgQuiet, true)
 			viper.Set(constants.ArgVerbose, false)
-			viper.Set(constants.ArgForce, true)
 
 			c := CertCreateCmd()
 			c.Command.Flags().Set(FlagCertName, "test_certificate-files_test")
@@ -189,12 +196,15 @@ func TestCertificateManagerServiceCmd(t *testing.T) {
 			p.Command.Flags().Set(FlagCertName, "test_certificate-files-updated_test")
 			err = p.Command.Execute()
 
-			cert, _, err := svc.CertManagerClient.CertificatesApi.CertificatesGetById(context.Background(), id).Execute()
+			cert, _, err := svc.CertManagerClient.CertificatesApi.CertificatesGetById(
+				context.Background(), id,
+			).Execute()
 			assert.NoError(t, err)
 			assert.Equal(t, "test_certificate-files-updated_test", *cert.GetProperties().GetName())
 
 			d := CertDeleteCmd()
 			d.Command.Flags().Set(FlagCertId, id)
+			d.Command.Flags().Set(constants.ArgForce, "true")
 			err = d.Command.Execute()
 			assert.NoError(t, err)
 

--- a/commands/certmanager/delete.go
+++ b/commands/certmanager/delete.go
@@ -28,11 +28,13 @@ func CertDeleteCmd() *core.Command {
 			InitClient: true,
 		},
 	)
-
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddStringFlag(FlagCertId, constants.FlagIdShort, "", "Response delete a single certificate (required)")
-	_ = cmd.Command.RegisterFlagCompletionFunc(FlagCertId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return CertificatesIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		FlagCertId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CertificatesIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Response delete all certificates")
 
 	cmd.Command.Flags().StringSlice(constants.ArgCols, nil, tabheaders.ColsMessage(defaultCertificateCols))
@@ -55,7 +57,9 @@ func CmdDelete(c *core.CommandConfig) error {
 	}
 
 	if allFlag {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all Certificates..."))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all Certificates..."),
+		)
 
 		certs, _, err := c.CertificateManagerServices.Certs().List()
 		if err != nil {
@@ -64,7 +68,9 @@ func CmdDelete(c *core.CommandConfig) error {
 
 		for _, cert := range *certs.Items {
 			msg := fmt.Sprintf("delete Certificate ID: %s", *cert.Id)
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+			if !confirm.FAsk(
+				c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			) {
 				return fmt.Errorf(confirm.UserDenied)
 			}
 
@@ -80,7 +86,9 @@ func CmdDelete(c *core.CommandConfig) error {
 		}
 
 		msg := fmt.Sprintf("delete Certificate ID: %s", id)
-		if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+		if !confirm.FAsk(
+			c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+		) {
 			return fmt.Errorf(confirm.UserDenied)
 		}
 

--- a/commands/cfg/cfg_test.go
+++ b/commands/cfg/cfg_test.go
@@ -46,7 +46,6 @@ func TestAuthCmds(t *testing.T) {
 	assert.NotEmpty(t, GoodToken)
 
 	viper.Set(constants.ArgOutput, "text")
-	viper.Set(constants.ArgForce, "true")
 
 	_, filename, _, _ := runtime.Caller(0)
 	testDir = strings.Split(filepath.Dir(filename), "/ionosctl/")[0] + "/ionosctl/temp-login-tests"
@@ -55,210 +54,234 @@ func TestAuthCmds(t *testing.T) {
 		t.Fatalf("failed creating config dir: %s", err.Error())
 	}
 	viper.Set(constants.ArgConfig, testDir+"/"+fake.Adjective()+".json")
-	err = config.Write(map[string]string{
-		constants.CfgUsername:  "UsernameHere",
-		constants.CfgPassword:  "PasswordHere",
-		constants.CfgToken:     "TokenHere",
-		constants.CfgServerUrl: "sample-url.com",
-	})
+	err = config.Write(
+		map[string]string{
+			constants.CfgUsername:  "UsernameHere",
+			constants.CfgPassword:  "PasswordHere",
+			constants.CfgToken:     "TokenHere",
+			constants.CfgServerUrl: "sample-url.com",
+		},
+	)
 	if err != nil {
 		t.Fatalf("failed setting up a test config file: %s", err.Error())
 	}
 
 	t.Parallel()
 
-	t.Run("login test user interactively, password as flag - valid token saved to config", func(t *testing.T) {
-		login := cfg.LoginCmd()
-		logout := cfg.LogoutCmd()
+	t.Run(
+		"login test user interactively, password as flag - valid token saved to config", func(t *testing.T) {
+			login := cfg.LoginCmd()
+			logout := cfg.LogoutCmd()
 
-		login.Command.Flags().Set(constants.ArgPassword, GoodPassword)
+			login.Command.Flags().Set(constants.ArgPassword, GoodPassword)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgForce), true)
 
-		out := &bytes.Buffer{}
-		in := bytes.NewBufferString(GoodUsername + "\n")
-		login.Command.SetOut(out)
-		login.Command.SetIn(in)
+			out := &bytes.Buffer{}
+			in := bytes.NewBufferString(GoodUsername + "\n")
+			login.Command.SetOut(out)
+			login.Command.SetIn(in)
 
-		// Exec login
-		err := login.Command.Execute()
-		assert.Contains(t, out.String(), "Enter your username: ")
-		assert.NoError(t, err)
+			// Exec login
+			err := login.Command.Execute()
+			assert.Contains(t, out.String(), "Enter your username: ")
+			assert.NoError(t, err)
 
-		// Read the configuration after login and assert that the token is valid
-		cfg, err := config.Read()
-		assert.NoError(t, err)
+			// Read the configuration after login and assert that the token is valid
+			cfg, err := config.Read()
+			assert.NoError(t, err)
 
-		assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
-		assert.Empty(t, cfg[constants.ArgServerUrl])
-		assert.Empty(t, cfg[constants.CfgUsername])
-		assert.Empty(t, cfg[constants.CfgPassword])
+			assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
+			assert.Empty(t, cfg[constants.ArgServerUrl])
+			assert.Empty(t, cfg[constants.CfgUsername])
+			assert.Empty(t, cfg[constants.CfgPassword])
 
-		// Exec logout
-		out = &bytes.Buffer{}
-		logout.Command.SetOut(out)
-		err = logout.Command.Execute()
+			// Exec logout
+			out = &bytes.Buffer{}
+			logout.Command.SetOut(out)
+			err = logout.Command.Execute()
 
-		// Assert that logout was successful and the token is removed from the configuration
-		assert.Contains(t, out.String(), "De-authentication successful")
-		assert.NoError(t, err)
-		cfg, err = config.Read()
-		assert.NoError(t, err)
-		assert.Empty(t, cfg[constants.CfgToken])
-	})
+			// Assert that logout was successful and the token is removed from the configuration
+			assert.Contains(t, out.String(), "De-authentication successful")
+			assert.NoError(t, err)
+			cfg, err = config.Read()
+			assert.NoError(t, err)
+			assert.Empty(t, cfg[constants.CfgToken])
+		},
+	)
 
-	t.Run("login test user, password as flag - valid token saved to config", func(t *testing.T) {
-		login := cfg.LoginCmd()
-		logout := cfg.LogoutCmd()
+	t.Run(
+		"login test user, password as flag - valid token saved to config", func(t *testing.T) {
+			login := cfg.LoginCmd()
+			logout := cfg.LogoutCmd()
 
-		viper.Set(core.GetFlagName(login.NS, constants.ArgUser), GoodUsername)
-		viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), GoodPassword)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgUser), GoodUsername)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), GoodPassword)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgForce), true)
 
-		out := &bytes.Buffer{}
-		login.Command.SetOut(out)
-		err := login.Command.Execute()
-		assert.Contains(t, out.String(), "Config file updated successfully")
-		assert.NoError(t, err)
+			out := &bytes.Buffer{}
+			login.Command.SetOut(out)
+			err := login.Command.Execute()
+			assert.Contains(t, out.String(), "Config file updated successfully")
+			assert.NoError(t, err)
 
-		// Read the configuration after login and assert that the token is valid
-		cfg, err := config.Read()
-		assert.NoError(t, err)
-		assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
+			// Read the configuration after login and assert that the token is valid
+			cfg, err := config.Read()
+			assert.NoError(t, err)
+			assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
 
-		out = &bytes.Buffer{}
-		logout.Command.SetOut(out)
-		err = logout.Command.Execute()
-		assert.Contains(t, out.String(), "De-authentication successful")
-		assert.NoError(t, err)
-		cfg, err = config.Read()
-		assert.NoError(t, err)
-		assert.Empty(t, cfg[constants.CfgToken])
-	})
+			out = &bytes.Buffer{}
+			logout.Command.SetOut(out)
+			err = logout.Command.Execute()
+			assert.Contains(t, out.String(), "De-authentication successful")
+			assert.NoError(t, err)
+			cfg, err = config.Read()
+			assert.NoError(t, err)
+			assert.Empty(t, cfg[constants.CfgToken])
+		},
+	)
 
-	t.Run("invalid user, password as flag - valid token saved to config - should still error out", func(t *testing.T) {
-		login := cfg.LoginCmd()
-		logout := cfg.LogoutCmd()
+	t.Run(
+		"invalid user, password as flag - valid token saved to config - should still error out", func(t *testing.T) {
+			login := cfg.LoginCmd()
+			logout := cfg.LogoutCmd()
 
-		viper.Set(core.GetFlagName(login.NS, constants.ArgUser), fake.Adjective())
-		viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), fake.Adjective())
+			viper.Set(core.GetFlagName(login.NS, constants.ArgUser), fake.Adjective())
+			viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), fake.Adjective())
+			viper.Set(core.GetFlagName(login.NS, constants.ArgForce), true)
 
-		config.Write(map[string]string{
-			constants.CfgToken: GoodToken,
-		})
+			config.Write(
+				map[string]string{
+					constants.CfgToken: GoodToken,
+				},
+			)
 
-		// Read the configuration after login and assert that the token is valid
-		cfg, err := config.Read()
-		assert.NoError(t, err)
-		assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
+			// Read the configuration after login and assert that the token is valid
+			cfg, err := config.Read()
+			assert.NoError(t, err)
+			assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
 
-		out := &bytes.Buffer{}
-		login.Command.SetOut(out)
-		err = login.Command.Execute()
-		assert.ErrorContains(t, err, "401 Unauthorized")
+			out := &bytes.Buffer{}
+			login.Command.SetOut(out)
+			err = login.Command.Execute()
+			assert.ErrorContains(t, err, "401 Unauthorized")
 
-		// Recreate file that is replaced by above login
-		config.Write(map[string]string{
-			constants.CfgToken: GoodToken,
-		})
+			// Recreate file that is replaced by above login
+			config.Write(
+				map[string]string{
+					constants.CfgToken: GoodToken,
+				},
+			)
 
-		out = &bytes.Buffer{}
-		logout.Command.SetOut(out)
-		err = logout.Command.Execute()
-		assert.Contains(t, out.String(), "De-authentication successful")
-		assert.NoError(t, err)
-		cfg, err = config.Read()
-		assert.NoError(t, err)
-		assert.Empty(t, cfg[constants.CfgToken])
-	})
+			out = &bytes.Buffer{}
+			logout.Command.SetOut(out)
+			err = logout.Command.Execute()
+			assert.Contains(t, out.String(), "De-authentication successful")
+			assert.NoError(t, err)
+			cfg, err = config.Read()
+			assert.NoError(t, err)
+			assert.Empty(t, cfg[constants.CfgToken])
+		},
+	)
 
-	t.Run("non existant config file should be created", func(t *testing.T) {
-		login := cfg.LoginCmd()
-		logout := cfg.LogoutCmd()
+	t.Run(
+		"non existant config file should be created", func(t *testing.T) {
+			login := cfg.LoginCmd()
+			logout := cfg.LogoutCmd()
 
-		viper.Set(core.GetFlagName(login.NS, constants.ArgUser), GoodUsername)
-		viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), GoodPassword)
-		newCfgFilePath := testDir + "/" + fake.Noun() + ".json"
-		viper.Set(constants.ArgConfig, newCfgFilePath)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgUser), GoodUsername)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgPassword), GoodPassword)
+			newCfgFilePath := testDir + "/" + fake.Noun() + ".json"
+			viper.Set(constants.ArgConfig, newCfgFilePath)
+			viper.Set(core.GetFlagName(login.NS, constants.ArgForce), true)
 
-		out := &bytes.Buffer{}
-		login.Command.SetOut(out)
-		err := login.Command.Execute()
-		assert.NoError(t, err)
+			out := &bytes.Buffer{}
+			login.Command.SetOut(out)
+			err := login.Command.Execute()
+			assert.NoError(t, err)
 
-		// Read the configuration after login and assert that the token is valid
-		cfg, err := config.Read()
-		assert.NoError(t, err)
-		assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
+			// Read the configuration after login and assert that the token is valid
+			cfg, err := config.Read()
+			assert.NoError(t, err)
+			assert.NoError(t, client.TestCreds("", "", cfg[constants.CfgToken]))
 
-		out = &bytes.Buffer{}
-		logout.Command.SetOut(out)
-		err = logout.Command.Execute()
-		assert.Contains(t, out.String(), "De-authentication successful")
-		assert.NoError(t, err)
-		cfg, err = config.Read()
-		assert.NoError(t, err)
-		assert.Empty(t, cfg[constants.CfgToken])
+			out = &bytes.Buffer{}
+			logout.Command.SetOut(out)
+			err = logout.Command.Execute()
+			assert.Contains(t, out.String(), "De-authentication successful")
+			assert.NoError(t, err)
+			cfg, err = config.Read()
+			assert.NoError(t, err)
+			assert.Empty(t, cfg[constants.CfgToken])
 
-		// err = os.Remove(newCfgFilePath)
-		// if err != nil {
-		// 	t.Fatalf("note: failed to remove file %s: %s, remove it manually\n", newCfgFilePath, err.Error())
-		// }
-	})
+			// err = os.Remove(newCfgFilePath)
+			// if err != nil {
+			// 	t.Fatalf("note: failed to remove file %s: %s, remove it manually\n", newCfgFilePath, err.Error())
+			// }
+		},
+	)
 
-	t.Run("Pre-rework config file logout - Username and password removed from config file", func(t *testing.T) {
-		logout := cfg.LogoutCmd()
+	t.Run(
+		"Pre-rework config file logout - Username and password removed from config file", func(t *testing.T) {
+			logout := cfg.LogoutCmd()
 
-		before := map[string]string{
-			constants.CfgUsername:  "UsernameHere",
-			constants.CfgPassword:  "PasswordHere",
-			constants.CfgToken:     "TokenHere",
-			constants.CfgServerUrl: "dont-kill-me.com",
-		}
-		config.Write(before)
+			before := map[string]string{
+				constants.CfgUsername:  "UsernameHere",
+				constants.CfgPassword:  "PasswordHere",
+				constants.CfgToken:     "TokenHere",
+				constants.CfgServerUrl: "dont-kill-me.com",
+			}
+			config.Write(before)
 
-		// Read the configuration - is it what we expect ?
-		cfg, err := config.Read()
-		assert.NoError(t, err)
-		assert.Equal(t, before, cfg)
+			// Read the configuration - is it what we expect ?
+			cfg, err := config.Read()
+			assert.NoError(t, err)
+			assert.Equal(t, before, cfg)
 
-		out := &bytes.Buffer{}
-		logout.Command.SetOut(out)
-		err = logout.Command.Execute()
+			out := &bytes.Buffer{}
+			logout.Command.SetOut(out)
+			err = logout.Command.Execute()
 
-		// Assert that logout was successful and the username, password, token removed from cfg
-		assert.Contains(t, out.String(), "De-authentication successful")
-		assert.NoError(t, err)
-		after, err := config.Read()
-		assert.NoError(t, err)
-		assert.Empty(t, after[constants.CfgToken])
-		assert.Empty(t, after[constants.CfgPassword])
-		assert.Empty(t, after[constants.CfgUsername])
-		assert.Equal(t, before[constants.CfgServerUrl], after[constants.CfgServerUrl])
-	})
+			// Assert that logout was successful and the username, password, token removed from cfg
+			assert.Contains(t, out.String(), "De-authentication successful")
+			assert.NoError(t, err)
+			after, err := config.Read()
+			assert.NoError(t, err)
+			assert.Empty(t, after[constants.CfgToken])
+			assert.Empty(t, after[constants.CfgPassword])
+			assert.Empty(t, after[constants.CfgUsername])
+			assert.Equal(t, before[constants.CfgServerUrl], after[constants.CfgServerUrl])
+		},
+	)
 
 	// cfg location tests
-	t.Run("cfg location cmd returns valid location", func(t *testing.T) {
-		cfgLocCmd := cfg.LocationCmd()
-		out := &bytes.Buffer{}
-		cfgLocCmd.Command.SetOut(out)
-		err := cfgLocCmd.Command.Execute()
-		assert.NoError(t, err)
+	t.Run(
+		"cfg location cmd returns valid location", func(t *testing.T) {
+			cfgLocCmd := cfg.LocationCmd()
+			out := &bytes.Buffer{}
+			cfgLocCmd.Command.SetOut(out)
+			err := cfgLocCmd.Command.Execute()
+			assert.NoError(t, err)
 
-		assert.Equal(t, config.GetConfigFilePath(), out.String())
-	})
+			assert.Equal(t, config.GetConfigFilePath(), out.String())
+		},
+	)
 
 	// cfg whoami tests
-	t.Run("cfg whoami returns current user - Env Username & Password", func(t *testing.T) {
-		cmd := cfg.WhoamiCmd()
+	t.Run(
+		"cfg whoami returns current user - Env Username & Password", func(t *testing.T) {
+			cmd := cfg.WhoamiCmd()
 
-		viper.Set(core.GetFlagName(cmd.NS, constants.ArgUser), GoodUsername)
-		viper.Set(core.GetFlagName(cmd.NS, constants.ArgPassword), GoodPassword)
+			viper.Set(core.GetFlagName(cmd.NS, constants.ArgUser), GoodUsername)
+			viper.Set(core.GetFlagName(cmd.NS, constants.ArgPassword), GoodPassword)
 
-		out := &bytes.Buffer{}
-		cmd.Command.SetOut(out)
-		err := cmd.Command.Execute()
-		assert.NoError(t, err)
+			out := &bytes.Buffer{}
+			cmd.Command.SetOut(out)
+			err := cmd.Command.Execute()
+			assert.NoError(t, err)
 
-		assert.Contains(t, out.String(), GoodUsername)
-	})
+			assert.Contains(t, out.String(), GoodUsername)
+		},
+	)
 
 }
 

--- a/commands/cloudapi-v6/applicationloadbalancer.go
+++ b/commands/cloudapi-v6/applicationloadbalancer.go
@@ -26,8 +26,12 @@ import (
 )
 
 var (
-	defaultApplicationLoadBalancerCols = []string{"ApplicationLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "PrivateIps", "State"}
-	allApplicationLoadBalancerCols     = []string{"ApplicationLoadBalancerId", "DatacenterId", "Name", "ListenerLan", "Ips", "TargetLan", "PrivateIps", "State"}
+	defaultApplicationLoadBalancerCols = []string{
+		"ApplicationLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "PrivateIps", "State",
+	}
+	allApplicationLoadBalancerCols = []string{
+		"ApplicationLoadBalancerId", "DatacenterId", "Name", "ListenerLan", "Ips", "TargetLan", "PrivateIps", "State",
+	}
 )
 
 func ApplicationLoadBalancerCmd() *core.Command {
@@ -42,114 +46,187 @@ func ApplicationLoadBalancerCmd() *core.Command {
 		},
 	}
 	globalFlags := applicationloadbalancerCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultApplicationLoadBalancerCols, tabheaders.ColsMessage(defaultApplicationLoadBalancerCols))
-	_ = viper.BindPFlag(core.GetFlagName(applicationloadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = applicationloadbalancerCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allApplicationLoadBalancerCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultApplicationLoadBalancerCols,
+		tabheaders.ColsMessage(defaultApplicationLoadBalancerCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(applicationloadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = applicationloadbalancerCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allApplicationLoadBalancerCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, applicationloadbalancerCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "applicationloadbalancer",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Application Load Balancers",
-		LongDesc:   "Use this command to list Application Load Balancers from a specified Virtual Data Center.\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listApplicationLoadBalancerExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerList,
-		CmdRun:     RunApplicationLoadBalancerList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, applicationloadbalancerCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "applicationloadbalancer",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Application Load Balancers",
+			LongDesc:   "Use this command to list Application Load Balancers from a specified Virtual Data Center.\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listApplicationLoadBalancerExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerList,
+			CmdRun:     RunApplicationLoadBalancerList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, applicationloadbalancerCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "applicationloadbalancer",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get an Application Load Balancer",
-		LongDesc:   "Use this command to get information about a specified Application Load Balancer from a Virtual Data Center. You can also wait for Application Load Balancer to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
-		Example:    getApplicationLoadBalancerExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
-		CmdRun:     RunApplicationLoadBalancerGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, applicationloadbalancerCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "applicationloadbalancer",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get an Application Load Balancer",
+			LongDesc:   "Use this command to get information about a specified Application Load Balancer from a Virtual Data Center. You can also wait for Application Load Balancer to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
+			Example:    getApplicationLoadBalancerExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
+			CmdRun:     RunApplicationLoadBalancerGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Application Load Balancer to be in AVAILABLE state")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for waiting for Application Load Balancer to be in AVAILABLE state [seconds]")
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified Application Load Balancer to be in AVAILABLE state",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for waiting for Application Load Balancer to be in AVAILABLE state [seconds]",
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, applicationloadbalancerCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "applicationloadbalancer",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create an Application Load Balancer",
-		LongDesc: `Use this command to create an Application Load Balancer in a specified Virtual Data Center.
+	create := core.NewCommand(
+		ctx, applicationloadbalancerCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "applicationloadbalancer",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create an Application Load Balancer",
+			LongDesc: `Use this command to create an Application Load Balancer in a specified Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Data Center Id`,
-		Example:    createApplicationLoadBalancerExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunApplicationLoadBalancerCreate,
-		InitClient: true,
-	})
+			Example:    createApplicationLoadBalancerExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunApplicationLoadBalancerCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Application Load Balancer", "The name of the Application Load Balancer.")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Application Load Balancer",
+		"The name of the Application Load Balancer.",
+	)
 	create.AddIntFlag(cloudapiv6.ArgListenerLan, "", 2, "ID of the listening (inbound) LAN.")
 	create.AddIntFlag(cloudapiv6.ArgTargetLan, "", 1, "ID of the balanced private target LAN (outbound).")
-	create.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.")
-	create.AddStringSliceFlag(cloudapiv6.ArgPrivateIps, "", nil, "Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.AlbTimeoutSeconds, "Timeout option for Request for Application Load Balancer creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddStringSliceFlag(
+		cloudapiv6.ArgIps, "", nil,
+		"Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.",
+	)
+	create.AddStringSliceFlag(
+		cloudapiv6.ArgPrivateIps, "", nil,
+		"Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.AlbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, applicationloadbalancerCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "applicationloadbalancer",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update an Application Load Balancer",
-		LongDesc: `Use this command to update a specified Application Load Balancer from a Virtual Data Center.
+	update := core.NewCommand(
+		ctx, applicationloadbalancerCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "applicationloadbalancer",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update an Application Load Balancer",
+			LongDesc: `Use this command to update a specified Application Load Balancer from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` or ` + "`" + `-w` + "`" + ` option.
 
@@ -157,38 +234,72 @@ Required values to run command:
 
 * Data Center Id
 * Application Load Balancer Id`,
-		Example:    updateApplicationLoadBalancerExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
-		CmdRun:     RunApplicationLoadBalancerUpdate,
-		InitClient: true,
-	})
+			Example:    updateApplicationLoadBalancerExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
+			CmdRun:     RunApplicationLoadBalancerUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Application Load Balancer", "The name of the Application Load Balancer.")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Application Load Balancer",
+		"The name of the Application Load Balancer.",
+	)
 	update.AddIntFlag(cloudapiv6.ArgListenerLan, "", 0, "ID of the listening (inbound) LAN.")
 	update.AddIntFlag(cloudapiv6.ArgTargetLan, "", 0, "ID of the balanced private target LAN (outbound).")
-	update.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.")
-	update.AddStringSliceFlag(cloudapiv6.ArgPrivateIps, "", nil, "Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddStringSliceFlag(
+		cloudapiv6.ArgIps, "", nil,
+		"Collection of the Application Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan are customer-reserved public IPs for the public Load Balancers, and private IPs for the private Load Balancers.",
+	)
+	update.AddStringSliceFlag(
+		cloudapiv6.ArgPrivateIps, "", nil,
+		"Collection of private IP addresses with the subnet mask of the Application Load Balancer. IPs must contain valid a subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, applicationloadbalancerCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "applicationloadbalancer",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete an Application Load Balancer",
-		LongDesc: `Use this command to delete a specified Application Load Balancer from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, applicationloadbalancerCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "applicationloadbalancer",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete an Application Load Balancer",
+			LongDesc: `Use this command to delete a specified Application Load Balancer from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` or ` + "`" + `-w` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -196,23 +307,48 @@ Required values to run command:
 
 * Data Center Id
 * Application Load Balancer Id`,
-		Example:    deleteApplicationLoadBalancerExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerDelete,
-		CmdRun:     RunApplicationLoadBalancerDelete,
-		InitClient: true,
-	})
+			Example:    deleteApplicationLoadBalancerExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerDelete,
+			CmdRun:     RunApplicationLoadBalancerDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ApplicationLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Application Load Balancers")
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer deletion to be executed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer deletion to be executed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	applicationloadbalancerCmd.AddCommand(ApplicationLoadBalancerRuleCmd())
 	applicationloadbalancerCmd.AddCommand(ApplicationLoadBalancerFlowLogCmd())
@@ -225,21 +361,25 @@ func PreRunDcApplicationLoadBalancerIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunApplicationLoadBalancerDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunApplicationLoadBalancerList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
-		return query.ValidateFilters(c, completer.ApplicationLoadBalancersFilters(), completer.ApplicationLoadBalancersFiltersUsage())
+		return query.ValidateFilters(
+			c, completer.ApplicationLoadBalancersFilters(), completer.ApplicationLoadBalancersFiltersUsage(),
+		)
 	}
 	return nil
 }
@@ -263,7 +403,9 @@ func RunApplicationLoadBalancerListAll(c *core.CommandConfig) error {
 	totalTime := time.Duration(0)
 
 	for _, dc := range allDcs {
-		ApplicationLoadBalancers, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().List(*dc.GetId(), listQueryParams)
+		ApplicationLoadBalancers, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().List(
+			*dc.GetId(), listQueryParams,
+		)
 		if err != nil {
 			return err
 		}
@@ -288,18 +430,25 @@ func RunApplicationLoadBalancerListAll(c *core.CommandConfig) error {
 			allApplicationLoadBalancersConverted = append(allApplicationLoadBalancersConverted, converted[0])
 		}
 
-		allApplicationLoadBalancers = append(allApplicationLoadBalancers, ApplicationLoadBalancers.ApplicationLoadBalancers)
+		allApplicationLoadBalancers = append(
+			allApplicationLoadBalancers, ApplicationLoadBalancers.ApplicationLoadBalancers,
+		)
 		totalTime += resp.RequestTime
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allApplicationLoadBalancers, allApplicationLoadBalancersConverted,
-		tabheaders.GetHeaders(allApplicationLoadBalancerCols, defaultApplicationLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allApplicationLoadBalancers, allApplicationLoadBalancersConverted,
+		tabheaders.GetHeaders(allApplicationLoadBalancerCols, defaultApplicationLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -322,20 +471,29 @@ func RunApplicationLoadBalancerList(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting ApplicationLoadBalancers from Datacenter with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting ApplicationLoadBalancers from Datacenter with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	applicationloadbalancers, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().List(dcId, listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.ApplicationLoadBalancer, applicationloadbalancers,
-		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.ApplicationLoadBalancer, applicationloadbalancers,
+		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols),
+	)
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
 	return nil
@@ -350,13 +508,23 @@ func RunApplicationLoadBalancerGet(c *core.CommandConfig) error {
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(),
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
 		jsontabwriter.GenerateVerboseOutput(
-			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting ApplicationLoadBalancer with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting ApplicationLoadBalancer with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
-	if err := waitfor.WaitForState(c, waiter.ApplicationLoadBalancerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.ApplicationLoadBalancerStateInterrogator,
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+	); err != nil {
 		return err
 	}
 
@@ -366,15 +534,20 @@ func RunApplicationLoadBalancerGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.OutOrStdout(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
-		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
+		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -390,29 +563,43 @@ func RunApplicationLoadBalancerCreate(c *core.CommandConfig) error {
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 	proper := getNewApplicationLoadBalancerInfo(c)
 
 	if !proper.HasName() {
 		proper.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	if !proper.HasTargetLan() {
 		proper.SetTargetLan(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property TargetLan set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property TargetLan set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)),
+			),
+		)
 	}
 
 	if !proper.HasListenerLan() {
 		proper.SetListenerLan(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property ListenerLan set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ListenerLan set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan)),
+			),
+		)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating ApplicationLoadBalancer"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating ApplicationLoadBalancer"),
+	)
 	ng, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().Create(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
 		resources.ApplicationLoadBalancer{
@@ -423,8 +610,14 @@ func RunApplicationLoadBalancerCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request href: %v ", resp.Header.Get("location")))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Request href: %v ", resp.Header.Get("location")),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -434,8 +627,10 @@ func RunApplicationLoadBalancerCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
-		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
+		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -454,12 +649,19 @@ func RunApplicationLoadBalancerUpdate(c *core.CommandConfig) error {
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	input := getNewApplicationLoadBalancerInfo(c)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Updating ApplicationLoadBalancer with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating ApplicationLoadBalancer with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().Update(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -468,7 +670,10 @@ func RunApplicationLoadBalancerUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -478,8 +683,10 @@ func RunApplicationLoadBalancerUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
-		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancer, ng.ApplicationLoadBalancer,
+		tabheaders.GetHeadersAllDefault(defaultApplicationLoadBalancerCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -496,8 +703,11 @@ func RunApplicationLoadBalancerDelete(c *core.CommandConfig) error {
 	var resp *resources.Response
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+			),
+		)
 
 		err = DeleteAllApplicationLoadBalancer(c)
 		if err != nil {
@@ -507,21 +717,39 @@ func RunApplicationLoadBalancerDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete application load balancer", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete application load balancer",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting ApplicationLoadBalancer"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting ApplicationLoadBalancer"),
+	)
 
-	resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().Delete(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)), queryParams)
+	resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().Delete(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -531,7 +759,10 @@ func RunApplicationLoadBalancerDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancer successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancer successfully deleted"),
+	)
 
 	return nil
 }
@@ -544,10 +775,13 @@ func DeleteAllApplicationLoadBalancer(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Getting Application Load Balancers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Getting Application Load Balancers..."),
+	)
 
 	applicationLoadBalancers, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().List(
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), cloudapiv6.ParentResourceListQueryParams)
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -577,11 +811,17 @@ func DeleteAllApplicationLoadBalancer(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Application Load Balancers", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Application Load Balancers",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Application Load Balancers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Application Load Balancers..."),
+	)
 
 	var multiErr error
 	for _, alb := range *albItems {
@@ -590,20 +830,35 @@ func DeleteAllApplicationLoadBalancer(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Application Load Balancer with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Application Load Balancer with id: %v...", *id,
+			),
+		)
 
-		resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().Delete(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), *id, queryParams)
+		resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().Delete(
+			viper.GetString(
+				core.GetFlagName(
+					c.NS, cloudapiv6.ArgDataCenterId,
+				),
+			), *id, queryParams,
+		)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime,
+				),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -615,7 +870,10 @@ func DeleteAllApplicationLoadBalancer(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancers successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancers successfully deleted"),
+	)
 	return nil
 }
 
@@ -623,23 +881,43 @@ func getNewApplicationLoadBalancerInfo(c *core.CommandConfig) *resources.Applica
 	input := ionoscloud.ApplicationLoadBalancerProperties{}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 		input.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgIps)) {
 		input.SetIps(viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgIps)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IPs set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgIps))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property IPs set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgIps)),
+			),
+		)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan)) {
 		input.SetListenerLan(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerLan set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ListenerLan set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan)),
+			),
+		)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)) {
 		input.SetTargetLan(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property TargetLan set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property TargetLan set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)),
+			),
+		)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps)) {
 		input.SetLbPrivateIps(viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property LbPrivateIps set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property LbPrivateIps set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps)),
+			),
+		)
 	}
 	return &resources.ApplicationLoadBalancerProperties{
 		ApplicationLoadBalancerProperties: input,

--- a/commands/cloudapi-v6/applicationloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_flowlog.go
@@ -38,85 +38,145 @@ func ApplicationLoadBalancerFlowLogCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "flowlog",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Application Load Balancer FlowLogs",
-		LongDesc:   "Use this command to list Application Load Balancer FlowLogs from a specified Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
-		Example:    listApplicationLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
-		CmdRun:     RunApplicationLoadBalancerFlowLogList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "flowlog",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Application Load Balancer FlowLogs",
+			LongDesc:   "Use this command to list Application Load Balancer FlowLogs from a specified Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
+			Example:    listApplicationLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
+			CmdRun:     RunApplicationLoadBalancerFlowLogList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "flowlog",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get an Application Load Balancer FlowLog",
-		LongDesc:   "Use this command to get information about a specified Application Load Balancer FlowLog from an Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Application Load Balancer FlowLog Id",
-		Example:    getApplicationLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerFlowLogIds,
-		CmdRun:     RunApplicationLoadBalancerFlowLogGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "flowlog",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get an Application Load Balancer FlowLog",
+			LongDesc:   "Use this command to get information about a specified Application Load Balancer FlowLog from an Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Application Load Balancer FlowLog Id",
+			Example:    getApplicationLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerFlowLogIds,
+			CmdRun:     RunApplicationLoadBalancerFlowLogGet,
+			InitClient: true,
+		},
+	)
 	get.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddStringFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddStringFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddStringFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddStringFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create an Application Load Balancer FlowLog",
-		LongDesc: `Use this command to create an Application Load Balancer FlowLog in a specified Application Load Balancer.
+	create := core.NewCommand(
+		ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create an Application Load Balancer FlowLog",
+			LongDesc: `Use this command to create an Application Load Balancer FlowLog in a specified Application Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -125,47 +185,90 @@ Required values to run command:
 * Data Center Id
 * Application Load Balancer Id
 * Bucket Name`,
-		Example:    createApplicationLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerFlowLogCreate,
-		CmdRun:     RunApplicationLoadBalancerFlowLogCreate,
-		InitClient: true,
-	})
+			Example:    createApplicationLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerFlowLogCreate,
+			CmdRun:     RunApplicationLoadBalancerFlowLogCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed ALB Flow Log", "The name of the Application Load Balancer FlowLog.")
-	create.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "ALL", "Specifies the traffic action pattern.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "INGRESS", "Specifies the traffic direction pattern.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer FlowLog creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer FlowLog creation [seconds]")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed ALB Flow Log",
+		"The name of the Application Load Balancer FlowLog.",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "ALL", "Specifies the traffic action pattern.",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "INGRESS", "Specifies the traffic direction pattern.",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.",
+		core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer FlowLog creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer FlowLog creation [seconds]",
+	)
 	create.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = create.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update an Application Load Balancer FlowLog",
-		LongDesc: `Use this command to update a specified Application Load Balancer FlowLog from an Application Load Balancer.
+	update := core.NewCommand(
+		ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update an Application Load Balancer FlowLog",
+			LongDesc: `Use this command to update a specified Application Load Balancer FlowLog from an Application Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -174,52 +277,98 @@ Required values to run command:
 * Data Center Id
 * Application Load Balancer Id
 * Application Load Balancer FlowLog Id`,
-		Example:    updateApplicationLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerFlowLogIds,
-		CmdRun:     RunApplicationLoadBalancerFlowLogUpdate,
-		InitClient: true,
-	})
+			Example:    updateApplicationLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerFlowLogIds,
+			CmdRun:     RunApplicationLoadBalancerFlowLogUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the Application Load Balancer FlowLog.")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the Application Load Balancer FlowLog.",
+	)
 	update.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "", "Specifies the traffic action pattern.")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic direction pattern.")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer FlowLog update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer FlowLog update [seconds]")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic direction pattern.",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer FlowLog update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer FlowLog update [seconds]",
+	)
 	update.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = update.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete an Application Load Balancer FlowLog",
-		LongDesc: `Use this command to delete a specified Application Load Balancer FlowLog from an Application Load Balancer.
+	deleteCmd := core.NewCommand(
+		ctx, applicationloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete an Application Load Balancer FlowLog",
+			LongDesc: `Use this command to delete a specified Application Load Balancer FlowLog from an Application Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -228,54 +377,99 @@ Required values to run command:
 * Data Center Id
 * Application Load Balancer Id
 * Application Load Balancer FlowLog Id`,
-		Example:    deleteApplicationLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerFlowLogDelete,
-		CmdRun:     RunApplicationLoadBalancerFlowLogDelete,
-		InitClient: true,
-	})
+			Example:    deleteApplicationLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerFlowLogDelete,
+			CmdRun:     RunApplicationLoadBalancerFlowLogDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Application Load Balancer FlowLogs")
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer FlowLog deletion to be executed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer FlowLog deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Application Load Balancer FlowLogs",
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Application Load Balancer FlowLog deletion to be executed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Application Load Balancer FlowLog deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return applicationloadbalancerFlowLogCmd
 }
 
 func PreRunApplicationLoadBalancerFlowLogCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgS3Bucket)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgS3Bucket,
+	)
 }
 
 func PreRunApplicationLoadBalancerFlowLogDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgFlowLogId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunDcApplicationLoadBalancerFlowLogIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgFlowLogId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgFlowLogId,
+	)
 }
 
 func RunApplicationLoadBalancerFlowLogList(c *core.CommandConfig) error {
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
@@ -290,14 +484,19 @@ func RunApplicationLoadBalancerFlowLogList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Flowlog, applicationloadbalancerFlowLogs,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Flowlog, applicationloadbalancerFlowLogs,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -317,12 +516,22 @@ func RunApplicationLoadBalancerFlowLogGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting FlowLog with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting FlowLog with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().GetFlowLog(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -331,14 +540,19 @@ func RunApplicationLoadBalancerFlowLogGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -358,31 +572,47 @@ func RunApplicationLoadBalancerFlowLogCreate(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Datacenter ID: %v ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"ApplicationLoadBalancer ID: %v ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Datacenter ID: %v ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"ApplicationLoadBalancer ID: %v ",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
 	proper := getFlowLogPropertiesSet(c)
 	if !proper.HasName() {
 		proper.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	if !proper.HasDirection() {
 		proper.SetDirection(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Direction set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Direction set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection)),
+			),
+		)
 	}
 
 	if !proper.HasAction() {
 		proper.SetAction(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAction)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Action set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAction))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Action set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAction)),
+			),
+		)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating FlowLog"))
@@ -398,7 +628,10 @@ func RunApplicationLoadBalancerFlowLogCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -408,7 +641,9 @@ func RunApplicationLoadBalancerFlowLogCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog, tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog, tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -428,12 +663,22 @@ func RunApplicationLoadBalancerFlowLogUpdate(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"FlowLog ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"FlowLog ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId)),
+		),
+	)
 
 	input := getFlowLogPropertiesUpdate(c)
 
@@ -447,7 +692,10 @@ func RunApplicationLoadBalancerFlowLogUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -457,8 +705,10 @@ func RunApplicationLoadBalancerFlowLogUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -478,10 +728,17 @@ func RunApplicationLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+			),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.ApplicationLoadBalancerId,
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			),
+		)
 
 		err = DeleteAllApplicationLoadBalancerFlowLog(c)
 		if err != nil {
@@ -491,14 +748,27 @@ func RunApplicationLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(
-		"FlowLog ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(
+			"FlowLog ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete application load balancer flowlog", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete application load balancer flowlog",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -511,7 +781,10 @@ func RunApplicationLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -521,7 +794,10 @@ func RunApplicationLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancers Flowlog successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancers Flowlog successfully deleted"),
+	)
 
 	return nil
 }
@@ -534,7 +810,10 @@ func DeleteAllApplicationLoadBalancerFlowLog(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Getting Application Load Balancer FlowLogs..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Getting Application Load Balancer FlowLogs..."),
+	)
 
 	applicationLoadBalancerFlowlogs, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().ListFlowLogs(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -570,11 +849,17 @@ func DeleteAllApplicationLoadBalancerFlowLog(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Application Load Balancer FlowLogs", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Application Load Balancer FlowLogs",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Application Load Balancer FlowLogs..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Application Load Balancer FlowLogs..."),
+	)
 
 	var multiErr error
 	for _, fl := range *albFlowLogItems {
@@ -583,8 +868,11 @@ func DeleteAllApplicationLoadBalancerFlowLog(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Application Load Balancer FlowLog with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Application Load Balancer FlowLog with id: %v...", *id,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().DeleteFlowLog(
 			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -592,14 +880,20 @@ func DeleteAllApplicationLoadBalancerFlowLog(c *core.CommandConfig) error {
 			queryParams,
 		)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -611,7 +905,10 @@ func DeleteAllApplicationLoadBalancerFlowLog(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancers Flowlogs successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancers Flowlogs successfully deleted"),
+	)
 	return nil
 
 }

--- a/commands/cloudapi-v6/applicationloadbalancer_flowlog_test.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_flowlog_test.go
@@ -30,474 +30,583 @@ func TestApplicationLoadBalancerFlowLogCmd(t *testing.T) {
 func TestPreRunApplicationLoadBalancerFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		err := PreRunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			err := PreRunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerFlowLogDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerFlowLogDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerFlowLogDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			err := PreRunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcApplicationLoadBalancerFlowLogIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		err := PreRunDcApplicationLoadBalancerFlowLogIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			err := PreRunDcApplicationLoadBalancerFlowLogIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcApplicationLoadBalancerFlowLogIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcApplicationLoadBalancerFlowLogIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcApplicationLoadBalancerFlowLogIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, nil)
-		err := RunApplicationLoadBalancerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, nil)
+			err := RunApplicationLoadBalancerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, nil)
-		err := RunApplicationLoadBalancerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, nil)
+			err := RunApplicationLoadBalancerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogListResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		err := RunApplicationLoadBalancerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			err := RunApplicationLoadBalancerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, testApplicationLoadBalancerFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, testApplicationLoadBalancerFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, nil)
-		err := RunApplicationLoadBalancerFlowLogGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, nil)
+			err := RunApplicationLoadBalancerFlowLogGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testApplicationLoadBalancerFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testApplicationLoadBalancerFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, nil)
-		err := RunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, nil)
+			err := RunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogCreateResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testApplicationLoadBalancerFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testApplicationLoadBalancerFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, nil, nil)
-		err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, nil, nil)
+			err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, nil, testApplicationLoadBalancerFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, nil, testApplicationLoadBalancerFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, testFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, testFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testApplicationLoadBalancerFlowLogErr)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testApplicationLoadBalancerFlowLogErr)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerFlowLogDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunApplicationLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunApplicationLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/applicationloadbalancer_rule.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule.go
@@ -24,8 +24,13 @@ import (
 )
 
 var (
-	defaultAlbForwardingRuleCols = []string{"ForwardingRuleId", "Name", "Protocol", "ListenerIp", "ListenerPort", "ServerCertificates", "State"}
-	allAlbForwardingRuleCols     = []string{"ForwardingRuleId", "Name", "Protocol", "ListenerIp", "ListenerPort", "ClientTimeout", "ServerCertificates", "State"}
+	defaultAlbForwardingRuleCols = []string{
+		"ForwardingRuleId", "Name", "Protocol", "ListenerIp", "ListenerPort", "ServerCertificates", "State",
+	}
+	allAlbForwardingRuleCols = []string{
+		"ForwardingRuleId", "Name", "Protocol", "ListenerIp", "ListenerPort", "ClientTimeout", "ServerCertificates",
+		"State",
+	}
 )
 
 func ApplicationLoadBalancerRuleCmd() *core.Command {
@@ -43,85 +48,149 @@ func ApplicationLoadBalancerRuleCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, albRuleCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "rule",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Application Load Balancer Forwarding Rules",
-		LongDesc:   "Use this command to list Application Load Balancer Forwarding Rules from a specified Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
-		Example:    listApplicationLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
-		CmdRun:     RunApplicationLoadBalancerForwardingRuleList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, albRuleCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "rule",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Application Load Balancer Forwarding Rules",
+			LongDesc:   "Use this command to list Application Load Balancer Forwarding Rules from a specified Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id",
+			Example:    listApplicationLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerIds,
+			CmdRun:     RunApplicationLoadBalancerForwardingRuleList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, albRuleCmd, core.CommandBuilder{
-		Namespace:  "applicationloadbalancer",
-		Resource:   "rule",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Application Load Balancer Forwarding Rule",
-		LongDesc:   "Use this command to get information about a specified Application Load Balancer Forwarding Rule from a Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Forwarding Rule Id",
-		Example:    getApplicationLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
-		CmdRun:     RunApplicationLoadBalancerForwardingRuleGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, albRuleCmd, core.CommandBuilder{
+			Namespace:  "applicationloadbalancer",
+			Resource:   "rule",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Application Load Balancer Forwarding Rule",
+			LongDesc:   "Use this command to get information about a specified Application Load Balancer Forwarding Rule from a Application Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Forwarding Rule Id",
+			Example:    getApplicationLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
+			CmdRun:     RunApplicationLoadBalancerForwardingRuleGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddStringSliceFlag(constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols))
-	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddStringSliceFlag(
+		constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, albRuleCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "rule",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Application Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to create a Application Load Balancer Forwarding Rule in a specified Application Load Balancer. You can also set Health Check Settings for Forwarding Rule.
+	create := core.NewCommand(
+		ctx, albRuleCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "rule",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Application Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to create a Application Load Balancer Forwarding Rule in a specified Application Load Balancer. You can also set Health Check Settings for Forwarding Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` or ` + "`" + `-w` + "`" + ` option.
 
@@ -131,46 +200,91 @@ Required values to run command:
 * Application Load Balancer Id
 * Listener Ip
 * Listener Port`,
-		Example:    createApplicationLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerForwardingRuleCreate,
-		CmdRun:     RunApplicationLoadBalancerForwardingRuleCreate,
-		InitClient: true,
-	})
+			Example:    createApplicationLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerForwardingRuleCreate,
+			CmdRun:     RunApplicationLoadBalancerForwardingRuleCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Forwarding Rule", "The name of the Application Load Balancer forwarding rule.")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Forwarding Rule",
+		"The name of the Application Load Balancer forwarding rule.",
+	)
 	create.AddStringFlag(cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, "HTTP", "Balancing protocol.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddIpFlag(cloudapiv6.ArgListenerIp, "", nil, "Listening (inbound) IP. It must be assigned to the listener NIC of Application Load Balancer.", core.RequiredFlagOption())
-	create.AddIntFlag(cloudapiv6.ArgListenerPort, "", 8080, "Listening (inbound) port number; valid range is 1 to 65535.", core.RequiredFlagOption())
-	create.AddIntFlag(cloudapiv6.ArgClientTimeout, "", 50, "The maximum time in milliseconds to wait for the client to acknowledge or send data; default is 50,000 (50 seconds).")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddIpFlag(
+		cloudapiv6.ArgListenerIp, "", nil,
+		"Listening (inbound) IP. It must be assigned to the listener NIC of Application Load Balancer.",
+		core.RequiredFlagOption(),
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgListenerPort, "", 8080, "Listening (inbound) port number; valid range is 1 to 65535.",
+		core.RequiredFlagOption(),
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgClientTimeout, "", 50,
+		"The maximum time in milliseconds to wait for the client to acknowledge or send data; default is 50,000 (50 seconds).",
+	)
 	create.AddStringSliceFlag(cloudapiv6.ArgServerCertificates, "", []string{""}, "Server Certificates")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Forwarding Rule creation [seconds]")
-	create.AddStringSliceFlag(constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols))
-	_ = create.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule creation [seconds]",
+	)
+	create.AddStringSliceFlag(
+		constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, albRuleCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "rule",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Application Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to update a specified Application Load Balancer Forwarding Rule from a Application Load Balancer. You can also update Health Check settings.
+	update := core.NewCommand(
+		ctx, albRuleCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "rule",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Application Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to update a specified Application Load Balancer Forwarding Rule from a Application Load Balancer. You can also update Health Check settings.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -179,47 +293,90 @@ Required values to run command:
 * Data Center Id
 * Application Load Balancer Id
 * Forwarding Rule Id`,
-		Example:    updateApplicationLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
-		CmdRun:     RunApplicationLoadBalancerForwardingRuleUpdate,
-		InitClient: true,
-	})
+			Example:    updateApplicationLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
+			CmdRun:     RunApplicationLoadBalancerForwardingRuleUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the Application Load Balancer forwarding rule.")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the Application Load Balancer forwarding rule.",
+	)
 	update.AddIpFlag(cloudapiv6.ArgListenerIp, "", nil, "Listening (inbound) IP.")
-	update.AddIntFlag(cloudapiv6.ArgListenerPort, "", 8080, "Listening (inbound) port number; valid range is 1 to 65535.")
-	update.AddIntFlag(cloudapiv6.ArgClientTimeout, "", 50, "The maximum time in milliseconds to wait for the client to acknowledge or send data; default is 50,000 (50 seconds).")
+	update.AddIntFlag(
+		cloudapiv6.ArgListenerPort, "", 8080, "Listening (inbound) port number; valid range is 1 to 65535.",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgClientTimeout, "", 50,
+		"The maximum time in milliseconds to wait for the client to acknowledge or send data; default is 50,000 (50 seconds).",
+	)
 	update.AddStringSliceFlag(cloudapiv6.ArgServerCertificates, "", []string{""}, "Server Certificates")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, cloudapiv6.DefaultWait, "Wait for the Request for Forwarding Rule update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Forwarding Rule update [seconds]")
-	update.AddStringSliceFlag(constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols))
-	_ = update.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, cloudapiv6.DefaultWait,
+		"Wait for the Request for Forwarding Rule update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule update [seconds]",
+	)
+	update.AddStringSliceFlag(
+		constants.ArgCols, "", defaultAlbForwardingRuleCols, tabheaders.ColsMessage(defaultAlbForwardingRuleCols),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allAlbForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, albRuleCmd, core.CommandBuilder{
-		Namespace: "applicationloadbalancer",
-		Resource:  "rule",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Application Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to delete a specified Application Load Balancer Forwarding Rule from a Application Load Balancer.
+	deleteCmd := core.NewCommand(
+		ctx, albRuleCmd, core.CommandBuilder{
+			Namespace: "applicationloadbalancer",
+			Resource:  "rule",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Application Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to delete a specified Application Load Balancer Forwarding Rule from a Application Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -228,28 +385,59 @@ Required values to run command:
 * Data Center Id
 * Application Load Balancer Id
 * Forwarding Rule Id`,
-		Example:    deleteApplicationLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerForwardingRuleDelete,
-		CmdRun:     RunApplicationLoadBalancerForwardingRuleDelete,
-		InitClient: true,
-	})
+			Example:    deleteApplicationLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerForwardingRuleDelete,
+			CmdRun:     RunApplicationLoadBalancerForwardingRuleDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Forwarding Rules")
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule deletion to be executed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Forwarding Rule deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule deletion to be executed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	albRuleCmd.AddCommand(AlbRuleHttpRuleCmd())
 
@@ -257,27 +445,40 @@ Required values to run command:
 }
 
 func PreRunApplicationLoadBalancerForwardingRuleDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunApplicationLoadBalancerForwardingRuleCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgListenerIp, cloudapiv6.ArgListenerPort)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgListenerIp,
+		cloudapiv6.ArgListenerPort,
+	)
 }
 
 func PreRunDcApplicationLoadBalancerForwardingRuleIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId,
+	)
 }
 
 func RunApplicationLoadBalancerForwardingRuleList(c *core.CommandConfig) error {
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
@@ -293,15 +494,20 @@ func RunApplicationLoadBalancerForwardingRuleList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.ApplicationLoadBalancerForwardingRule,
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.ApplicationLoadBalancerForwardingRule,
 		albForwardingRules.ApplicationLoadBalancerForwardingRules,
-		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols))
+		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -321,12 +527,22 @@ func RunApplicationLoadBalancerForwardingRuleGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting ForwardingRule with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting ForwardingRule with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	applicationLoadBalancerForwardingRule, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().GetForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -335,15 +551,20 @@ func RunApplicationLoadBalancerForwardingRuleGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancerForwardingRule,
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancerForwardingRule,
 		applicationLoadBalancerForwardingRule.ApplicationLoadBalancerForwardingRule,
-		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols))
+		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -363,19 +584,34 @@ func RunApplicationLoadBalancerForwardingRuleCreate(c *core.CommandConfig) error
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
 
 	proper := getAlbForwardingRulePropertiesSet(c)
 	if !proper.HasProtocol() {
 		proper.SetProtocol(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)),
+			),
+		)
 	}
 	if !proper.HasName() {
 		proper.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating ForwardingRule"))
@@ -391,7 +627,10 @@ func RunApplicationLoadBalancerForwardingRuleCreate(c *core.CommandConfig) error
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -401,9 +640,11 @@ func RunApplicationLoadBalancerForwardingRuleCreate(c *core.CommandConfig) error
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancerForwardingRule,
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancerForwardingRule,
 		applicationLoadBalancerForwardingRule.ApplicationLoadBalancerForwardingRule,
-		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols))
+		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -423,12 +664,22 @@ func RunApplicationLoadBalancerForwardingRuleUpdate(c *core.CommandConfig) error
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	input := getAlbForwardingRulePropertiesSet(c)
 
@@ -442,7 +693,10 @@ func RunApplicationLoadBalancerForwardingRuleUpdate(c *core.CommandConfig) error
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -452,9 +706,11 @@ func RunApplicationLoadBalancerForwardingRuleUpdate(c *core.CommandConfig) error
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancerForwardingRule,
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancerForwardingRule,
 		applicationLoadBalancerForwardingRule.ApplicationLoadBalancerForwardingRule,
-		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols))
+		tabheaders.GetHeaders(allAlbForwardingRuleCols, defaultAlbForwardingRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -474,10 +730,17 @@ func RunApplicationLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error
 	queryParams := listQueryParams.QueryParams
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+			),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.ApplicationLoadBalancerId,
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			),
+		)
 
 		err = DeleteAllApplicationLoadBalancerForwardingRule(c)
 		if err != nil {
@@ -487,19 +750,35 @@ func RunApplicationLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error
 		return nil
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete application load balancer forwarding rule", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete application load balancer forwarding rule",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Deleting ForwardingRule with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Deleting ForwardingRule with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().DeleteForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -508,7 +787,10 @@ func RunApplicationLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -518,7 +800,10 @@ func RunApplicationLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancer Forwarding Rule successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancer Forwarding Rule successfully deleted"),
+	)
 
 	return nil
 }
@@ -531,7 +816,10 @@ func DeleteAllApplicationLoadBalancerForwardingRule(c *core.CommandConfig) error
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Getting Application Load Balancer Forwarding Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Getting Application Load Balancer Forwarding Rules..."),
+	)
 
 	applicationLoadBalancerRules, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().ListForwardingRules(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -567,12 +855,18 @@ func DeleteAllApplicationLoadBalancerForwardingRule(c *core.CommandConfig) error
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Forwarding Rules", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Forwarding Rules",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Deleting all the Application Load Balancer Forwarding Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Deleting all the Application Load Balancer Forwarding Rules...",
+		),
+	)
 
 	var multiErr error
 	for _, fr := range *albRuleItems {
@@ -581,8 +875,11 @@ func DeleteAllApplicationLoadBalancerForwardingRule(c *core.CommandConfig) error
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Application Load Balancer Forwarding Rule with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Application Load Balancer Forwarding Rule with id: %v...", *id,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().DeleteForwardingRule(
 			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -590,14 +887,20 @@ func DeleteAllApplicationLoadBalancerForwardingRule(c *core.CommandConfig) error
 			queryParams,
 		)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -610,7 +913,10 @@ func DeleteAllApplicationLoadBalancerForwardingRule(c *core.CommandConfig) error
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancer Forwarding Rules successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancer Forwarding Rules successfully deleted"),
+	)
 	return nil
 }
 
@@ -619,32 +925,58 @@ func getAlbForwardingRulePropertiesSet(c *core.CommandConfig) *resources.Applica
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 		input.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)) {
 		input.SetProtocol(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp)) {
 		input.SetListenerIp(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerIp set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ListenerIp set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort)) {
 		input.SetListenerPort(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerPort set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ListenerPort set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgServerCertificates)) {
 		input.SetServerCertificates(viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgServerCertificates)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ServerCertificates set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgServerCertificates))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ServerCertificates set: %v",
+				viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgServerCertificates)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgClientTimeout)) {
 		input.SetClientTimeout(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgClientTimeout)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Client Timeout set: %v", viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgClientTimeout))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Client Timeout set: %v",
+				viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgClientTimeout)),
+			),
+		)
 	}
 
 	return &resources.ApplicationLoadBalancerForwardingRuleProperties{

--- a/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_httprule.go
@@ -26,7 +26,10 @@ import (
 
 var (
 	defaultAlbRuleHttpRuleCols = []string{"Name", "Type", "TargetGroupId", "DropQuery", "Condition"}
-	allAlbRuleHttpRuleCols     = []string{"Name", "Type", "TargetGroupId", "DropQuery", "Location", "StatusCode", "ResponseMessage", "ContentType", "Condition"}
+	allAlbRuleHttpRuleCols     = []string{
+		"Name", "Type", "TargetGroupId", "DropQuery", "Location", "StatusCode", "ResponseMessage", "ContentType",
+		"Condition",
+	}
 )
 
 func AlbRuleHttpRuleCmd() *core.Command {
@@ -41,54 +44,86 @@ func AlbRuleHttpRuleCmd() *core.Command {
 		},
 	}
 	globalFlags := albRuleHttpRuleCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultAlbRuleHttpRuleCols, tabheaders.ColsMessage(allAlbRuleHttpRuleCols))
-	_ = viper.BindPFlag(core.GetFlagName(albRuleHttpRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = albRuleHttpRuleCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allAlbRuleHttpRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultAlbRuleHttpRuleCols, tabheaders.ColsMessage(allAlbRuleHttpRuleCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(albRuleHttpRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = albRuleHttpRuleCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allAlbRuleHttpRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, albRuleHttpRuleCmd, core.CommandBuilder{
-		Namespace:  "forwardingrule",
-		Resource:   "httprule",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Application Load Balancer Forwarding Rule Http Rules",
-		LongDesc:   "Use this command to list Http Rules of a Application Load Balancer Forwarding Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Forwarding Rule Id",
-		Example:    listApplicationLoadBalancerForwardingRuleHttpExample,
-		PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
-		CmdRun:     RunAlbRuleHttpRuleList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, albRuleHttpRuleCmd, core.CommandBuilder{
+			Namespace:  "forwardingrule",
+			Resource:   "httprule",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Application Load Balancer Forwarding Rule Http Rules",
+			LongDesc:   "Use this command to list Http Rules of a Application Load Balancer Forwarding Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Application Load Balancer Id\n* Forwarding Rule Id",
+			Example:    listApplicationLoadBalancerForwardingRuleHttpExample,
+			PreCmdRun:  PreRunDcApplicationLoadBalancerForwardingRuleIds,
+			CmdRun:     RunAlbRuleHttpRuleList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	add := core.NewCommand(ctx, albRuleHttpRuleCmd, core.CommandBuilder{
-		Namespace: "forwardingrule",
-		Resource:  "httprule",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add a Http Rule to Application Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to add a Http Rule in a specified Application Load Balancer Forwarding Rule.
+	add := core.NewCommand(
+		ctx, albRuleHttpRuleCmd, core.CommandBuilder{
+			Namespace: "forwardingrule",
+			Resource:  "httprule",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add a Http Rule to Application Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to add a Http Rule in a specified Application Load Balancer Forwarding Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -99,74 +134,157 @@ Required values to run command:
 * Forwarding Rule Id
 * Http Rule Name
 * Http Rule Type`,
-		Example:    addApplicationLoadBalancerForwardingRuleHttpExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerRuleHttpRule,
-		CmdRun:     RunAlbRuleHttpRuleAdd,
-		InitClient: true,
-	})
+			Example:    addApplicationLoadBalancerForwardingRuleHttpExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerRuleHttpRule,
+			CmdRun:     RunAlbRuleHttpRuleAdd,
+			InitClient: true,
+		},
+	)
 	add.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddUUIDFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId)), viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, cloudapiv6.ArgDataCenterId,
+					),
+				), viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	// see https://github.com/ionos-cloud/ionosctl/issues/263#issuecomment-1485258399
-	add.AddStringFlag(cloudapiv6.ArgConditionType, cloudapiv6.ArgConditionTypeShort, "HEADER", "selects which element in the incoming HTTP request is used for the rule. Possible values HEADER, PATH, QUERY, METHOD, HOST, COOKIE, SOURCE _IP")
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgConditionType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HEADER", "PATH", "QUERY", "METHOD", "HOST", "COOKIE", "SOURCE_IP"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddStringFlag(cloudapiv6.ArgConditionKey, cloudapiv6.ArgConditionKeyShort, "Accept", "selects which entry in the selected HTTP element is used for the rule. For example, \"Accept\" for condition-type=HEADER. Not applicable for HOST, PATH or SOURCE_IP")
-	add.AddStringFlag(cloudapiv6.ArgCondition, cloudapiv6.ArgConditionShort, "EQUALS", "comparison rule for condition-value and the element selected with condition-type and condition-key. Possible values: EXISTS, CONTAINS, EQUALS, MATCHES, STARTS_WITH, ENDS_WITH. mandatory for HEADER, PATH, QUERY, METHOD, HOST, and COOKIE types; must be null when type is SOURCE_IP.")
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCondition, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"EXISTS", "CONTAINS", "EQUALS", "MATCHES", "STARTS_WITH", "ENDS_WITH"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddStringFlag(cloudapiv6.ArgConditionValue, cloudapiv6.ArgConditionValueShort, "application/json", "value compared with the selected HTTP element. For example \"application/json\" in combination with condition=EQUALS, condition-type=HEADER, condition-key=Accept would be valid. Not applicable for condition EXISTS. Mandatory for conditions CONTAINS, EQUALS, MATCHES, STARTS_WITH, ENDS_WITH; must be null when condition is EXISTS")
+	add.AddStringFlag(
+		cloudapiv6.ArgConditionType, cloudapiv6.ArgConditionTypeShort, "HEADER",
+		"selects which element in the incoming HTTP request is used for the rule. Possible values HEADER, PATH, QUERY, METHOD, HOST, COOKIE, SOURCE _IP",
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgConditionType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"HEADER", "PATH", "QUERY", "METHOD", "HOST", "COOKIE", "SOURCE_IP",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddStringFlag(
+		cloudapiv6.ArgConditionKey, cloudapiv6.ArgConditionKeyShort, "Accept",
+		"selects which entry in the selected HTTP element is used for the rule. For example, \"Accept\" for condition-type=HEADER. Not applicable for HOST, PATH or SOURCE_IP",
+	)
+	add.AddStringFlag(
+		cloudapiv6.ArgCondition, cloudapiv6.ArgConditionShort, "EQUALS",
+		"comparison rule for condition-value and the element selected with condition-type and condition-key. Possible values: EXISTS, CONTAINS, EQUALS, MATCHES, STARTS_WITH, ENDS_WITH. mandatory for HEADER, PATH, QUERY, METHOD, HOST, and COOKIE types; must be null when type is SOURCE_IP.",
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgCondition,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"EXISTS", "CONTAINS", "EQUALS", "MATCHES", "STARTS_WITH", "ENDS_WITH",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddStringFlag(
+		cloudapiv6.ArgConditionValue, cloudapiv6.ArgConditionValueShort, "application/json",
+		"value compared with the selected HTTP element. For example \"application/json\" in combination with condition=EQUALS, condition-type=HEADER, condition-key=Accept would be valid. Not applicable for condition EXISTS. Mandatory for conditions CONTAINS, EQUALS, MATCHES, STARTS_WITH, ENDS_WITH; must be null when condition is EXISTS",
+	)
 	add.AddBoolFlag(cloudapiv6.ArgNegate, "", false, "Specifies whether the condition is negated or not")
 
-	add.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The unique name of the Application Load Balancer HTTP rule.", core.RequiredFlagOption())
+	add.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The unique name of the Application Load Balancer HTTP rule.",
+		core.RequiredFlagOption(),
+	)
 	add.AddStringFlag(constants.FlagType, "", "", "Type of the HTTP rule.", core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(constants.FlagType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"FORWARD", "STATIC", "REDIRECT"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, "", "", "he ID of the target group; mandatory and only valid for FORWARD actions.")
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddBoolFlag(cloudapiv6.ArgQuery, cloudapiv6.ArgQueryShort, false, "Default is false; valid only for REDIRECT actions.")
-	add.AddStringFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "www.ionos.com", "The location for redirecting; mandatory and valid only for REDIRECT actions.")
-	add.AddIntFlag(cloudapiv6.ArgStatusCode, "", 301, "Valid only for REDIRECT and STATIC actions. For REDIRECT actions, default is 301 and possible values are 301, 302, 303, 307, and 308. For STATIC actions, default is 503 and valid range is 200 to 599.")
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgStatusCode, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"301", "302", "303", "307", "308", "200", "503", "599"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddStringFlag(cloudapiv6.ArgMessage, cloudapiv6.ArgMessageShort, "Application Down", "The response message of the request; mandatory for STATIC actions.")
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.FlagType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"FORWARD", "STATIC", "REDIRECT"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, "", "", "he ID of the target group; mandatory and only valid for FORWARD actions.",
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgQuery, cloudapiv6.ArgQueryShort, false, "Default is false; valid only for REDIRECT actions.",
+	)
+	add.AddStringFlag(
+		cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "www.ionos.com",
+		"The location for redirecting; mandatory and valid only for REDIRECT actions.",
+	)
+	add.AddIntFlag(
+		cloudapiv6.ArgStatusCode, "", 301,
+		"Valid only for REDIRECT and STATIC actions. For REDIRECT actions, default is 301 and possible values are 301, 302, 303, 307, and 308. For STATIC actions, default is 503 and valid range is 200 to 599.",
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgStatusCode,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"301", "302", "303", "307", "308", "200", "503", "599"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddStringFlag(
+		cloudapiv6.ArgMessage, cloudapiv6.ArgMessageShort, "Application Down",
+		"The response message of the request; mandatory for STATIC actions.",
+	)
 	add.AddStringFlag(cloudapiv6.ArgContentType, "", "application/json", "Valid only for STATIC actions.")
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgContentType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"application/json", "text/html"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgContentType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"application/json", "text/html"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
-	add.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule Http Rule creation to be executed")
-	add.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Forwarding Rule Http Rule creation [seconds]")
-	add.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	add.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule Http Rule creation to be executed",
+	)
+	add.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule Http Rule creation [seconds]",
+	)
+	add.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	add.Command.Flags().SortFlags = false
 
 	/*
 		Remove Command
 	*/
-	removeCmd := core.NewCommand(ctx, albRuleHttpRuleCmd, core.CommandBuilder{
-		Namespace: "forwardingrule",
-		Resource:  "httprule",
-		Verb:      "remove",
-		Aliases:   []string{"r"},
-		ShortDesc: "Remove a Http Rule from a Application Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to remove a specified Http Rule from Application Load Balancer Forwarding Rule.
+	removeCmd := core.NewCommand(
+		ctx, albRuleHttpRuleCmd, core.CommandBuilder{
+			Namespace: "forwardingrule",
+			Resource:  "httprule",
+			Verb:      "remove",
+			Aliases:   []string{"r"},
+			ShortDesc: "Remove a Http Rule from a Application Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to remove a specified Http Rule from Application Load Balancer Forwarding Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -176,42 +294,82 @@ Required values to run command:
 * Application Load Balancer Id
 * Forwarding Rule Id
 * Http Rule Name`,
-		Example:    removeApplicationLoadBalancerForwardingRuleHttpExample,
-		PreCmdRun:  PreRunApplicationLoadBalancerRuleHttpRuleDelete,
-		CmdRun:     RunAlbRuleHttpRuleRemove,
-		InitClient: true,
-	})
+			Example:    removeApplicationLoadBalancerForwardingRuleHttpExample,
+			PreCmdRun:  PreRunApplicationLoadBalancerRuleHttpRuleDelete,
+			CmdRun:     RunAlbRuleHttpRuleRemove,
+			InitClient: true,
+		},
+	)
+	removeCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeCmd.AddUUIDFlag(cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgApplicationLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ApplicationLoadBalancersIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeCmd.AddUUIDFlag(
+		cloudapiv6.ArgApplicationLoadBalancerId, "", "", cloudapiv6.ApplicationLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgApplicationLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ApplicationLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AlbForwardingRulesIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeCmd.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "A name of that Application Load Balancer Http Rule", core.RequiredFlagOption())
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AlbForwardingRulesIds(
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeCmd.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "A name of that Application Load Balancer Http Rule",
+		core.RequiredFlagOption(),
+	)
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all HTTP Rules")
-	removeCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule Http Rule deletion to be executed")
-	removeCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Forwarding Rule Http Rule deletion [seconds]")
-	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	removeCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule Http Rule deletion to be executed",
+	)
+	removeCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule Http Rule deletion [seconds]",
+	)
+	removeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return albRuleHttpRuleCmd
 }
 
 func PreRunApplicationLoadBalancerRuleHttpRule(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId,
-		cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgName, constants.FlagType)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId,
+		cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgName, constants.FlagType,
+	)
 }
 
 func PreRunApplicationLoadBalancerRuleHttpRuleDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgName},
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgAll},
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId,
+			cloudapiv6.ArgName,
+		},
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgApplicationLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgAll,
+		},
 	)
 }
 
@@ -225,12 +383,22 @@ func RunAlbRuleHttpRuleList(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting HttpRules"))
 
 	ng, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().GetForwardingRule(
@@ -240,7 +408,10 @@ func RunAlbRuleHttpRuleList(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -256,8 +427,10 @@ func RunAlbRuleHttpRuleList(c *core.CommandConfig) error {
 		return errors.New("error getting rule http rules")
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancerHTTPRule, *httpRules,
-		tabheaders.GetHeaders(allAlbRuleHttpRuleCols, defaultAlbRuleHttpRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancerHTTPRule, *httpRules,
+		tabheaders.GetHeaders(allAlbRuleHttpRuleCols, defaultAlbRuleHttpRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -276,14 +449,28 @@ func RunAlbRuleHttpRuleAdd(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 	var httpRuleItems []ionoscloud.ApplicationLoadBalancerHttpRule
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting HttpRules from ForwardingRule with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting HttpRules from ForwardingRule with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	ngOld, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().GetForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -302,10 +489,16 @@ func RunAlbRuleHttpRuleAdd(c *core.CommandConfig) error {
 	}
 
 	httpRuleNew := getRuleHttpRuleInfo(c)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding the new HttpRule to the existing HttpRules"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Adding the new HttpRule to the existing HttpRules"),
+	)
 
 	httpRuleItems = append(httpRuleItems, httpRuleNew.ApplicationLoadBalancerHttpRule)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating ForwardingRule with the new HttpRules"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Updating ForwardingRule with the new HttpRules"),
+	)
 
 	_, resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().UpdateForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -319,7 +512,10 @@ func RunAlbRuleHttpRuleAdd(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -331,8 +527,10 @@ func RunAlbRuleHttpRuleAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.ApplicationLoadBalancerHTTPRule, httpRuleNew.ApplicationLoadBalancerHttpRule,
-		tabheaders.GetHeaders(allAlbRuleHttpRuleCols, defaultAlbRuleHttpRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.ApplicationLoadBalancerHTTPRule, httpRuleNew.ApplicationLoadBalancerHttpRule,
+		tabheaders.GetHeaders(allAlbRuleHttpRuleCols, defaultAlbRuleHttpRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -351,32 +549,58 @@ func RunAlbRuleHttpRuleRemove(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+			),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.ApplicationLoadBalancerId,
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+			),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+			),
+		)
 
 		resp, err := RemoveAllHTTPRules(c)
 		if err != nil {
 			return err
 		}
 		if resp != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 
 		return nil
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ApplicationLoadBalancerId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ApplicationLoadBalancerId,
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgApplicationLoadBalancerId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ForwardingRuleId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove forwarding rule http rule", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove forwarding rule http rule",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -392,14 +616,20 @@ func RunAlbRuleHttpRuleRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing the HTTP Rule from the existing HTTP Rules"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Removing the HTTP Rule from the existing HTTP Rules"),
+	)
 
 	proper, err := getRuleHttpRulesRemove(c, frOld)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating ForwardingRule with the new HTTP Rules"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Updating ForwardingRule with the new HTTP Rules"),
+	)
 
 	_, resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().UpdateForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -409,7 +639,10 @@ func RunAlbRuleHttpRuleRemove(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -419,7 +652,10 @@ func RunAlbRuleHttpRuleRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Application Load Balancer HTTP Rule successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancer HTTP Rule successfully deleted"),
+	)
 
 	return nil
 
@@ -433,7 +669,9 @@ func RemoveAllHTTPRules(c *core.CommandConfig) (*resources.Response, error) {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rules to be deleted:"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rules to be deleted:"),
+	)
 
 	applicationLoadBalancerRules, resp, err := c.CloudApiV6Services.ApplicationLoadBalancers().GetForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -461,19 +699,31 @@ func RemoveAllHTTPRules(c *core.CommandConfig) (*resources.Response, error) {
 
 	for _, httpRuleOk := range *httpRulesOk {
 		if nameOk, ok := httpRuleOk.GetNameOk(); ok && nameOk != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rule Name: %v", *nameOk))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rule Name: %v", *nameOk),
+			)
 		}
 
 		if typeOk, ok := httpRuleOk.GetTypeOk(); ok && typeOk != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rule Type: %v", *typeOk))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateLogOutput("Forwarding Rule HTTP Rule Type: %v", *typeOk),
+			)
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Forwarding Rule HTTP Rules", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Forwarding Rule HTTP Rules",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return nil, fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Forwarding Rule HTTP Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Forwarding Rule HTTP Rules..."),
+	)
 
 	propertiesOk.SetHttpRules([]ionoscloud.ApplicationLoadBalancerHttpRule{})
 	_, resp, err = c.CloudApiV6Services.ApplicationLoadBalancers().UpdateForwardingRule(
@@ -486,8 +736,13 @@ func RemoveAllHTTPRules(c *core.CommandConfig) (*resources.Response, error) {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return nil, err
@@ -497,7 +752,10 @@ func RemoveAllHTTPRules(c *core.CommandConfig) (*resources.Response, error) {
 		return nil, err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Application Load Balancer HTTP Rules successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Application Load Balancer HTTP Rules successfully deleted"),
+	)
 	return resp, err
 }
 
@@ -506,57 +764,89 @@ func getRuleHttpRuleInfo(c *core.CommandConfig) resources.ApplicationLoadBalance
 	httprule := resources.ApplicationLoadBalancerHttpRule{}
 
 	httprule.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+		),
+	)
 
 	httprule.SetType(viper.GetString(core.GetFlagName(c.NS, constants.FlagType)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Type set: %v", viper.GetString(core.GetFlagName(c.NS, constants.FlagType))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Type set: %v", viper.GetString(core.GetFlagName(c.NS, constants.FlagType)),
+		),
+	)
 
 	if strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, constants.FlagType)), "FORWARD") {
 		httprule.SetTargetGroup(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property TargetGroup set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property TargetGroup set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+			),
+		)
 	}
 
 	if strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, constants.FlagType)), "REDIRECT") {
 		httprule.SetLocation(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLocation)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Location set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLocation))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Location set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLocation)),
+			),
+		)
 
 		httprule.SetDropQuery(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgQuery)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property DropQuery set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgQuery))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property DropQuery set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgQuery)),
+			),
+		)
 
 		httprule.SetStatusCode(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property StatusCode set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property StatusCode set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode)),
+			),
+		)
 	}
 
 	if strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, constants.FlagType)), "STATIC") {
 		httprule.SetResponseMessage(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMessage)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property ResponseMessage set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMessage))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ResponseMessage set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMessage)),
+			),
+		)
 
 		httprule.SetContentType(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgContentType)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property ContentType set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgContentType))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property ContentType set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgContentType)),
+			),
+		)
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode)) {
 			httprule.SetStatusCode(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property StatusCode set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property StatusCode set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgStatusCode)),
+				),
+			)
 		} else {
 			httprule.SetStatusCode(503)
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property StatusCode set with the default value: %v", 503))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property StatusCode set with the default value: %v", 503,
+				),
+			)
 		}
 	}
 
 	httpRuleCondition := getRuleHttpRuleConditionInfo(c)
-	httprule.SetConditions([]ionoscloud.ApplicationLoadBalancerHttpRuleCondition{
-		httpRuleCondition.ApplicationLoadBalancerHttpRuleCondition,
-	})
+	httprule.SetConditions(
+		[]ionoscloud.ApplicationLoadBalancerHttpRuleCondition{
+			httpRuleCondition.ApplicationLoadBalancerHttpRuleCondition,
+		},
+	)
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Setting Condition to HttpRule"))
 
@@ -568,38 +858,56 @@ func getRuleHttpRuleConditionInfo(c *core.CommandConfig) resources.ApplicationLo
 	httpRuleCondition := resources.ApplicationLoadBalancerHttpRuleCondition{}
 	httpRuleCondition.SetType(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Condition Type set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Condition Type set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)),
+		),
+	)
 
 	if !strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)), "SOURCE_IP") {
 		httpRuleCondition.SetCondition(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCondition)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Condition set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCondition))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Condition set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCondition)),
+			),
+		)
 	}
 
 	httpRuleCondition.SetNegate(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Condition Negate set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Condition Negate set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)),
+		),
+	)
 
 	if strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)), "COOKIES") ||
 		strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)), "HEADER") ||
 		strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionType)), "QUERY") {
 		httpRuleCondition.SetKey(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionKey)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Condition Key set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionKey))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Condition Key set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionKey)),
+			),
+		)
 	}
 
 	if !strings.EqualFold(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCondition)), "EXISTS") {
 		httpRuleCondition.SetValue(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionValue)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Condition Value set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionValue))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Condition Value set: %v",
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgConditionValue)),
+			),
+		)
 	}
 
 	return httpRuleCondition
 }
 
-func getRuleHttpRulesRemove(c *core.CommandConfig, frOld *resources.ApplicationLoadBalancerForwardingRule) (*resources.ApplicationLoadBalancerForwardingRuleProperties, error) {
+func getRuleHttpRulesRemove(
+	c *core.CommandConfig, frOld *resources.ApplicationLoadBalancerForwardingRule,
+) (*resources.ApplicationLoadBalancerForwardingRuleProperties, error) {
 	httpRuleItems := make([]ionoscloud.ApplicationLoadBalancerHttpRule, 0)
 
 	properties, ok := frOld.GetPropertiesOk()
@@ -607,14 +915,20 @@ func getRuleHttpRulesRemove(c *core.CommandConfig, frOld *resources.ApplicationL
 		return nil, fmt.Errorf("could not get Application Load Balancer Forwarding Rule properties")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Properties from the Forwarding Rule"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting Properties from the Forwarding Rule"),
+	)
 
 	httpRules, ok := properties.GetHttpRulesOk()
 	if !ok || httpRules == nil {
 		return nil, fmt.Errorf("coudl not get Application Load Balancer HTTP Rules")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting HTTP Rules from the Forwarding Rule Properties"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting HTTP Rules from the Forwarding Rule Properties"),
+	)
 
 	for _, httpRuleItem := range *httpRules {
 		removeName := false
@@ -622,7 +936,10 @@ func getRuleHttpRulesRemove(c *core.CommandConfig, frOld *resources.ApplicationL
 		if nameOk, ok := httpRuleItem.GetNameOk(); ok && nameOk != nil {
 			if *nameOk == viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 				removeName = true
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Found HTTP Rule with Name: %v", *nameOk))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Found HTTP Rule with Name: %v", *nameOk),
+				)
 			}
 		}
 

--- a/commands/cloudapi-v6/applicationloadbalancer_rule_httprule_test.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_httprule_test.go
@@ -124,506 +124,645 @@ func TestAlbRuleHttpRuleCmd(t *testing.T) {
 func TestPreRunApplicationLoadBalancerRuleHttpRule(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleIntVar)
-		err := PreRunApplicationLoadBalancerRuleHttpRule(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleIntVar)
+			err := PreRunApplicationLoadBalancerRuleHttpRule(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerRuleHttpRuleErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunApplicationLoadBalancerRuleHttpRule(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunApplicationLoadBalancerRuleHttpRule(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerRuleHttpRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerRuleHttpRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerRuleHttpRuleDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			err := PreRunApplicationLoadBalancerRuleHttpRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		err := RunAlbRuleHttpRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			err := RunAlbRuleHttpRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleListResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
-		err := RunAlbRuleHttpRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
+			err := RunAlbRuleHttpRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleListGetHttpRulesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		err := RunAlbRuleHttpRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			err := RunAlbRuleHttpRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleListGetPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.ApplicationLoadBalancerForwardingRule{}, nil, nil)
-		err := RunAlbRuleHttpRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.ApplicationLoadBalancerForwardingRule{}, nil, nil)
+			err := RunAlbRuleHttpRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddForward(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleForwardProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleForwardProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddStatic(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleStaticTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgStatusCode), testAlbRuleHttpRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMessage), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgContentType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleStaticProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleStaticGetUpdated, nil, nil)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleStaticTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgStatusCode), testAlbRuleHttpRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMessage), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgContentType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleStaticProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleStaticGetUpdated, nil, nil)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddRedirect(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleRedirectTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgQuery), testAlbRuleHttpRuleBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgStatusCode), testAlbRuleHttpRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgContentType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleRedirectProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleRedirectGetUpdated, nil, nil)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleRedirectTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgQuery), testAlbRuleHttpRuleBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgStatusCode), testAlbRuleHttpRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgContentType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleRedirectProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleRedirectGetUpdated, nil, nil)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleForwardProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleForwardProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleForwardProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleForwardProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleAddWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, &testAlbRuleHttpRuleForwardProperties, testQueryParamOther).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunAlbRuleHttpRuleAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testAlbRuleHttpRuleForwardTypeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCondition), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionType), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConditionValue), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testAlbRuleHttpRuleBoolVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&testAlbRuleHttpRuleForwardProperties, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunAlbRuleHttpRuleAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
-			&resources.ApplicationLoadBalancerForwardingRuleProperties{
-				ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
-					HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
-				},
-			}, testQueryParamOther).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&resources.ApplicationLoadBalancerForwardingRuleProperties{
+					ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
+						HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
+					},
+				}, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
-			&resources.ApplicationLoadBalancerForwardingRuleProperties{
-				ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
-					HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
-				},
-			}, testQueryParamOther).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&resources.ApplicationLoadBalancerForwardingRuleProperties{
+					ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
+						HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
+					},
+				}, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
-			&resources.ApplicationLoadBalancerForwardingRuleProperties{
-				ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
-					HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
-				},
-			}, testQueryParamOther).Return(&testAlbRuleHttpRuleGet, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&resources.ApplicationLoadBalancerForwardingRuleProperties{
+					ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
+						HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
+					},
+				}, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleGet, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, testAlbRuleHttpRuleErr)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
-			&resources.ApplicationLoadBalancerForwardingRuleProperties{
-				ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
-					HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
-				},
-			}, testQueryParamOther).Return(&testAlbRuleHttpRuleGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&resources.ApplicationLoadBalancerForwardingRuleProperties{
+					ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
+						HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
+					},
+				}, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
-			&resources.ApplicationLoadBalancerForwardingRuleProperties{
-				ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
-					HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
-				},
-			}, testQueryParamOther).Return(&testAlbRuleHttpRuleGet, nil, nil)
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbRuleHttpRuleForwardGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar, testAlbRuleHttpRuleVar,
+				&resources.ApplicationLoadBalancerForwardingRuleProperties{
+					ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
+						HttpRules: &[]ionoscloud.ApplicationLoadBalancerHttpRule{},
+					},
+				}, testQueryParamOther,
+			).Return(&testAlbRuleHttpRuleGet, nil, nil)
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunAlbRuleHttpRuleRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunAlbRuleHttpRuleRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbRuleHttpRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbRuleHttpRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunAlbRuleHttpRuleRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/applicationloadbalancer_rule_test.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_rule_test.go
@@ -28,7 +28,8 @@ var (
 				ListenerPort:       &testAlbForwardingRuleIntVar,
 				ClientTimeout:      &testAlbForwardingRuleIntVar,
 				ServerCertificates: &testAlbForwardingRuleServerCerts,
-			}},
+			},
+		},
 	}
 	testAlbForwardingRulePropertiesNew = resources.ApplicationLoadBalancerForwardingRuleProperties{
 		ApplicationLoadBalancerForwardingRuleProperties: ionoscloud.ApplicationLoadBalancerForwardingRuleProperties{
@@ -81,490 +82,614 @@ func TestApplicationLoadBalancerRuleCmd(t *testing.T) {
 func TestPreRunApplicationLoadBalancerForwardingRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
-		err := PreRunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
+			err := PreRunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerForwardingRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerForwardingRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerForwardingRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerForwardingRuleDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			err := PreRunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcApplicationLoadBalancerForwardingRuleIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		err := PreRunDcApplicationLoadBalancerForwardingRuleIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			err := PreRunDcApplicationLoadBalancerForwardingRuleIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcApplicationLoadBalancerForwardingRuleIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcApplicationLoadBalancerForwardingRuleIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcApplicationLoadBalancerForwardingRuleIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, &testResponse, nil)
-		err := RunApplicationLoadBalancerForwardingRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, &testResponse, nil)
+			err := RunApplicationLoadBalancerForwardingRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, nil, nil)
-		err := RunApplicationLoadBalancerForwardingRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, nil, nil)
+			err := RunApplicationLoadBalancerForwardingRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleListResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, &testResponse, nil)
-		err := RunApplicationLoadBalancerForwardingRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, &testResponse, nil)
+			err := RunApplicationLoadBalancerForwardingRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, nil, testApplicationLoadBalancerForwardingRuleErr)
-		err := RunApplicationLoadBalancerForwardingRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, nil, testApplicationLoadBalancerForwardingRuleErr)
+			err := RunApplicationLoadBalancerForwardingRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, nil, nil)
-		err := RunApplicationLoadBalancerForwardingRuleGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, nil, nil)
+			err := RunApplicationLoadBalancerForwardingRuleGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, nil, testApplicationLoadBalancerForwardingRuleErr)
-		err := RunApplicationLoadBalancerForwardingRuleGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().GetForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, nil, testApplicationLoadBalancerForwardingRuleErr)
+			err := RunApplicationLoadBalancerForwardingRuleGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, nil, nil)
-		err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, nil, nil)
+			err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleCreateResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, &testResponse, nil)
-		err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, &testResponse, nil)
+			err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, nil, testApplicationLoadBalancerForwardingRuleErr)
-		err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, nil, testApplicationLoadBalancerForwardingRuleErr)
+			err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testAlbForwardingRuleGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testAlbForwardingRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().CreateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testInputAlbForwardingRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testAlbForwardingRuleGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, &testAlbForwardingRulePropertiesNew, testQueryParamOther).Return(&testAlbForwardingRuleUpdated, nil, nil)
-		err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				&testAlbForwardingRulePropertiesNew, testQueryParamOther,
+			).Return(&testAlbForwardingRuleUpdated, nil, nil)
+			err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, &testAlbForwardingRulePropertiesNew, testQueryParamOther).Return(&testAlbForwardingRuleUpdated, nil, testApplicationLoadBalancerForwardingRuleErr)
-		err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				&testAlbForwardingRulePropertiesNew, testQueryParamOther,
+			).Return(&testAlbForwardingRuleUpdated, nil, testApplicationLoadBalancerForwardingRuleErr)
+			err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, &testAlbForwardingRulePropertiesNew, testQueryParamOther).Return(&testAlbForwardingRuleUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testAlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testAlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerCertificates), testAlbForwardingRuleServerNewCerts)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().UpdateForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				&testAlbForwardingRulePropertiesNew, testQueryParamOther,
+			).Return(&testAlbForwardingRuleUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerForwardingRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testApplicationLoadBalancerForwardingRuleErr)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testApplicationLoadBalancerForwardingRuleErr)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testAlbForwardingRules, nil, testApplicationLoadBalancerForwardingRuleErr)
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().ListForwardingRules(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testAlbForwardingRules, nil, testApplicationLoadBalancerForwardingRuleErr)
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testApplicationLoadBalancerForwardingRuleErr)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testApplicationLoadBalancerForwardingRuleErr)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().DeleteForwardingRule(
+				testAlbForwardingRuleVar, testAlbForwardingRuleVar, testAlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerForwardingRuleDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testAlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testAlbForwardingRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunApplicationLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/applicationloadbalancer_test.go
+++ b/commands/cloudapi-v6/applicationloadbalancer_test.go
@@ -76,485 +76,627 @@ func TestApplicationLoadBalancerCmd(t *testing.T) {
 func TestPreRunDcApplicationLoadBalancerIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		err := PreRunDcApplicationLoadBalancerIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			err := PreRunDcApplicationLoadBalancerIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcApplicationLoadBalancerIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcApplicationLoadBalancerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcApplicationLoadBalancerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunApplicationLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunApplicationLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunApplicationLoadBalancerDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		err := PreRunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			err := PreRunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(cloudapiv6.ParentResourceListQueryParams).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunApplicationLoadBalancerListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(cloudapiv6.ParentResourceListQueryParams).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunApplicationLoadBalancerListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil)
-		err := RunApplicationLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil)
+			err := RunApplicationLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil)
-		err := RunApplicationLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil)
+			err := RunApplicationLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, nil, nil)
-		err := RunApplicationLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, nil, nil)
+			err := RunApplicationLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerGetResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, &testResponse, nil)
-		err := RunApplicationLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, &testResponse, nil)
+			err := RunApplicationLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, nil, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, nil, nil)
-		err := RunApplicationLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, nil, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, nil, nil)
+			err := RunApplicationLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTestGet, nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Get(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTestGet, nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(testApplicationLoadBalancerVar, applicationloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTest, nil, nil)
-		err := RunApplicationLoadBalancerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(
+				testApplicationLoadBalancerVar, applicationloadbalancerTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTest, nil, nil)
+			err := RunApplicationLoadBalancerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerCreateResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(testApplicationLoadBalancerVar, applicationloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTest, &testResponse, nil)
-		err := RunApplicationLoadBalancerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(
+				testApplicationLoadBalancerVar, applicationloadbalancerTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTest, &testResponse, nil)
+			err := RunApplicationLoadBalancerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(testApplicationLoadBalancerVar, applicationloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTest, nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(
+				testApplicationLoadBalancerVar, applicationloadbalancerTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTest, nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(testApplicationLoadBalancerVar, applicationloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Create(
+				testApplicationLoadBalancerVar, applicationloadbalancerTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerNew, nil, nil)
-		err := RunApplicationLoadBalancerUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerNew, nil, nil)
+			err := RunApplicationLoadBalancerUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerNew, nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerNew, nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&applicationloadbalancerNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testApplicationLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testApplicationLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testApplicationLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Update(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, applicationloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&applicationloadbalancerNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAllResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAllAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(applicationloadbalancers, &testResponse, nil)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().List(
+				testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(applicationloadbalancers, &testResponse, nil)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testApplicationLoadBalancerErr)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testApplicationLoadBalancerErr)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(testApplicationLoadBalancerVar, testApplicationLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.ApplicationLoadBalancer.EXPECT().Delete(
+				testApplicationLoadBalancerVar, testApplicationLoadBalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunApplicationLoadBalancerDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunApplicationLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testApplicationLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApplicationLoadBalancerId), testApplicationLoadBalancerVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunApplicationLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -42,88 +42,126 @@ func BackupunitCmd() *core.Command {
 		},
 	}
 	globalFlags := backupUnitCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultBackupUnitCols, tabheaders.ColsMessage(defaultBackupUnitCols))
-	_ = viper.BindPFlag(core.GetFlagName(backupUnitCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = backupUnitCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultBackupUnitCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultBackupUnitCols, tabheaders.ColsMessage(defaultBackupUnitCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(backupUnitCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = backupUnitCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultBackupUnitCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace:  "backupunit",
-		Resource:   "backupunit",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List BackupUnits",
-		LongDesc:   "Use this command to get a list of existing BackupUnits available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.BackupUnitsFiltersUsage(),
-		Example:    listBackupUnitsExample,
-		PreCmdRun:  PreRunBackupUnitList,
-		CmdRun:     RunBackupUnitList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace:  "backupunit",
+			Resource:   "backupunit",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List BackupUnits",
+			LongDesc:   "Use this command to get a list of existing BackupUnits available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.BackupUnitsFiltersUsage(),
+			Example:    listBackupUnitsExample,
+			PreCmdRun:  PreRunBackupUnitList,
+			CmdRun:     RunBackupUnitList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace:  "backupunit",
-		Resource:   "backupunit",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a BackupUnit",
-		LongDesc:   "Use this command to retrieve details about a specific BackupUnit.\n\nRequired values to run command:\n\n* BackupUnit Id",
-		Example:    getBackupUnitExample,
-		PreCmdRun:  PreRunBackupUnitId,
-		CmdRun:     RunBackupUnitGet,
-		InitClient: true,
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	get := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace:  "backupunit",
+			Resource:   "backupunit",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a BackupUnit",
+			LongDesc:   "Use this command to retrieve details about a specific BackupUnit.\n\nRequired values to run command:\n\n* BackupUnit Id",
+			Example:    getBackupUnitExample,
+			PreCmdRun:  PreRunBackupUnitId,
+			CmdRun:     RunBackupUnitGet,
+			InitClient: true,
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBackupUnitId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Get SSO URL Command
 	*/
-	getsso := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace:  "backupunit",
-		Resource:   "backupunit",
-		Verb:       "get-sso-url",
-		ShortDesc:  "Get BackupUnit SSO URL",
-		LongDesc:   "Use this command to access the GUI with a Single Sign On URL that can be retrieved from the Cloud API using this request. If you copy the entire value returned and paste it into a browser, you will be logged into the BackupUnit GUI.\n\nRequired values to run command:\n\n* BackupUnit Id",
-		Example:    getBackupUnitSSOExample,
-		PreCmdRun:  PreRunBackupUnitId,
-		CmdRun:     RunBackupUnitGetSsoUrl,
-		InitClient: true,
-	})
-	getsso.AddUUIDFlag(cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption())
-	_ = getsso.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	getsso := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace:  "backupunit",
+			Resource:   "backupunit",
+			Verb:       "get-sso-url",
+			ShortDesc:  "Get BackupUnit SSO URL",
+			LongDesc:   "Use this command to access the GUI with a Single Sign On URL that can be retrieved from the Cloud API using this request. If you copy the entire value returned and paste it into a browser, you will be logged into the BackupUnit GUI.\n\nRequired values to run command:\n\n* BackupUnit Id",
+			Example:    getBackupUnitSSOExample,
+			PreCmdRun:  PreRunBackupUnitId,
+			CmdRun:     RunBackupUnitGetSsoUrl,
+			InitClient: true,
+		},
+	)
+	getsso.AddUUIDFlag(
+		cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption(),
+	)
+	_ = getsso.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBackupUnitId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace: "backupunit",
-		Resource:  "backupunit",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a BackupUnit",
-		LongDesc: `Use this command to create a BackupUnit under a particular contract. You need to specify the name, email and password for the new BackupUnit.
+	create := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace: "backupunit",
+			Resource:  "backupunit",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a BackupUnit",
+			LongDesc: `Use this command to create a BackupUnit under a particular contract. You need to specify the name, email and password for the new BackupUnit.
 
 Notes:
 
@@ -137,74 +175,128 @@ Required values to run a command:
 * Name
 * Email
 * Password`,
-		Example:    createBackupUnitExample,
-		PreCmdRun:  PreRunBackupUnitNameEmailPwd,
-		CmdRun:     RunBackupUnitCreate,
-		InitClient: true,
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Alphanumeric name you want to assign to the BackupUnit", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The e-mail address you want to assign to the BackupUnit", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "Alphanumeric password you want to assign to the BackupUnit", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+			Example:    createBackupUnitExample,
+			PreCmdRun:  PreRunBackupUnitNameEmailPwd,
+			CmdRun:     RunBackupUnitCreate,
+			InitClient: true,
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Alphanumeric name you want to assign to the BackupUnit",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The e-mail address you want to assign to the BackupUnit",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "",
+		"Alphanumeric password you want to assign to the BackupUnit", core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for BackupUnit creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace: "backupunit",
-		Resource:  "backupunit",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a BackupUnit",
-		LongDesc: `Use this command to update details about a specific BackupUnit. The password and the email may be updated.
+	update := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace: "backupunit",
+			Resource:  "backupunit",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a BackupUnit",
+			LongDesc: `Use this command to update details about a specific BackupUnit. The password and the email may be updated.
 
 Required values to run command:
 
 * BackupUnit Id`,
-		Example:    updateBackupUnitExample,
-		PreCmdRun:  PreRunBackupUnitId,
-		CmdRun:     RunBackupUnitUpdate,
-		InitClient: true,
-	})
-	update.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "Alphanumeric password you want to update for the BackupUnit")
-	update.AddStringFlag(cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The e-mail address you want to update for the BackupUnit")
-	update.AddUUIDFlag(cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+			Example:    updateBackupUnitExample,
+			PreCmdRun:  PreRunBackupUnitId,
+			CmdRun:     RunBackupUnitUpdate,
+			InitClient: true,
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "",
+		"Alphanumeric password you want to update for the BackupUnit",
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The e-mail address you want to update for the BackupUnit",
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBackupUnitId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for BackupUnit update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, backupUnitCmd, core.CommandBuilder{
-		Namespace: "backupunit",
-		Resource:  "backupunit",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a BackupUnit",
-		LongDesc: `Use this command to delete a BackupUnit. Deleting a BackupUnit is a dangerous operation. A successful DELETE will remove the backup plans inside a BackupUnit, ALL backups associated with the BackupUnit, the backup user and finally the BackupUnit itself.
+	deleteCmd := core.NewCommand(
+		ctx, backupUnitCmd, core.CommandBuilder{
+			Namespace: "backupunit",
+			Resource:  "backupunit",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a BackupUnit",
+			LongDesc: `Use this command to delete a BackupUnit. Deleting a BackupUnit is a dangerous operation. A successful DELETE will remove the backup plans inside a BackupUnit, ALL backups associated with the BackupUnit, the backup user and finally the BackupUnit itself.
 
 Required values to run command:
 
 * BackupUnit Id`,
-		Example:    deleteBackupUnitExample,
-		PreCmdRun:  PreRunBackupUnitDelete,
-		CmdRun:     RunBackupUnitDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit deletion to be executed")
+			Example:    deleteBackupUnitExample,
+			PreCmdRun:  PreRunBackupUnitDelete,
+			CmdRun:     RunBackupUnitDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgBackupUnitId, cloudapiv6.ArgIdShort, "", cloudapiv6.BackupUnitId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBackupUnitId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all BackupUnits.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for BackupUnit deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return backupUnitCmd
 }
@@ -221,7 +313,8 @@ func PreRunBackupUnitId(c *core.PreCommandConfig) error {
 }
 
 func PreRunBackupUnitDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgBackupUnitId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -242,14 +335,19 @@ func RunBackupUnitList(c *core.CommandConfig) error {
 
 	backupUnits, resp, err := c.CloudApiV6Services.BackupUnit().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.BackupUnit, backupUnits.BackupUnits,
-		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.BackupUnit, backupUnits.BackupUnits,
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -269,19 +367,34 @@ func RunBackupUnitGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Backup unit with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Backup unit with id: %v is getting... ",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.BackupUnit().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.BackupUnit().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgBackupUnitId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.BackupUnit, u.BackupUnit,
-		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.BackupUnit, u.BackupUnit,
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -299,12 +412,25 @@ func RunBackupUnitGetSsoUrl(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Backup unit with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Backup unit with id: %v is getting... ",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.BackupUnit().GetSsoUrl(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.BackupUnit().GetSsoUrl(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgBackupUnitId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.OutOrStdout(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -312,8 +438,10 @@ func RunBackupUnitGetSsoUrl(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.BackupUnitSSOUrl, u.BackupUnitSSO,
-		tabheaders.GetHeadersAllDefault(defaultBackupUnitSSOUrl, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.BackupUnitSSOUrl, u.BackupUnitSSO,
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitSSOUrl, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -344,12 +472,18 @@ func RunBackupUnitCreate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Backup Unit: Name: %v , Email: %v", name, email))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Backup Unit: Name: %v , Email: %v", name, email,
+		),
+	)
 
 	u, resp, err := c.CloudApiV6Services.BackupUnit().Create(newBackupUnit, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -363,8 +497,10 @@ func RunBackupUnitCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.BackupUnit, u.BackupUnit,
-		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.BackupUnit, u.BackupUnit,
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -380,9 +516,18 @@ func RunBackupUnitUpdate(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 	newProperties := getBackupUnitInfo(c)
 
-	backupUnitUpd, resp, err := c.CloudApiV6Services.BackupUnit().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)), *newProperties, queryParams)
+	backupUnitUpd, resp, err := c.CloudApiV6Services.BackupUnit().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgBackupUnitId,
+			),
+		), *newProperties, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -394,8 +539,10 @@ func RunBackupUnitUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.BackupUnit, backupUnitUpd.BackupUnit,
-		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.BackupUnit, backupUnitUpd.BackupUnit,
+		tabheaders.GetHeadersAllDefault(defaultBackupUnitCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -420,15 +567,23 @@ func RunBackupUnitDelete(c *core.CommandConfig) error {
 
 	backupunitId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId))
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete backup unit", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete backup unit", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Backup unit with id: %v...", backupunitId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Backup unit with id: %v...", backupunitId),
+	)
 
 	resp, err := c.CloudApiV6Services.BackupUnit().Delete(backupunitId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -457,7 +612,9 @@ func getBackupUnitInfo(c *core.CommandConfig) *resources.BackupUnitProperties {
 		email := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgEmail))
 		properties.SetEmail(email)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Email set: %v", email))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Email set: %v", email),
+		)
 	}
 
 	return &properties
@@ -504,7 +661,10 @@ func DeleteAllBackupUnits(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Backup Units", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Backup Units",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -517,18 +677,27 @@ func DeleteAllBackupUnits(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Backup unit with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Backup unit with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.BackupUnit().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/backupunit_test.go
+++ b/commands/cloudapi-v6/backupunit_test.go
@@ -123,480 +123,608 @@ func TestBackupunitCmd(t *testing.T) {
 func TestPreRunBackupUnitListNoFilter(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunBackupUnitList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunBackupUnitList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("name=%s", testQueryParamVar)})
-		err := PreRunBackupUnitList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("name=%s", testQueryParamVar)},
+			)
+			err := PreRunBackupUnitList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunBackupUnitList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunBackupUnitList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitListFormatErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), testBackupUnitVar)
-		err := PreRunBackupUnitList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), testBackupUnitVar)
+			err := PreRunBackupUnitList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		err := PreRunBackupUnitId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			err := PreRunBackupUnitId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunBackupUnitId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunBackupUnitId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitNameEmailPwd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
-		err := PreRunBackupUnitNameEmailPwd(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
+			err := PreRunBackupUnitNameEmailPwd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunBackupUnitNameEmailPwdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunBackupUnitNameEmailPwd(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunBackupUnitNameEmailPwd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(backupUnits, nil, nil)
-		err := RunBackupUnitList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				backupUnits, nil, nil,
+			)
+			err := RunBackupUnitList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.BackupUnits{}, nil, nil)
-		err := RunBackupUnitList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.BackupUnits{}, nil, nil,
+			)
+			err := RunBackupUnitList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(backupUnits, nil, testBackupUnitErr)
-		err := RunBackupUnitList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				backupUnits, nil, testBackupUnitErr,
+			)
+			err := RunBackupUnitList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Get(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTestGet, &testResponse, nil)
-		err := RunBackupUnitGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Get(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTestGet, &testResponse, nil)
+			err := RunBackupUnitGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Get(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTestGet, nil, testBackupUnitErr)
-		err := RunBackupUnitGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Get(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTestGet, nil, testBackupUnitErr)
+			err := RunBackupUnitGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitGetSsoUrl(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().GetSsoUrl(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTestGetSSO, &testResponse, nil)
-		err := RunBackupUnitGetSsoUrl(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().GetSsoUrl(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTestGetSSO, &testResponse, nil)
+			err := RunBackupUnitGetSsoUrl(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitGetSsoUrlErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().GetSsoUrl(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTestGetSSO, nil, testBackupUnitErr)
-		err := RunBackupUnitGetSsoUrl(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().GetSsoUrl(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTestGetSSO, nil, testBackupUnitErr)
+			err := RunBackupUnitGetSsoUrl(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTest, &testResponse, nil)
-		err := RunBackupUnitCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(
+				backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTest, &testResponse, nil)
+			err := RunBackupUnitCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTest, &testResponseErr, testBackupUnitErr)
-		err := RunBackupUnitCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(
+				backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTest, &testResponseErr, testBackupUnitErr)
+			err := RunBackupUnitCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
-		err := RunBackupUnitCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(
+				backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
+			err := RunBackupUnitCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTest, nil, testBackupUnitErr)
-		err := RunBackupUnitCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(
+				backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitTest, nil, testBackupUnitErr)
+			err := RunBackupUnitCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitNew, &testResponse, nil)
-		err := RunBackupUnitUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testBackupUnitNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(
+				testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitNew, &testResponse, nil)
+			err := RunBackupUnitUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunBackupUnitUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(
+				testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunBackupUnitUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitNew, nil, testBackupUnitErr)
-		err := RunBackupUnitUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(
+				testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&backupUnitNew, nil, testBackupUnitErr)
+			err := RunBackupUnitUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunBackupUnitDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(backupUnitsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				backupUnitsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunBackupUnitDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(backupUnitsList, nil, testBackupUnitErr)
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				backupUnitsList, nil, testBackupUnitErr,
+			)
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.BackupUnits{}, &testResponse, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.BackupUnits{}, &testResponse, nil,
+			)
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.BackupUnits{BackupUnits: ionoscloud.BackupUnits{Items: &[]ionoscloud.BackupUnit{}}}, &testResponse, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.BackupUnits{BackupUnits: ionoscloud.BackupUnits{Items: &[]ionoscloud.BackupUnit{}}},
+				&testResponse, nil,
+			)
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(backupUnitsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testBackupUnitErr)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				backupUnitsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testBackupUnitErr)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackUnitId, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testBackupUnitErr)
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testBackupUnitErr)
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
+			err := RunBackupUnitDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunBackupUnitDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(
+				testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunBackupUnitDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunBackupUnitDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunBackupUnitDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunBackupUnitDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/cdrom.go
+++ b/commands/cloudapi-v6/cdrom.go
@@ -38,21 +38,27 @@ func ServerCdromCmd() *core.Command {
 	}
 	globalFlags := serverCdromCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultImageCols, tabheaders.ColsMessage(allImageCols))
-	_ = viper.BindPFlag(core.GetFlagName(serverCdromCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = serverCdromCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allImageCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = viper.BindPFlag(
+		core.GetFlagName(serverCdromCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = serverCdromCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allImageCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Attach Cdrom Command
 	*/
-	attachCdrom := core.NewCommand(ctx, serverCdromCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "cdrom",
-		Verb:      "attach",
-		Aliases:   []string{"a"},
-		ShortDesc: "Attach a CD-ROM to a Server",
-		LongDesc: `Use this command to attach a CD-ROM to an existing Server.
+	attachCdrom := core.NewCommand(
+		ctx, serverCdromCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "cdrom",
+			Verb:      "attach",
+			Aliases:   []string{"a"},
+			ShortDesc: "Attach a CD-ROM to a Server",
+			LongDesc: `Use this command to attach a CD-ROM to an existing Server.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -61,109 +67,193 @@ Required values to run command:
 * Data Center Id
 * Server Id
 * Cdrom Id`,
-		Example:    attachCdromServerExample,
-		PreCmdRun:  PreRunDcServerCdromIds,
-		CmdRun:     RunServerCdromAttach,
-		InitClient: true,
-	})
+			Example:    attachCdromServerExample,
+			PreCmdRun:  PreRunDcServerCdromIds,
+			CmdRun:     RunServerCdromAttach,
+			InitClient: true,
+		},
+	)
 	attachCdrom.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = attachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	attachCdrom.AddUUIDFlag(cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption())
-	_ = attachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			// Completer for CDROM images that are in the same location as the datacenter
-			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
-				viper.GetString(core.GetFlagName(attachCdrom.NS, cloudapiv6.ArgDataCenterId))).Execute()
-			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
-				return ionoscloud.ApiImagesGetRequest{}
-			}
+	_ = attachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	attachCdrom.AddUUIDFlag(
+		cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption(),
+	)
+	_ = attachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgCdromId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					// Completer for CDROM images that are in the same location as the datacenter
+					chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+						context.Background(),
+						viper.GetString(core.GetFlagName(attachCdrom.NS, cloudapiv6.ArgDataCenterId)),
+					).Execute()
+					if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+						return ionoscloud.ApiImagesGetRequest{}
+					}
 
-			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "CDROM")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+					return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "CDROM")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	attachCdrom.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = attachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(attachCdrom.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	attachCdrom.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for CD-ROM attachment to be executed")
-	attachCdrom.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cdrom attachment [seconds]")
-	attachCdrom.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = attachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						attachCdrom.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	attachCdrom.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for CD-ROM attachment to be executed",
+	)
+	attachCdrom.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Cdrom attachment [seconds]",
+	)
+	attachCdrom.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		List Cdroms Command
 	*/
-	listCdroms := core.NewCommand(ctx, serverCdromCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "cdrom",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List attached CD-ROMs from a Server",
-		LongDesc:   "Use this command to retrieve a list of CD-ROMs attached to the Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ImagesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
-		Example:    listCdromServerExample,
-		PreCmdRun:  PreRunServerCdromList,
-		CmdRun:     RunServerCdromsList,
-		InitClient: true,
-	})
+	listCdroms := core.NewCommand(
+		ctx, serverCdromCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "cdrom",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List attached CD-ROMs from a Server",
+			LongDesc:   "Use this command to retrieve a list of CD-ROMs attached to the Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ImagesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
+			Example:    listCdromServerExample,
+			PreCmdRun:  PreRunServerCdromList,
+			CmdRun:     RunServerCdromsList,
+			InitClient: true,
+		},
+	)
 	listCdroms.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listCdroms.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	listCdroms.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(listCdroms.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	listCdroms.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
+	_ = listCdroms.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						listCdroms.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listCdroms.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
 	listCdroms.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	listCdroms.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = listCdroms.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	listCdroms.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = listCdroms.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listCdroms.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = listCdroms.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listCdroms.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Get Cdrom Command
 	*/
-	getCdromCmd := core.NewCommand(ctx, serverCdromCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "cdrom",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a specific attached CD-ROM from a Server",
-		LongDesc:   "Use this command to retrieve information about an attached CD-ROM on Server.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Cdrom Id",
-		Example:    getCdromServerExample,
-		InitClient: true,
-		PreCmdRun:  PreRunDcServerCdromIds,
-		CmdRun:     RunServerCdromGet,
-	})
+	getCdromCmd := core.NewCommand(
+		ctx, serverCdromCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "cdrom",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a specific attached CD-ROM from a Server",
+			LongDesc:   "Use this command to retrieve information about an attached CD-ROM on Server.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Cdrom Id",
+			Example:    getCdromServerExample,
+			InitClient: true,
+			PreCmdRun:  PreRunDcServerCdromIds,
+			CmdRun:     RunServerCdromGet,
+		},
+	)
 	getCdromCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	getCdromCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	getCdromCmd.AddUUIDFlag(cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption())
-	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AttachedCdromsIds(viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgDataCenterId)), viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	getCdromCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						getCdromCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	getCdromCmd.AddUUIDFlag(
+		cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption(),
+	)
+	_ = getCdromCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgCdromId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AttachedCdromsIds(
+				viper.GetString(
+					core.GetFlagName(
+						getCdromCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				), viper.GetString(core.GetFlagName(getCdromCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	getCdromCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Detach Cdrom Command
 	*/
-	detachCdrom := core.NewCommand(ctx, serverCdromCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "cdrom",
-		Verb:      "detach",
-		Aliases:   []string{"d"},
-		ShortDesc: "Detach a CD-ROM from a Server",
-		LongDesc: `This will detach the CD-ROM from the Server.
+	detachCdrom := core.NewCommand(
+		ctx, serverCdromCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "cdrom",
+			Verb:      "detach",
+			Aliases:   []string{"d"},
+			ShortDesc: "Detach a CD-ROM from a Server",
+			LongDesc: `This will detach the CD-ROM from the Server.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -172,28 +262,57 @@ Required values to run command:
 * Data Center Id
 * Server Id
 * Cdrom Id`,
-		Example:    detachCdromServerExample,
-		PreCmdRun:  PreRunDcServerCdromDetach,
-		CmdRun:     RunServerCdromDetach,
-		InitClient: true,
-	})
+			Example:    detachCdromServerExample,
+			PreCmdRun:  PreRunDcServerCdromDetach,
+			CmdRun:     RunServerCdromDetach,
+			InitClient: true,
+		},
+	)
+	detachCdrom.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	detachCdrom.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = detachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	detachCdrom.AddUUIDFlag(cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption())
-	_ = detachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AttachedCdromsIds(viper.GetString(core.GetFlagName(detachCdrom.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(detachCdrom.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = detachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	detachCdrom.AddUUIDFlag(
+		cloudapiv6.ArgCdromId, cloudapiv6.ArgIdShort, "", cloudapiv6.CdromId, core.RequiredFlagOption(),
+	)
+	_ = detachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgCdromId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AttachedCdromsIds(
+				viper.GetString(core.GetFlagName(detachCdrom.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(detachCdrom.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	detachCdrom.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = detachCdrom.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(detachCdrom.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	detachCdrom.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for CD-ROM detachment to be executed")
-	detachCdrom.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for CD-ROM detachment [seconds]")
+	_ = detachCdrom.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						detachCdrom.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	detachCdrom.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for CD-ROM detachment to be executed",
+	)
+	detachCdrom.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for CD-ROM detachment [seconds]",
+	)
 	detachCdrom.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Detach all CD-ROMS from a Server.")
-	detachCdrom.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	detachCdrom.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return serverCdromCmd
 }
@@ -209,11 +328,14 @@ func PreRunServerCdromList(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcServerCdromIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgCdromId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgCdromId,
+	)
 }
 
 func PreRunDcServerCdromDetach(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgCdromId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgAll},
 	)
@@ -230,12 +352,19 @@ func RunServerCdromAttach(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 	cdRomId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"CD-ROM with id: %v is attaching to server with id: %v from Datacenter with id: %v... ", cdRomId, serverId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"CD-ROM with id: %v is attaching to server with id: %v from Datacenter with id: %v... ", cdRomId, serverId,
+			dcId,
+		),
+	)
 
 	attachedCdrom, resp, err := c.CloudApiV6Services.Servers().AttachCdrom(dcId, serverId, cdRomId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 
 	if err != nil {
@@ -248,8 +377,10 @@ func RunServerCdromAttach(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Image, attachedCdrom.Image,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Image, attachedCdrom.Image,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -272,7 +403,10 @@ func RunServerCdromsList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -280,8 +414,10 @@ func RunServerCdromsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Image, attachedCdroms.Cdroms,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Image, attachedCdroms.Cdroms,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -298,8 +434,11 @@ func RunServerCdromGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"CD-ROM with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"CD-ROM with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId)),
+		),
+	)
 
 	attachedCdrom, resp, err := c.CloudApiV6Services.Servers().GetCdrom(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -308,7 +447,10 @@ func RunServerCdromGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -316,8 +458,10 @@ func RunServerCdromGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Image, attachedCdrom.Image,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Image, attachedCdrom.Image,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -342,12 +486,18 @@ func RunServerCdromDetach(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "detach cdrom from server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "detach cdrom from server",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"CD-ROM with id: %v is detaching... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"CD-ROM with id: %v is detaching... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId)),
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Servers().DetachCdrom(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -356,7 +506,10 @@ func RunServerCdromDetach(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -383,7 +536,9 @@ func DetachAllCdRoms(c *core.CommandConfig) error {
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting CD-ROMs..."))
 
-	cdRoms, resp, err := c.CloudApiV6Services.Servers().ListCdroms(dcId, serverId, cloudapiv6.ParentResourceListQueryParams)
+	cdRoms, resp, err := c.CloudApiV6Services.Servers().ListCdroms(
+		dcId, serverId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -414,7 +569,10 @@ func DetachAllCdRoms(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "detach all the CD-ROMS", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "detach all the CD-ROMS",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -427,18 +585,27 @@ func DetachAllCdRoms(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting detaching CD-ROM with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting detaching CD-ROM with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Servers().DetachCdrom(dcId, serverId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/cdrom_test.go
+++ b/commands/cloudapi-v6/cdrom_test.go
@@ -61,412 +61,518 @@ var (
 func TestPreRunDcServerCdromIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		err := PreRunDcServerCdromIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			err := PreRunDcServerCdromIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerCdromIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcServerCdromIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcServerCdromIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCdromList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		err := PreRunServerCdromList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			err := PreRunServerCdromList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCdromListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunServerCdromList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunServerCdromList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCdromListFilter(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunServerCdromList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunServerCdromList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromAttach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testImage, &testResponse, nil)
-		err := RunServerCdromAttach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testImage, &testResponse, nil)
+			err := RunServerCdromAttach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromAttachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testImage, nil, testCdromErr)
-		err := RunServerCdromAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testImage, nil, testCdromErr)
+			err := RunServerCdromAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromAttachWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testImage, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerCdromAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testImage, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerCdromAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testCdroms, &testResponse, nil)
-		err := RunServerCdromsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testCdroms, &testResponse, nil)
+			err := RunServerCdromsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromsListListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Cdroms{}, &testResponse, nil)
-		err := RunServerCdromsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Cdroms{}, &testResponse, nil)
+			err := RunServerCdromsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testCdroms, nil, testCdromErr)
-		err := RunServerCdromsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testCdroms, nil, testCdromErr)
+			err := RunServerCdromsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().GetCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testImage, &testResponse, nil)
-		err := RunServerCdromGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().GetCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testImage, &testResponse, nil)
+			err := RunServerCdromGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().GetCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testImage, nil, testCdromErr)
-		err := RunServerCdromGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().GetCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testImage, nil, testCdromErr)
+			err := RunServerCdromGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerCdromDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testCdromsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testCdromsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerCdromDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testCdromsList, nil, testCdromErr)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testCdromsList, nil, testCdromErr)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Cdroms{}, &testResponse, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Cdroms{}, &testResponse, nil)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Cdroms{Cdroms: ionoscloud.Cdroms{Items: &[]ionoscloud.Image{}}}, &testResponse, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.Cdroms{Cdroms: ionoscloud.Cdroms{Items: &[]ionoscloud.Image{}}}, &testResponse, nil,
+			)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testCdromsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testCdromErr)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().ListCdroms(
+				testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testCdromsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testCdromErr)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testCdromErr)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testCdromErr)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponseErr, testCdromErr)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponseErr, testCdromErr)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunCdromDetachAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunServerCdromDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().DetachCdrom(
+				testCdromVar, testCdromVar, testCdromVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunServerCdromDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCdromDetachAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerCdromDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testCdromVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerCdromDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/datacenter.go
+++ b/commands/cloudapi-v6/datacenter.go
@@ -25,8 +25,10 @@ import (
 
 var (
 	defaultDatacenterCols = []string{"DatacenterId", "Name", "Location", "CpuFamily", "IPv6CidrBlock", "State"}
-	allDatacenterCols     = []string{"DatacenterId", "Name", "Location", "State", "Description", "Version",
-		"Features", "CpuFamily", "SecAuthProtection", "IPv6CidrBlock"}
+	allDatacenterCols     = []string{
+		"DatacenterId", "Name", "Location", "State", "Description", "Version",
+		"Features", "CpuFamily", "SecAuthProtection", "IPv6CidrBlock",
+	}
 )
 
 func DatacenterCmd() *core.Command {
@@ -43,150 +45,226 @@ func DatacenterCmd() *core.Command {
 	}
 	globalFlags := datacenterCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultDatacenterCols, tabheaders.ColsMessage(allDatacenterCols))
-	_ = viper.BindPFlag(core.GetFlagName(datacenterCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = datacenterCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allDatacenterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = viper.BindPFlag(
+		core.GetFlagName(datacenterCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = datacenterCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allDatacenterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, datacenterCmd, core.CommandBuilder{
-		Namespace: "datacenter",
-		Resource:  "datacenter",
-		Verb:      "list",
-		Aliases:   []string{"l", "ls"},
-		ShortDesc: "List Data Centers",
-		LongDesc: `Use this command to retrieve a complete list of Virtual Data Centers provisioned under your account. You can setup multiple query parameters.
+	list := core.NewCommand(
+		ctx, datacenterCmd, core.CommandBuilder{
+			Namespace: "datacenter",
+			Resource:  "datacenter",
+			Verb:      "list",
+			Aliases:   []string{"l", "ls"},
+			ShortDesc: "List Data Centers",
+			LongDesc: `Use this command to retrieve a complete list of Virtual Data Centers provisioned under your account. You can setup multiple query parameters.
 
 You can filter the results using ` + "`" + `--filters` + "`" + ` option. Use the following format to set filters: ` + "`" + `--filters KEY1=VALUE1,KEY2=VALUE2` + "`" + `
 ` + completer.DataCentersFiltersUsage(),
-		Example:    listDatacenterExample,
-		PreCmdRun:  PreRunDataCenterList,
-		CmdRun:     RunDataCenterList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+			Example:    listDatacenterExample,
+			PreCmdRun:  PreRunDataCenterList,
+			CmdRun:     RunDataCenterList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, datacenterCmd, core.CommandBuilder{
-		Namespace:  "datacenter",
-		Resource:   "datacenter",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Data Center",
-		LongDesc:   "Use this command to retrieve details about a Virtual Data Center by using its ID.\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    getDatacenterExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunDataCenterGet,
-		InitClient: true,
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	get := core.NewCommand(
+		ctx, datacenterCmd, core.CommandBuilder{
+			Namespace:  "datacenter",
+			Resource:   "datacenter",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Data Center",
+			LongDesc:   "Use this command to retrieve details about a Virtual Data Center by using its ID.\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    getDatacenterExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunDataCenterGet,
+			InitClient: true,
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, datacenterCmd, core.CommandBuilder{
-		Namespace: "datacenter",
-		Resource:  "datacenter",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Data Center",
-		LongDesc: `Use this command to create a Virtual Data Center. You can specify the name, description or location for the object.
+	create := core.NewCommand(
+		ctx, datacenterCmd, core.CommandBuilder{
+			Namespace: "datacenter",
+			Resource:  "datacenter",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Data Center",
+			LongDesc: `Use this command to create a Virtual Data Center. You can specify the name, description or location for the object.
 
 Virtual Data Centers are the foundation of the IONOS platform. VDCs act as logical containers for all other objects you will be creating, e.g. servers. You can provision as many Data Centers as you want. Data Centers have their own private network and are logically segmented from each other to create isolation.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.`,
-		Example:    createDatacenterExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunDataCenterCreate,
-		InitClient: true,
-	})
+			Example:    createDatacenterExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunDataCenterCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Data Center", "Name of the Data Center")
-	create.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Data Center")
+	create.AddStringFlag(
+		cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Data Center",
+	)
 	create.AddStringFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "de/txl", "Location for the Data Center")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Data Center creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Data Center creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Data Center creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Data Center creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, datacenterCmd, core.CommandBuilder{
-		Namespace: "datacenter",
-		Resource:  "datacenter",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Data Center",
-		LongDesc: `Use this command to change a Virtual Data Center's name, description.
+	update := core.NewCommand(
+		ctx, datacenterCmd, core.CommandBuilder{
+			Namespace: "datacenter",
+			Resource:  "datacenter",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Data Center",
+			LongDesc: `Use this command to change a Virtual Data Center's name, description.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Data Center Id`,
-		Example:    updateDatacenterExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunDataCenterUpdate,
-		InitClient: true,
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+			Example:    updateDatacenterExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunDataCenterUpdate,
+			InitClient: true,
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Data Center")
-	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Data Center")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Data Center update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Data Center update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddStringFlag(
+		cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Data Center",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Data Center update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Data Center update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, datacenterCmd, core.CommandBuilder{
-		Namespace: "datacenter",
-		Resource:  "datacenter",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Data Center",
-		LongDesc: `Use this command to delete a specified Virtual Data Center from your account. This will remove all objects within the VDC and remove the VDC object itself.
+	deleteCmd := core.NewCommand(
+		ctx, datacenterCmd, core.CommandBuilder{
+			Namespace: "datacenter",
+			Resource:  "datacenter",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Data Center",
+			LongDesc: `Use this command to delete a specified Virtual Data Center from your account. This will remove all objects within the VDC and remove the VDC object itself.
 
 NOTE: This is a highly destructive operation which should be used with extreme caution!
 
 Required values to run command:
 
 * Data Center Id`,
-		Example:    deleteDatacenterExample,
-		PreCmdRun:  PreRunDataCenterDelete,
-		CmdRun:     RunDataCenterDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Data Center deletion")
+			Example:    deleteDatacenterExample,
+			PreCmdRun:  PreRunDataCenterDelete,
+			CmdRun:     RunDataCenterDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgDataCenterId, cloudapiv6.ArgIdShort, "", cloudapiv6.DatacenterId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Data Center deletion",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Datacenters.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Data Center deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Data Center deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return datacenterCmd
 }
@@ -196,7 +274,8 @@ func PreRunDataCenterId(c *core.PreCommandConfig) error {
 }
 
 func PreRunDataCenterDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -218,7 +297,10 @@ func RunDataCenterList(c *core.CommandConfig) error {
 
 	datacenters, resp, err := c.CloudApiV6Services.DataCenters().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -226,8 +308,10 @@ func RunDataCenterList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Datacenter, datacenters.Datacenters,
-		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Datacenter, datacenters.Datacenters,
+		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -244,12 +328,24 @@ func RunDataCenterGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting Datacenter with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting Datacenter with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
-	dc, resp, err := c.CloudApiV6Services.DataCenters().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), queryParams)
+	dc, resp, err := c.CloudApiV6Services.DataCenters().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -257,8 +353,10 @@ func RunDataCenterGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Datacenter, dc.Datacenter,
-		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Datacenter, dc.Datacenter,
+		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -279,12 +377,19 @@ func RunDataCenterCreate(c *core.CommandConfig) error {
 	description := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDescription))
 	loc := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLocation))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the datacenter: Name: %v, Description: %v, Location: %v", name, description, loc))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the datacenter: Name: %v, Description: %v, Location: %v", name, description,
+			loc,
+		),
+	)
 
 	dc, resp, err := c.CloudApiV6Services.DataCenters().Create(name, description, loc, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -296,8 +401,10 @@ func RunDataCenterCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Datacenter, dc,
-		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Datacenter, dc,
+		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -325,7 +432,10 @@ func RunDataCenterUpdate(c *core.CommandConfig) error {
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDescription)) {
 		description := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDescription))
 		input.SetDescription(description)
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description),
+		)
 	}
 
 	dc, resp, err := c.CloudApiV6Services.DataCenters().Update(
@@ -334,7 +444,10 @@ func RunDataCenterUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -345,8 +458,10 @@ func RunDataCenterUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Datacenter, dc,
-		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Datacenter, dc,
+		tabheaders.GetHeaders(allDatacenterCols, defaultDatacenterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -371,17 +486,25 @@ func RunDataCenterDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete data center", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete data center", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Datacenter with ID: %v...", dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Datacenter with ID: %v...", dcId),
+	)
 
 	resp, err := c.CloudApiV6Services.DataCenters().Delete(dcId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -444,18 +567,27 @@ func DeleteAllDatacenters(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Datacenter with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Datacenter with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.DataCenters().Delete(*id, resources.QueryParams{})
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/datacenter_test.go
+++ b/commands/cloudapi-v6/datacenter_test.go
@@ -31,7 +31,8 @@ var (
 			CpuArchitecture: &[]ionoscloud.CpuArchitectureProperties{
 				{
 					CpuFamily: &testDatacenterVar,
-				}},
+				},
+			},
 			SecAuthProtection: &testDatacenterBoolVar,
 		},
 		Metadata: &ionoscloud.DatacenterElementMetadata{
@@ -78,433 +79,552 @@ func TestDatacenterCmd(t *testing.T) {
 func TestPreRunDataCenterId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		err := PreRunDataCenterId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			err := PreRunDataCenterId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDataCenterIdRequiredFlagErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDataCenterId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDataCenterId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDataCenterList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDataCenterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDataCenterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDataCenterListFilter(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunDataCenterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunDataCenterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDataCenterListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunDataCenterList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunDataCenterList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		err := RunDataCenterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			err := RunDataCenterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Datacenters{}, &testResponse, nil)
-		err := RunDataCenterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Datacenters{}, &testResponse, nil,
+			)
+			err := RunDataCenterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, nil, testDatacenterErr)
-		err := RunDataCenterList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, nil, testDatacenterErr,
+			)
+			err := RunDataCenterList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		res := resources.Datacenter{Datacenter: dc}
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&res, &testResponse, nil)
-		err := RunDataCenterGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			res := resources.Datacenter{Datacenter: dc}
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&res, &testResponse, nil)
+			err := RunDataCenterGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		res := resources.Datacenter{Datacenter: dc}
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&res, nil, testDatacenterErr)
-		err := RunDataCenterGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			res := resources.Datacenter{Datacenter: dc}
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&res, nil, testDatacenterErr)
+			err := RunDataCenterGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Datacenter{dc}, &testResponse, nil)
-		err := RunDataCenterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(
+				testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Datacenter{dc}, &testResponse, nil)
+			err := RunDataCenterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Datacenter{Datacenter: dc}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunDataCenterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(
+				testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Datacenter{Datacenter: dc}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunDataCenterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Datacenter{Datacenter: dc}, nil, testDatacenterErr)
-		err := RunDataCenterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Create(
+				testDatacenterVar, testDatacenterVar, testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Datacenter{Datacenter: dc}, nil, testDatacenterErr)
+			err := RunDataCenterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&dcNew, &testResponse, nil)
-		err := RunDataCenterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(
+				testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&dcNew, &testResponse, nil)
+			err := RunDataCenterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&dcNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunDataCenterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(
+				testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&dcNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunDataCenterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&dcNew, nil, testDatacenterErr)
-		err := RunDataCenterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(
+				testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&dcNew, nil, testDatacenterErr)
+			err := RunDataCenterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterUpdateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&dcNew, &testResponse, testDatacenterErr)
-		err := RunDataCenterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testDatacenterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Update(
+				testDatacenterVar, dcProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&dcNew, &testResponse, testDatacenterErr)
+			err := RunDataCenterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunDataCenterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunDataCenterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, nil, testDatacenterErr)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, nil, testDatacenterErr,
+			)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Datacenters{}, nil, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Datacenters{}, nil, nil,
+			)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Datacenters{Datacenters: ionoscloud.Datacenters{Items: &[]ionoscloud.Datacenter{}}}, &testResponse, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Datacenters{Datacenters: ionoscloud.Datacenters{Items: &[]ionoscloud.Datacenter{}}},
+				&testResponse, nil,
+			)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testDatacenterErr)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testDatacenterErr)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testDatacenterErr)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testDatacenterErr)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunDataCenterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Delete(
+				testDatacenterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunDataCenterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunDataCenterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testDatacenterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunDataCenterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -26,9 +26,14 @@ import (
 )
 
 var (
-	defaultFirewallRuleCols = []string{"FirewallRuleId", "Name", "Protocol", "PortRangeStart", "PortRangeEnd", "Direction", "IPVersion", "State"}
-	allFirewallRuleCols     = []string{"FirewallRuleId", "Name", "Protocol", "SourceMac", "SourceIP", "DestinationIP", "PortRangeStart", "PortRangeEnd",
-		"IcmpCode", "IcmpType", "Direction", "IPVersion", "State"}
+	defaultFirewallRuleCols = []string{
+		"FirewallRuleId", "Name", "Protocol", "PortRangeStart", "PortRangeEnd", "Direction", "IPVersion", "State",
+	}
+	allFirewallRuleCols = []string{
+		"FirewallRuleId", "Name", "Protocol", "SourceMac", "SourceIP", "DestinationIP", "PortRangeStart",
+		"PortRangeEnd",
+		"IcmpCode", "IcmpType", "Direction", "IPVersion", "State",
+	}
 )
 
 func FirewallruleCmd() *core.Command {
@@ -43,99 +48,160 @@ func FirewallruleCmd() *core.Command {
 		},
 	}
 	globalFlags := firewallRuleCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultFirewallRuleCols, tabheaders.ColsMessage(allFirewallRuleCols))
-	_ = viper.BindPFlag(core.GetFlagName(firewallRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = firewallRuleCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allFirewallRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultFirewallRuleCols, tabheaders.ColsMessage(allFirewallRuleCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(firewallRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = firewallRuleCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allFirewallRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, firewallRuleCmd, core.CommandBuilder{
-		Namespace:  "firewallrule",
-		Resource:   "firewallrule",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Firewall Rules",
-		LongDesc:   "Use this command to get a list of Firewall Rules from a specified NIC from a Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FirewallRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id",
-		Example:    listFirewallRuleExample,
-		PreCmdRun:  PreRunFirewallRuleList,
-		CmdRun:     RunFirewallRuleList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, firewallRuleCmd, core.CommandBuilder{
+			Namespace:  "firewallrule",
+			Resource:   "firewallrule",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Firewall Rules",
+			LongDesc:   "Use this command to get a list of Firewall Rules from a specified NIC from a Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FirewallRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id",
+			Example:    listFirewallRuleExample,
+			PreCmdRun:  PreRunFirewallRuleList,
+			CmdRun:     RunFirewallRuleList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgServerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
 	list.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FirewallRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, firewallRuleCmd, core.CommandBuilder{
-		Namespace:  "firewallrule",
-		Resource:   "firewallrule",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Firewall Rule",
-		LongDesc:   "Use this command to retrieve information of a specified Firewall Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id\n* FirewallRule Id",
-		Example:    getFirewallRuleExample,
-		PreCmdRun:  PreRunDcServerNicFRuleIds,
-		CmdRun:     RunFirewallRuleGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, firewallRuleCmd, core.CommandBuilder{
+			Namespace:  "firewallrule",
+			Resource:   "firewallrule",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Firewall Rule",
+			LongDesc:   "Use this command to retrieve information of a specified Firewall Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id\n* FirewallRule Id",
+			Example:    getFirewallRuleExample,
+			PreCmdRun:  PreRunDcServerNicFRuleIds,
+			CmdRun:     RunFirewallRuleGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFirewallRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FirewallRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFirewallRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FirewallRulesIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, firewallRuleCmd, core.CommandBuilder{
-		Namespace: "firewallrule",
-		Resource:  "firewallrule",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Firewall Rule",
-		LongDesc: `Use this command to create/add a new Firewall Rule to the specified NIC. All Firewall Rules must be associated with a NIC.
+	create := core.NewCommand(
+		ctx, firewallRuleCmd, core.CommandBuilder{
+			Namespace: "firewallrule",
+			Resource:  "firewallrule",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Firewall Rule",
+			LongDesc: `Use this command to create/add a new Firewall Rule to the specified NIC. All Firewall Rules must be associated with a NIC.
 
 NOTE: the Firewall Rule Protocol can only be set when creating a new Firewall Rule.
 
@@ -147,56 +213,113 @@ Required values to run command:
 * Server Id
 * Nic Id
 * Protocol`,
-		Example:    createFirewallRuleExample,
-		PreCmdRun:  PreRunDcServerNicIdsFRuleProtocol,
-		CmdRun:     RunFirewallRuleCreate,
-		InitClient: true,
-	})
+			Example:    createFirewallRuleExample,
+			PreCmdRun:  PreRunDcServerNicIdsFRuleProtocol,
+			CmdRun:     RunFirewallRuleCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Rule", "The name for the Firewall Rule")
-	create.AddStringFlag(cloudapiv6.ArgProtocol, "", "", "The Protocol for Firewall Rule: TCP, UDP, ICMP, ANY", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"TCP", "UDP", "ICMP", "ANY"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgSourceMac, "", "", "Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Unset option allows all source MAC addresses")
-	create.AddIpFlag(cloudapiv6.ArgSourceIp, "", nil, "Only traffic originating from the respective IPv4 address is allowed. Not setting option allows all source IPs")
-	create.AddIpFlag(cloudapiv6.ArgDestinationIp, cloudapiv6.ArgDestinationIpShort, nil, "In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Not setting option allows all target/destination IPs. WARNING: This short-hand flag `-D` is deprecated.")
-	create.AddIntFlag(cloudapiv6.ArgIcmpType, "", 0, "Define the allowed type (from 0 to 254) if the protocol ICMP is chosen. Not setting option allows all types")
-	create.AddIntFlag(cloudapiv6.ArgIcmpCode, "", 0, "Define the allowed code (from 0 to 254) if protocol ICMP is chosen. Not setting option allows all codes")
-	create.AddIntFlag(cloudapiv6.ArgPortRangeStart, "", 1, "Define the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports")
-	create.AddIntFlag(cloudapiv6.ArgPortRangeEnd, "", 1, "Define the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports")
-	create.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "INGRESS", "The type/direction of Firewall Rule")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Firewall Rule creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Firewall Rule creation [seconds]")
+	create.AddStringFlag(
+		cloudapiv6.ArgProtocol, "", "", "The Protocol for Firewall Rule: TCP, UDP, ICMP, ANY", core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"TCP", "UDP", "ICMP", "ANY"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgSourceMac, "", "",
+		"Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Unset option allows all source MAC addresses",
+	)
+	create.AddIpFlag(
+		cloudapiv6.ArgSourceIp, "", nil,
+		"Only traffic originating from the respective IPv4 address is allowed. Not setting option allows all source IPs",
+	)
+	create.AddIpFlag(
+		cloudapiv6.ArgDestinationIp, cloudapiv6.ArgDestinationIpShort, nil,
+		"In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Not setting option allows all target/destination IPs. WARNING: This short-hand flag `-D` is deprecated.",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgIcmpType, "", 0,
+		"Define the allowed type (from 0 to 254) if the protocol ICMP is chosen. Not setting option allows all types",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgIcmpCode, "", 0,
+		"Define the allowed code (from 0 to 254) if protocol ICMP is chosen. Not setting option allows all codes",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgPortRangeStart, "", 1,
+		"Define the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgPortRangeEnd, "", 1,
+		"Define the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "INGRESS", "The type/direction of Firewall Rule",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Firewall Rule creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Firewall Rule creation [seconds]",
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgServerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
-	create.AddSetFlag(cloudapiv6.FlagIPVersion, "", "IPv4", []string{"IPv4", "IPv6"}, "The IP version for the Firewall Rule")
+	create.AddSetFlag(
+		cloudapiv6.FlagIPVersion, "", "IPv4", []string{"IPv4", "IPv6"}, "The IP version for the Firewall Rule",
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, firewallRuleCmd, core.CommandBuilder{
-		Namespace: "firewallrule",
-		Resource:  "firewallrule",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a FirewallRule",
-		LongDesc: `Use this command to update a specified Firewall Rule.
+	update := core.NewCommand(
+		ctx, firewallRuleCmd, core.CommandBuilder{
+			Namespace: "firewallrule",
+			Resource:  "firewallrule",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a FirewallRule",
+			LongDesc: `Use this command to update a specified Firewall Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -206,58 +329,117 @@ Required values to run command:
 * Server Id
 * Nic Id
 * Firewall Rule Id`,
-		Example:    updateFirewallRuleExample,
-		PreCmdRun:  PreRunDcServerNicFRuleIds,
-		CmdRun:     RunFirewallRuleUpdate,
-		InitClient: true,
-	})
+			Example:    updateFirewallRuleExample,
+			PreCmdRun:  PreRunDcServerNicFRuleIds,
+			CmdRun:     RunFirewallRuleUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the Firewall Rule")
-	update.AddStringFlag(cloudapiv6.ArgSourceMac, "", "", "Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Not setting option allows all source MAC addresses")
-	update.AddIpFlag(cloudapiv6.ArgSourceIp, "", nil, "Only traffic originating from the respective IPv4 address is allowed. Not setting option allows all source IPs")
-	update.AddIpFlag(cloudapiv6.ArgDestinationIp, cloudapiv6.ArgDestinationIpShort, nil, "In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Not setting option allows all target/destination IPs. WARNING: This short-hand flag `-D` is deprecated.")
-	update.AddIntFlag(cloudapiv6.ArgIcmpType, "", 0, "Redefine the allowed type (from 0 to 254) if the protocol ICMP is chosen. Not setting option allows all types")
-	update.AddIntFlag(cloudapiv6.ArgIcmpCode, "", 0, "Redefine the allowed code (from 0 to 254) if protocol ICMP is chosen. Not setting option allows all codes")
-	update.AddIntFlag(cloudapiv6.ArgPortRangeStart, "", 1, "Redefine the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports")
-	update.AddIntFlag(cloudapiv6.ArgPortRangeEnd, "", 1, "Redefine the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports")
-	update.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "The type/direction of Firewall Rule")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFirewallRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FirewallRulesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgServerId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Firewall Rule update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Firewall Rule update [seconds]")
+	update.AddStringFlag(
+		cloudapiv6.ArgSourceMac, "", "",
+		"Only traffic originating from the respective MAC address is allowed. Valid format: aa:bb:cc:dd:ee:ff. Not setting option allows all source MAC addresses",
+	)
+	update.AddIpFlag(
+		cloudapiv6.ArgSourceIp, "", nil,
+		"Only traffic originating from the respective IPv4 address is allowed. Not setting option allows all source IPs",
+	)
+	update.AddIpFlag(
+		cloudapiv6.ArgDestinationIp, cloudapiv6.ArgDestinationIpShort, nil,
+		"In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed. Not setting option allows all target/destination IPs. WARNING: This short-hand flag `-D` is deprecated.",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgIcmpType, "", 0,
+		"Redefine the allowed type (from 0 to 254) if the protocol ICMP is chosen. Not setting option allows all types",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgIcmpCode, "", 0,
+		"Redefine the allowed code (from 0 to 254) if protocol ICMP is chosen. Not setting option allows all codes",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgPortRangeStart, "", 1,
+		"Redefine the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgPortRangeEnd, "", 1,
+		"Redefine the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Not setting portRangeStart and portRangeEnd allows all ports",
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "The type/direction of Firewall Rule",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFirewallRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FirewallRulesIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgServerId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNicId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Firewall Rule update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Firewall Rule update [seconds]",
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgServerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
-	update.AddSetFlag(cloudapiv6.FlagIPVersion, "", "IPv4", []string{"IPv4", "IPv6"}, "The IP version for the Firewall Rule")
+	update.AddSetFlag(
+		cloudapiv6.FlagIPVersion, "", "IPv4", []string{"IPv4", "IPv6"}, "The IP version for the Firewall Rule",
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, firewallRuleCmd, core.CommandBuilder{
-		Namespace: "firewallrule",
-		Resource:  "firewallrule",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a FirewallRule",
-		LongDesc: `Use this command to delete a specified Firewall Rule from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, firewallRuleCmd, core.CommandBuilder{
+			Namespace: "firewallrule",
+			Resource:  "firewallrule",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a FirewallRule",
+			LongDesc: `Use this command to delete a specified Firewall Rule from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -267,41 +449,74 @@ Required values to run command:
 * Server Id
 * Nic Id
 * Firewall Rule Id`,
-		Example:    deleteFirewallRuleExample,
-		PreCmdRun:  PreRunFirewallDelete,
-		CmdRun:     RunFirewallRuleDelete,
-		InitClient: true,
-	})
+			Example:    deleteFirewallRuleExample,
+			PreCmdRun:  PreRunFirewallDelete,
+			CmdRun:     RunFirewallRuleDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFirewallRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FirewallRulesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Firewall Rule deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgFirewallRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.FirewallRuleId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFirewallRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FirewallRulesIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNicId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Firewall Rule deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Firewalls.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Firewall Rule deletion [seconds]")
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Firewall Rule deletion [seconds]",
+	)
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
 	return firewallRuleCmd
 }
 
 func PreRunFirewallRuleList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -311,22 +526,30 @@ func PreRunFirewallRuleList(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcServerNicIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+	)
 }
 
 func PreRunFirewallDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgFirewallRuleId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunDcServerNicIdsFRuleProtocol(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgProtocol)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgProtocol,
+	)
 }
 
 func PreRunDcServerNicFRuleIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgFirewallRuleId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+		cloudapiv6.ArgFirewallRuleId,
+	)
 }
 
 func RunFirewallRuleList(c *core.CommandConfig) error {
@@ -343,7 +566,10 @@ func RunFirewallRuleList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -351,8 +577,10 @@ func RunFirewallRuleList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.FirewallRule, firewallRules.FirewallRules,
-		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.FirewallRule, firewallRules.FirewallRules,
+		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -370,8 +598,11 @@ func RunFirewallRuleGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting Firewall Rule with id: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirewallRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting Firewall Rule with id: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirewallRuleId)),
+		),
+	)
 
 	firewallRule, resp, err := c.CloudApiV6Services.FirewallRules().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -381,7 +612,10 @@ func RunFirewallRuleGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -389,8 +623,10 @@ func RunFirewallRuleGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.FirewallRule, firewallRule.FirewallRule,
-		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.FirewallRule, firewallRule.FirewallRule,
+		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -437,7 +673,10 @@ func RunFirewallRuleCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -449,8 +688,10 @@ func RunFirewallRuleCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.FirewallRule, firewallRule.FirewallRule,
-		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.FirewallRule, firewallRule.FirewallRule,
+		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -483,7 +724,10 @@ func RunFirewallRuleUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -495,8 +739,10 @@ func RunFirewallRuleUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.FirewallRule, firewallRule.FirewallRule,
-		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.FirewallRule, firewallRule.FirewallRule,
+		tabheaders.GetHeaders(allFirewallRuleCols, defaultFirewallRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -526,15 +772,23 @@ func RunFirewallRuleDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete firewall rule", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete firewall rule", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Firewall Rule with id: %v...", fruleId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Firewall Rule with id: %v...", fruleId),
+	)
 
 	resp, err := c.CloudApiV6Services.FirewallRules().Delete(datacenterId, serverId, nicId, fruleId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -565,70 +819,96 @@ func getFirewallRulePropertiesSet(c *core.CommandConfig) resources.FirewallRuleP
 		protocol := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))
 		properties.SetProtocol(protocol)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", protocol))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", protocol),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSourceIp)) {
 		sourceIp := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSourceIp))
 		properties.SetSourceIp(sourceIp)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SourceIp set: %v", sourceIp))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SourceIp set: %v", sourceIp),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSourceMac)) {
 		sourceMac := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSourceMac))
 		properties.SetSourceMac(sourceMac)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SourceMac set: %v", sourceMac))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property SourceMac set: %v", sourceMac),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDestinationIp)) {
 		targetIp := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDestinationIp))
 		properties.SetTargetIp(targetIp)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property TargetIp/DestinationIp set: %v", targetIp))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property TargetIp/DestinationIp set: %v", targetIp),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgIcmpCode)) {
 		icmpCode := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgIcmpCode))
 		properties.SetIcmpCode(icmpCode)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IcmpCode set: %v", icmpCode))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IcmpCode set: %v", icmpCode),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgIcmpType)) {
 		icmpType := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgIcmpType))
 		properties.SetIcmpType(icmpType)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IcmpType set: %v", icmpType))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IcmpType set: %v", icmpType),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPortRangeStart)) {
 		portRangeStart := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgPortRangeStart))
 		properties.SetPortRangeStart(portRangeStart)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PortRangeStart set: %v", portRangeStart))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property PortRangeStart set: %v", portRangeStart),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPortRangeEnd)) {
 		portRangeEnd := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgPortRangeEnd))
 		properties.SetPortRangeEnd(portRangeEnd)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PortRangeEnd set: %v", portRangeEnd))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property PortRangeEnd set: %v", portRangeEnd),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDirection)) {
 		firewallruleType := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection))
 		properties.SetType(strings.ToUpper(firewallruleType))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Type/Direction set: %v", firewallruleType))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Type/Direction set: %v", firewallruleType),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.FlagIPVersion)) {
 		ipVersion := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.FlagIPVersion))
 		properties.SetIpVersion(ipVersion)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IP Version set: %v", ipVersion))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property IP Version set: %v", ipVersion),
+		)
 	}
 
 	return properties
@@ -645,12 +925,16 @@ func DeleteAllFirewallRules(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, datacenterId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, datacenterId),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Server ID: %v", serverId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NIC with ID: %v", nicId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Firewall Rules..."))
 
-	firewallRules, resp, err := c.CloudApiV6Services.FirewallRules().List(datacenterId, serverId, nicId, cloudapiv6.ParentResourceListQueryParams)
+	firewallRules, resp, err := c.CloudApiV6Services.FirewallRules().List(
+		datacenterId, serverId, nicId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -682,11 +966,16 @@ func DeleteAllFirewallRules(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Firewall Rules", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Firewall Rules",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Firewall Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Firewall Rules..."),
+	)
 
 	var multiErr error
 	for _, firewall := range *firewallRulesItems {
@@ -695,18 +984,27 @@ func DeleteAllFirewallRules(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Firewall Rule with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Firewall Rule with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.FirewallRules().Delete(datacenterId, serverId, nicId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/firewallrule_test.go
+++ b/commands/cloudapi-v6/firewallrule_test.go
@@ -118,626 +118,780 @@ func TestFirewallruleCmd(t *testing.T) {
 func TestPreRunDcServerNicIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		err := PreRunDcServerNicIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			err := PreRunDcServerNicIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerNicIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerNicIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunFirewallRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		err := PreRunFirewallRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			err := PreRunFirewallRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunFirewallRuleListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunFirewallRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunFirewallRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunFirewallRuleListFiltersErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunFirewallRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunFirewallRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicIdsFRuleProtocol(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleVar)
-		err := PreRunDcServerNicIdsFRuleProtocol(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleVar)
+			err := PreRunDcServerNicIdsFRuleProtocol(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicIdsFRuleProtocolErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerNicIdsFRuleProtocol(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerNicIdsFRuleProtocol(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicFRuleIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		err := PreRunDcServerNicFRuleIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			err := PreRunDcServerNicFRuleIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicFRuleIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerNicFRuleIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerNicFRuleIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFirewallRules, &testResponse, nil)
-		err := RunFirewallRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFirewallRules, &testResponse, nil)
+			err := RunFirewallRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FirewallRules{}, &testResponse, nil)
-		err := RunFirewallRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FirewallRules{}, &testResponse, nil)
+			err := RunFirewallRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFirewallRules, nil, testFirewallRuleErr)
-		err := RunFirewallRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFirewallRules, nil, testFirewallRuleErr)
+			err := RunFirewallRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Get(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testRule, &testResponse, nil)
-		err := RunFirewallRuleGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Get(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testRule, &testResponse, nil)
+			err := RunFirewallRuleGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Get(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testRule, nil, testFirewallRuleErr)
-		err := RunFirewallRuleGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Get(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testRule, nil, testFirewallRuleErr)
+			err := RunFirewallRuleGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testInputFirewallRule, &testResponse, nil)
-		err := RunFirewallRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testInputFirewallRule, &testResponse, nil)
+			err := RunFirewallRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testInputFirewallRule, &testResponse, testFirewallRuleErr)
-		err := RunFirewallRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testInputFirewallRule, &testResponse, testFirewallRuleErr)
+			err := RunFirewallRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testInputFirewallRule, nil, testFirewallRuleErr)
-		err := RunFirewallRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testInputFirewallRule, nil, testFirewallRuleErr)
+			err := RunFirewallRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testInputFirewallRule, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunFirewallRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Create(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRule,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testInputFirewallRule, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunFirewallRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testRule, &testResponse, nil)
-		err := RunFirewallRuleUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testRule, &testResponse, nil)
+			err := RunFirewallRuleUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testRule, nil, testFirewallRuleErr)
-		err := RunFirewallRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testRule, nil, testFirewallRuleErr)
+			err := RunFirewallRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testRule, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunFirewallRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testFirewallRuleProtocol)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testFirewallRulePortRangeStart)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testFirewallRulePortRangeEnd)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpCode), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIcmpType), testFirewallRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceMac), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDestinationIp), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFirewallRuleType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Update(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				testInputFirewallRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testRule, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunFirewallRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testResponse, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testResponse, nil)
+			err := RunFirewallRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFirewallRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFirewallRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunFirewallRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFirewallRulesList, nil, testFirewallRuleErr)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFirewallRulesList, nil, testFirewallRuleErr)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FirewallRules{}, &testResponse, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FirewallRules{}, &testResponse, nil)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.FirewallRules{FirewallRules: ionoscloud.FirewallRules{Items: &[]ionoscloud.FirewallRule{}}}, nil, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.FirewallRules{FirewallRules: ionoscloud.FirewallRules{Items: &[]ionoscloud.FirewallRule{}}},
+				nil, nil,
+			)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFirewallRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testFirewallRuleErr)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().List(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFirewallRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testFirewallRuleErr)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testFirewallRuleErr)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testFirewallRuleErr)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunFirewallRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FirewallRule.EXPECT().Delete(
+				testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar, testFirewallRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunFirewallRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFirewallRuleDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunFirewallRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallRuleId), testFirewallRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunFirewallRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -42,95 +42,156 @@ func FlowlogCmd() *core.Command {
 	globalFlags := flowLogCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
 	_ = viper.BindPFlag(core.GetFlagName(flowLogCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = flowLogCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = flowLogCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, flowLogCmd, core.CommandBuilder{
-		Namespace:  "flowlog",
-		Resource:   "flowlog",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List FlowLogs",
-		LongDesc:   "Use this command to get a list of FlowLogs from a specified NIC from a Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id",
-		Example:    listFlowLogExample,
-		PreCmdRun:  PreRunFlowLogList,
-		CmdRun:     RunFlowLogList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, flowLogCmd, core.CommandBuilder{
+			Namespace:  "flowlog",
+			Resource:   "flowlog",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List FlowLogs",
+			LongDesc:   "Use this command to get a list of FlowLogs from a specified NIC from a Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id",
+			Example:    listFlowLogExample,
+			PreCmdRun:  PreRunFlowLogList,
+			CmdRun:     RunFlowLogList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, flowLogCmd, core.CommandBuilder{
-		Namespace:  "flowlog",
-		Resource:   "flowlog",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a FlowLog",
-		LongDesc:   "Use this command to retrieve information of a specified FlowLog from a NIC.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id\n* FlowLog Id",
-		Example:    getFlowLogExample,
-		PreCmdRun:  PreRunDcServerNicFlowLogIds,
-		CmdRun:     RunFlowLogGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, flowLogCmd, core.CommandBuilder{
+			Namespace:  "flowlog",
+			Resource:   "flowlog",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a FlowLog",
+			LongDesc:   "Use this command to retrieve information of a specified FlowLog from a NIC.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Nic Id\n* FlowLog Id",
+			Example:    getFlowLogExample,
+			PreCmdRun:  PreRunDcServerNicFlowLogIds,
+			CmdRun:     RunFlowLogGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgServerId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNicId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, flowLogCmd, core.CommandBuilder{
-		Namespace: "flowlog",
-		Resource:  "flowlog",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a FlowLog on a NIC",
-		LongDesc: `Use this command to create a new FlowLog to the specified NIC.
+	create := core.NewCommand(
+		ctx, flowLogCmd, core.CommandBuilder{
+			Namespace: "flowlog",
+			Resource:  "flowlog",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a FlowLog on a NIC",
+			LongDesc: `Use this command to create a new FlowLog to the specified NIC.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -142,48 +203,87 @@ Required values to run command:
 * Server Id
 * Nic Id
 * Target S3 Bucket Name`,
-		Example:    createFlowLogExample,
-		PreCmdRun:  PreRunFlowLogCreate,
-		CmdRun:     RunFlowLogCreate,
-		InitClient: true,
-	})
+			Example:    createFlowLogExample,
+			PreCmdRun:  PreRunFlowLogCreate,
+			CmdRun:     RunFlowLogCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed FlowLog", "The name for the FlowLog")
 	create.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "ALL", "Specifies the traffic Action pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL", "Specifies the traffic Direction pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for FlowLog creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for FlowLog creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL",
+		"Specifies the traffic Direction pattern",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket",
+		core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for FlowLog creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for FlowLog creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, flowLogCmd, core.CommandBuilder{
-		Namespace: "flowlog",
-		Resource:  "flowlog",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a FlowLog from a NIC",
-		LongDesc: `Use this command to delete a specified FlowLog from a NIC.
+	deleteCmd := core.NewCommand(
+		ctx, flowLogCmd, core.CommandBuilder{
+			Namespace: "flowlog",
+			Resource:  "flowlog",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a FlowLog from a NIC",
+			LongDesc: `Use this command to delete a specified FlowLog from a NIC.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -193,40 +293,76 @@ Required values to run command:
 * Server Id
 * Nic Id
 * FlowLog Id`,
-		Example:    deleteFlowLogExample,
-		PreCmdRun:  PreRunFlowlogDelete,
-		CmdRun:     RunFlowLogDelete,
-		InitClient: true,
-	})
+			Example:    deleteFlowLogExample,
+			PreCmdRun:  PreRunFlowlogDelete,
+			CmdRun:     RunFlowLogDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNicId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for FlowLog deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgServerId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNicId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for FlowLog deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Flowlogs.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for FlowLog deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for FlowLog deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return flowLogCmd
 }
 
 func PreRunFlowLogList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -236,15 +372,21 @@ func PreRunFlowLogList(c *core.PreCommandConfig) error {
 }
 
 func PreRunFlowLogCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgS3Bucket)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgS3Bucket,
+	)
 }
 
 func PreRunDcServerNicFlowLogIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgFlowLogId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+		cloudapiv6.ArgFlowLogId,
+	)
 }
 
 func PreRunFlowlogDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgFlowLogId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgAll},
 	)
@@ -266,14 +408,19 @@ func RunFlowLogList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Flowlog, flowLogs.FlowLogs,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Flowlog, flowLogs.FlowLogs,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -297,18 +444,26 @@ func RunFlowLogGet(c *core.CommandConfig) error {
 	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 	flowLogId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("FlowLog with id: %v from Nic with id: %v is getting...", flowLogId, nicId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("FlowLog with id: %v from Nic with id: %v is getting...", flowLogId, nicId),
+	)
 
 	flowLog, resp, err := c.CloudApiV6Services.FlowLogs().Get(dcId, serverId, nicId, flowLogId, queryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, flowLog.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, flowLog.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -342,7 +497,10 @@ func RunFlowLogCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -352,8 +510,10 @@ func RunFlowLogCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, flowLog.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, flowLog.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -383,15 +543,23 @@ func RunFlowLogDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete flow log", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete flow log", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting FlowLog with id: %v...", flowLogId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting FlowLog with id: %v...", flowLogId),
+	)
 
 	resp, err := c.CloudApiV6Services.FlowLogs().Delete(dcId, serverId, nicId, flowLogId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -421,12 +589,16 @@ func getFlowLogPropertiesSet(c *core.CommandConfig) resources.FlowLogProperties 
 
 	direction := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection))
 	properties.SetDirection(strings.ToUpper(direction))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Direction set: %v", direction))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Direction set: %v", direction),
+	)
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgS3Bucket)) {
 		bucketName := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3Bucket))
 		properties.SetBucket(bucketName)
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Bucket set: %v", bucketName))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Bucket set: %v", bucketName),
+		)
 	}
 
 	return properties
@@ -445,19 +617,26 @@ func getFlowLogPropertiesUpdate(c *core.CommandConfig) resources.FlowLogProperti
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAction)) {
 		action := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAction))
 		properties.SetAction(strings.ToUpper(action))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Action set: %v", action))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Action set: %v", action),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDirection)) {
 		direction := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDirection))
 		properties.SetDirection(strings.ToUpper(direction))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Direction set: %v", direction))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Direction set: %v", direction),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgS3Bucket)) {
 		bucketName := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3Bucket))
 		properties.SetBucket(bucketName)
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Bucket set: %v", bucketName))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Bucket set: %v", bucketName),
+		)
 	}
 
 	return properties
@@ -479,7 +658,9 @@ func DeleteAllFlowlogs(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NIC ID: %v", nicId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Flowlogs..."))
 
-	flowlogs, resp, err := c.CloudApiV6Services.FlowLogs().List(dcId, serverId, nicId, cloudapiv6.ParentResourceListQueryParams)
+	flowlogs, resp, err := c.CloudApiV6Services.FlowLogs().List(
+		dcId, serverId, nicId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -511,7 +692,10 @@ func DeleteAllFlowlogs(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the flow logs", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the flow logs",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -524,18 +708,27 @@ func DeleteAllFlowlogs(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Flowlog with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Flowlog with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.FlowLogs().Delete(dcId, serverId, nicId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/flowlog_test.go
+++ b/commands/cloudapi-v6/flowlog_test.go
@@ -87,420 +87,525 @@ func TestFlowlogCmd(t *testing.T) {
 func TestPreRunFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		err := PreRunFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			err := PreRunFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunFlowLogListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunFlowLogListFiltersErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		err := PreRunFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			err := PreRunFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicFlowLogIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		err := PreRunDcServerNicFlowLogIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			err := PreRunDcServerNicFlowLogIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerNicFlowLogIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerNicFlowLogIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerNicFlowLogIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		err := RunFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			err := RunFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, testFlowLogErr)
-		err := RunFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, testFlowLogErr)
+			err := RunFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Get(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testFlowLogErr)
-		err := RunFlowLogGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Get(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testFlowLogErr)
+			err := RunFlowLogGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Get(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunFlowLogGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Get(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunFlowLogGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Create(testFlowLogVar, testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testInputFlowLog, &testResponse, nil)
-		err := RunFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Create(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testInputFlowLog,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testInputFlowLog, &testResponse, nil)
+			err := RunFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Create(testFlowLogVar, testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testInputFlowLog, &testResponse, testFlowLogErr)
-		err := RunFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Create(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testInputFlowLog,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testInputFlowLog, &testResponse, testFlowLogErr)
+			err := RunFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, testFlowLogErr)
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, testFlowLogErr)
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil,
+			)
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().List(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testFlowLogErr)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().List(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testFlowLogErr)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testFlowLogErr)
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testFlowLogErr)
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.FlowLog.EXPECT().Delete(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, testFlowLogVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunFlowLogDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/group.go
+++ b/commands/cloudapi-v6/group.go
@@ -24,11 +24,15 @@ import (
 )
 
 var (
-	defaultGroupCols = []string{"GroupId", "Name", "CreateDataCenter", "CreateSnapshot", "CreatePcc", "CreateBackupUnit",
-		"CreateInternetAccess", "CreateK8s", "ReserveIp"}
-	allGroupCols = []string{"GroupId", "Name", "CreateDataCenter", "CreateSnapshot", "ReserveIp", "AccessActivityLog",
+	defaultGroupCols = []string{
+		"GroupId", "Name", "CreateDataCenter", "CreateSnapshot", "CreatePcc", "CreateBackupUnit",
+		"CreateInternetAccess", "CreateK8s", "ReserveIp",
+	}
+	allGroupCols = []string{
+		"GroupId", "Name", "CreateDataCenter", "CreateSnapshot", "ReserveIp", "AccessActivityLog",
 		"CreatePcc", "S3Privilege", "CreateBackupUnit", "CreateInternetAccess", "CreateK8s", "CreateFlowLog",
-		"AccessAndManageMonitoring", "AccessAndManageCertificates", "AccessAndManageDns", "ManageDBaaS", "ManageRegistry",
+		"AccessAndManageMonitoring", "AccessAndManageCertificates", "AccessAndManageDns", "ManageDBaaS",
+		"ManageRegistry",
 		"ManageDataplatform",
 	}
 )
@@ -47,166 +51,315 @@ func GroupCmd() *core.Command {
 	globalFlags := groupCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultGroupCols, tabheaders.ColsMessage(allGroupCols))
 	_ = viper.BindPFlag(core.GetFlagName(groupCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = groupCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allGroupCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = groupCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allGroupCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, groupCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "group",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Groups",
-		LongDesc:   "Use this command to get a list of available Groups available on your account\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.GroupsFiltersUsage(),
-		Example:    listGroupExample,
-		PreCmdRun:  PreRunGroupList,
-		CmdRun:     RunGroupList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, groupCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "group",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Groups",
+			LongDesc:   "Use this command to get a list of available Groups available on your account\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.GroupsFiltersUsage(),
+			Example:    listGroupExample,
+			PreCmdRun:  PreRunGroupList,
+			CmdRun:     RunGroupList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, groupCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "group",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Group",
-		LongDesc:   "Use this command to retrieve details about a specific Group.\n\nRequired values to run command:\n\n* Group Id",
-		Example:    getGroupExample,
-		PreCmdRun:  PreRunGroupId,
-		CmdRun:     RunGroupGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, groupCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "group",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Group",
+			LongDesc:   "Use this command to retrieve details about a specific Group.\n\nRequired values to run command:\n\n* Group Id",
+			Example:    getGroupExample,
+			PreCmdRun:  PreRunGroupId,
+			CmdRun:     RunGroupGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, groupCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "group",
-		Verb:       "create",
-		Aliases:    []string{"c"},
-		ShortDesc:  "Create a Group",
-		LongDesc:   `Use this command to create a new Group and set Group privileges. You can specify the name for the new Group. By default, all privileges will be set to false. You need to use flags privileges to be set to true.`,
-		Example:    createGroupExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunGroupCreate,
-		InitClient: true,
-	})
+	create := core.NewCommand(
+		ctx, groupCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "group",
+			Verb:       "create",
+			Aliases:    []string{"c"},
+			ShortDesc:  "Create a Group",
+			LongDesc:   `Use this command to create a new Group and set Group privileges. You can specify the name for the new Group. By default, all privileges will be set to false. You need to use flags privileges to be set to true.`,
+			Example:    createGroupExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunGroupCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Group", "Name for the Group")
-	create.AddBoolFlag(cloudapiv6.ArgCreateDc, "", false, "The group will be allowed to create Data Centers. E.g.: --create-dc=true, --create-dc=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreateSnapshot, "", false, "The group will be allowed to create Snapshots. E.g.: --create-snapshot=true, --create-snapshot=false")
-	create.AddBoolFlag(cloudapiv6.ArgReserveIp, "", false, "The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false")
-	create.AddBoolFlag(cloudapiv6.ArgAccessLog, "", false, "The group will be allowed to access the activity log. E.g.: --access-logs=true, --access-logs=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreatePcc, "", false, "The group will be allowed to create PCCs. E.g.: --create-pcc=true, --create-pcc=false")
-	create.AddBoolFlag(cloudapiv6.ArgS3Privilege, "", false, "The group will be allowed to manage S3. E.g.: --s3privilege=true, --s3privilege=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreateBackUpUnit, "", false, "The group will be able to manage Backup Units. E.g.: --create-backup=true, --create-backup=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreateNic, "", false, "The group will be allowed to create NICs. E.g.: --create-nic=true, --create-nic=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreateK8s, "", false, "The group will be allowed to create K8s Clusters. E.g.: --create-k8s=true, --create-k8s=false")
-	create.AddBoolFlag(cloudapiv6.ArgCreateFlowLog, "", false, "The group will be allowed to create Flow Logs. E.g.: --create-flowlog=true, --create-flowlog=false")
-	create.AddBoolFlag(cloudapiv6.ArgAccessMonitoring, "", false, "Privilege for a group to access and manage monitoring related functionality using Monotoring-as-a-Service. E.g.: --access-monitoring=true, --access-monitoring=false")
-	create.AddBoolFlag(cloudapiv6.ArgAccessCerts, "", false, "Privilege for a group to access and manage certificates. E.g.: --access-certs=true, --access-certs=false")
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateDc, "", false,
+		"The group will be allowed to create Data Centers. E.g.: --create-dc=true, --create-dc=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateSnapshot, "", false,
+		"The group will be allowed to create Snapshots. E.g.: --create-snapshot=true, --create-snapshot=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgReserveIp, "", false,
+		"The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgAccessLog, "", false,
+		"The group will be allowed to access the activity log. E.g.: --access-logs=true, --access-logs=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreatePcc, "", false,
+		"The group will be allowed to create PCCs. E.g.: --create-pcc=true, --create-pcc=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgS3Privilege, "", false,
+		"The group will be allowed to manage S3. E.g.: --s3privilege=true, --s3privilege=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateBackUpUnit, "", false,
+		"The group will be able to manage Backup Units. E.g.: --create-backup=true, --create-backup=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateNic, "", false,
+		"The group will be allowed to create NICs. E.g.: --create-nic=true, --create-nic=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateK8s, "", false,
+		"The group will be allowed to create K8s Clusters. E.g.: --create-k8s=true, --create-k8s=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCreateFlowLog, "", false,
+		"The group will be allowed to create Flow Logs. E.g.: --create-flowlog=true, --create-flowlog=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgAccessMonitoring, "", false,
+		"Privilege for a group to access and manage monitoring related functionality using Monotoring-as-a-Service. E.g.: --access-monitoring=true, --access-monitoring=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgAccessCerts, "", false,
+		"Privilege for a group to access and manage certificates. E.g.: --access-certs=true, --access-certs=false",
+	)
 	create.AddBoolFlag(cloudapiv6.ArgAccessDNS, "", false, "Privilege for a group to access and manage dns records")
-	create.AddBoolFlag(cloudapiv6.ArgManageDbaas, "", false, "Privilege for a group to manage DBaaS related functionality")
-	create.AddBoolFlag(cloudapiv6.ArgManageDataplatform, "", false, "Privilege for a group to access and manage the Data Platform")
-	create.AddBoolFlag(cloudapiv6.ArgManageRegistry, "", false, "Privilege for group accessing container registry related functionality")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Group creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Group creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		cloudapiv6.ArgManageDbaas, "", false, "Privilege for a group to manage DBaaS related functionality",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgManageDataplatform, "", false, "Privilege for a group to access and manage the Data Platform",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgManageRegistry, "", false,
+		"Privilege for group accessing container registry related functionality",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Group creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Group creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, groupCmd, core.CommandBuilder{
-		Namespace: "group",
-		Resource:  "group",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Group",
-		LongDesc: `Use this command to update details about a specific Group.
+	update := core.NewCommand(
+		ctx, groupCmd, core.CommandBuilder{
+			Namespace: "group",
+			Resource:  "group",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Group",
+			LongDesc: `Use this command to update details about a specific Group.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Group Id`,
-		Example:    updateGroupExample,
-		PreCmdRun:  PreRunGroupId,
-		CmdRun:     RunGroupUpdate,
-		InitClient: true,
-	})
+			Example:    updateGroupExample,
+			PreCmdRun:  PreRunGroupId,
+			CmdRun:     RunGroupUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name for the Group")
-	update.AddBoolFlag(cloudapiv6.ArgCreateDc, "", false, "The group will be allowed to create Data Centers. E.g.: --create-dc=true, --create-dc=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreateSnapshot, "", false, "The group will be allowed to create Snapshots. E.g.: --create-snapshot=true, --create-snapshot=false")
-	update.AddBoolFlag(cloudapiv6.ArgReserveIp, "", false, "The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false")
-	update.AddBoolFlag(cloudapiv6.ArgAccessLog, "", false, "The group will be allowed to access the activity log. E.g.: --access-logs=true, --access-logs=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreatePcc, "", false, "The group will be allowed to create PCCs. E.g.: --create-pcc=true, --create-pcc=false")
-	update.AddBoolFlag(cloudapiv6.ArgS3Privilege, "", false, "The group will be allowed to manage S3. E.g.: --s3privilege=true, --s3privilege=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreateBackUpUnit, "", false, "The group will be able to manage Backup Units. E.g.: --create-backup=true, --create-backup=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreateNic, "", false, "The group will be allowed to create NICs. E.g.: --create-nic=true, --create-nic=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreateK8s, "", false, "The group will be allowed to create K8s Clusters. E.g.: --create-k8s=true, --create-k8s=false")
-	update.AddBoolFlag(cloudapiv6.ArgCreateFlowLog, "", false, "The group will be allowed to create Flow Logs. E.g.: --create-flowlog=true, --create-flowlog=false")
-	update.AddBoolFlag(cloudapiv6.ArgAccessMonitoring, "", false, "Privilege for a group to access and manage monitoring related functionality using Monotoring-as-a-Service. E.g.: --access-monitoring=true, --access-monitoring=false")
-	update.AddBoolFlag(cloudapiv6.ArgAccessCerts, "", false, "Privilege for a group to access and manage certificates. E.g.: --access-certs=true, --access-certs=false")
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateDc, "", false,
+		"The group will be allowed to create Data Centers. E.g.: --create-dc=true, --create-dc=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateSnapshot, "", false,
+		"The group will be allowed to create Snapshots. E.g.: --create-snapshot=true, --create-snapshot=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgReserveIp, "", false,
+		"The group will be allowed to reserve IP addresses. E.g.: --reserve-ip=true, --reserve-ip=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgAccessLog, "", false,
+		"The group will be allowed to access the activity log. E.g.: --access-logs=true, --access-logs=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreatePcc, "", false,
+		"The group will be allowed to create PCCs. E.g.: --create-pcc=true, --create-pcc=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgS3Privilege, "", false,
+		"The group will be allowed to manage S3. E.g.: --s3privilege=true, --s3privilege=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateBackUpUnit, "", false,
+		"The group will be able to manage Backup Units. E.g.: --create-backup=true, --create-backup=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateNic, "", false,
+		"The group will be allowed to create NICs. E.g.: --create-nic=true, --create-nic=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateK8s, "", false,
+		"The group will be allowed to create K8s Clusters. E.g.: --create-k8s=true, --create-k8s=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCreateFlowLog, "", false,
+		"The group will be allowed to create Flow Logs. E.g.: --create-flowlog=true, --create-flowlog=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgAccessMonitoring, "", false,
+		"Privilege for a group to access and manage monitoring related functionality using Monotoring-as-a-Service. E.g.: --access-monitoring=true, --access-monitoring=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgAccessCerts, "", false,
+		"Privilege for a group to access and manage certificates. E.g.: --access-certs=true, --access-certs=false",
+	)
 	update.AddBoolFlag(cloudapiv6.ArgAccessDNS, "", false, "Privilege for a group to access and manage dns records")
-	update.AddBoolFlag(cloudapiv6.ArgManageDbaas, "", false, "Privilege for a group to manage DBaaS related functionality")
-	update.AddBoolFlag(cloudapiv6.ArgManageDataplatform, "", false, "Privilege for a group to access and manage the Data Platform")
-	update.AddBoolFlag(cloudapiv6.ArgManageRegistry, "", false, "Privilege for group accessing container registry related functionality")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Group update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Group update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		cloudapiv6.ArgManageDbaas, "", false, "Privilege for a group to manage DBaaS related functionality",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgManageDataplatform, "", false, "Privilege for a group to access and manage the Data Platform",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgManageRegistry, "", false,
+		"Privilege for group accessing container registry related functionality",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Group update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Group update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, groupCmd, core.CommandBuilder{
-		Namespace: "group",
-		Resource:  "group",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Group",
-		LongDesc: `Use this operation to delete a single Group. Resources that are assigned to the Group are NOT deleted, but are no longer accessible to the Group members unless the member is a Contract Owner, Admin, or Resource Owner.
+	deleteCmd := core.NewCommand(
+		ctx, groupCmd, core.CommandBuilder{
+			Namespace: "group",
+			Resource:  "group",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Group",
+			LongDesc: `Use this operation to delete a single Group. Resources that are assigned to the Group are NOT deleted, but are no longer accessible to the Group members unless the member is a Contract Owner, Admin, or Resource Owner.
 
 Required values to run command:
 
 * Group Id`,
-		Example:    deleteGroupExample,
-		PreCmdRun:  PreRunGroupDelete,
-		CmdRun:     RunGroupDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Group deletion to be executed")
+			Example:    deleteGroupExample,
+			PreCmdRun:  PreRunGroupDelete,
+			CmdRun:     RunGroupDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.GroupId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Group deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Groups.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Group deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Group deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	groupCmd.AddCommand(GroupResourceCmd())
 	groupCmd.AddCommand(GroupUserCmd())
@@ -225,7 +378,8 @@ func PreRunGroupId(c *core.PreCommandConfig) error {
 }
 
 func PreRunGroupDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgGroupId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -244,7 +398,10 @@ func RunGroupList(c *core.CommandConfig) error {
 
 	groups, resp, err := c.CloudApiV6Services.Groups().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -252,8 +409,10 @@ func RunGroupList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Group, groups.Groups,
-		tabheaders.GetHeaders(allGroupCols, defaultGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Group, groups.Groups,
+		tabheaders.GetHeaders(allGroupCols, defaultGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -271,12 +430,20 @@ func RunGroupGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Group with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Group with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.Groups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.Groups().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -284,7 +451,9 @@ func RunGroupGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Group, u.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Group, u.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -310,7 +479,10 @@ func RunGroupCreate(c *core.CommandConfig) error {
 	}
 	u, resp, err := c.CloudApiV6Services.Groups().Create(newGroup, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -322,7 +494,9 @@ func RunGroupCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Group, u.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Group, u.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -339,7 +513,9 @@ func RunGroupUpdate(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	u, resp, err := c.CloudApiV6Services.Groups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.Groups().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), queryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -350,9 +526,18 @@ func RunGroupUpdate(c *core.CommandConfig) error {
 			Properties: &properties.GroupProperties,
 		},
 	}
-	groupUpd, resp, err := c.CloudApiV6Services.Groups().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), newGroup, queryParams)
+	groupUpd, resp, err := c.CloudApiV6Services.Groups().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgGroupId,
+			),
+		), newGroup, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -364,7 +549,9 @@ func RunGroupUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Group, groupUpd.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Group, groupUpd.Group, tabheaders.GetHeaders(allGroupCols, allGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -391,15 +578,23 @@ func RunGroupDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete group", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Group with id: %v...", groupId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Group with id: %v...", groupId),
+	)
 
 	resp, err := c.CloudApiV6Services.Groups().Delete(groupId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -434,13 +629,18 @@ func getGroupCreateInfo(c *core.CommandConfig) *resources.GroupProperties {
 	manageReg := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgManageRegistry))
 	manageData := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgManageDataplatform))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(),
-		jsontabwriter.GenerateVerboseOutput("Properties set for creating the group: Name: %v, CreateDatacenter: %v, CreateSnapshot: %v, "+
-			"ReserveIp: %v, AccessActivityLog: %v, CreateBackupUnit: %v, CreatePcc: %v, CreateInternetAccess: %v, CreateK8sCluster: %v, "+
-			"S3Privilege: %v, CreateFlowLog: %v, AccessAndManageMonitoring: %v, AccessAndManageCertificates: %v, AccessAndManageDns: %v,"+
-			"ManageDBaaS: %v, ManageRegistry: %v, ManageDataplatform: %v",
-			name, createDc, createSnap, reserveIp, accessLog, createBackUp, createPcc, createNic, createK8s, s3, createFlowLog, monitoring, certs,
-			dns, manageDb, manageReg, manageData))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the group: Name: %v, CreateDatacenter: %v, CreateSnapshot: %v, "+
+				"ReserveIp: %v, AccessActivityLog: %v, CreateBackupUnit: %v, CreatePcc: %v, CreateInternetAccess: %v, CreateK8sCluster: %v, "+
+				"S3Privilege: %v, CreateFlowLog: %v, AccessAndManageMonitoring: %v, AccessAndManageCertificates: %v, AccessAndManageDns: %v,"+
+				"ManageDBaaS: %v, ManageRegistry: %v, ManageDataplatform: %v",
+			name, createDc, createSnap, reserveIp, accessLog, createBackUp, createPcc, createNic, createK8s, s3,
+			createFlowLog, monitoring, certs,
+			dns, manageDb, manageReg, manageData,
+		),
+	)
 
 	return &resources.GroupProperties{
 		GroupProperties: ionoscloud.GroupProperties{
@@ -477,7 +677,9 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 			groupName = viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", groupName))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", groupName),
+			)
 		} else {
 			if name, ok := properties.GetNameOk(); ok && name != nil {
 				groupName = *name
@@ -487,7 +689,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateDc)) {
 			createDc = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateDc))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateDataCenter set: %v", createDc))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateDataCenter set: %v", createDc),
+			)
 		} else {
 			if dc, ok := properties.GetCreateDataCenterOk(); ok && dc != nil {
 				createDc = *dc
@@ -497,7 +702,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateSnapshot)) {
 			createSnap = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateSnapshot))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateSnapshot set: %v", createSnap))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateSnapshot set: %v", createSnap),
+			)
 		} else {
 			if s, ok := properties.GetCreateSnapshotOk(); ok && s != nil {
 				createSnap = *s
@@ -507,7 +715,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreatePcc)) {
 			createPcc = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreatePcc))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreatePcc set: %v", createPcc))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreatePcc set: %v", createPcc),
+			)
 		} else {
 			if s, ok := properties.GetCreatePccOk(); ok && s != nil {
 				createPcc = *s
@@ -517,7 +728,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateK8s)) {
 			createK8s = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateK8s))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateK8sCluster set: %v", createK8s))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateK8sCluster set: %v", createK8s),
+			)
 		} else {
 			if s, ok := properties.GetCreateK8sClusterOk(); ok && s != nil {
 				createK8s = *s
@@ -527,7 +741,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateNic)) {
 			createNic = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateNic))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateInternetAccess set: %v", createNic))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateInternetAccess set: %v", createNic),
+			)
 		} else {
 			if s, ok := properties.GetCreateInternetAccessOk(); ok && s != nil {
 				createNic = *s
@@ -537,7 +754,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateBackUpUnit)) {
 			createBackUp = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateBackUpUnit))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateBackupUnit set: %v", createBackUp))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateBackupUnit set: %v", createBackUp),
+			)
 		} else {
 			if s, ok := properties.GetCreateBackupUnitOk(); ok && s != nil {
 				createBackUp = *s
@@ -547,7 +767,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgReserveIp)) {
 			reserveIp = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgReserveIp))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ReserveIp set: %v", reserveIp))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property ReserveIp set: %v", reserveIp),
+			)
 		} else {
 			if ip, ok := properties.GetReserveIpOk(); ok && ip != nil {
 				reserveIp = *ip
@@ -557,7 +780,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAccessLog)) {
 			accessLog = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAccessLog))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AccessActivityLog set: %v", accessLog))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property AccessActivityLog set: %v", accessLog),
+			)
 		} else {
 			if log, ok := properties.GetAccessActivityLogOk(); ok && log != nil {
 				accessLog = *log
@@ -567,7 +793,9 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgS3Privilege)) {
 			s3 = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgS3Privilege))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property S3Privilege set: %v", s3))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property S3Privilege set: %v", s3),
+			)
 		} else {
 			if s, ok := properties.GetS3PrivilegeOk(); ok && s != nil {
 				s3 = *s
@@ -577,7 +805,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCreateFlowLog)) {
 			createFlowLog = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCreateFlowLog))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CreateFlowLog set: %v", createFlowLog))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property CreateFlowLog set: %v", createFlowLog),
+			)
 		} else {
 			if f, ok := properties.GetCreateFlowLogOk(); ok && f != nil {
 				createFlowLog = *f
@@ -587,7 +818,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAccessMonitoring)) {
 			monitoring = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAccessMonitoring))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AccessAndManageMonitoring set: %v", monitoring))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property AccessAndManageMonitoring set: %v", monitoring),
+			)
 		} else {
 			if m, ok := properties.GetAccessAndManageMonitoringOk(); ok && m != nil {
 				monitoring = *m
@@ -597,7 +831,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAccessCerts)) {
 			certs = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAccessCerts))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AccessAndManageCertificates set: %v", certs))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property AccessAndManageCertificates set: %v", certs),
+			)
 		} else {
 			if accessCerts, ok := properties.GetAccessAndManageCertificatesOk(); ok && accessCerts != nil {
 				certs = *accessCerts
@@ -607,7 +844,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAccessDNS)) {
 			dns = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAccessDNS))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AccessAndManageDNS set: %v", dns))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property AccessAndManageDNS set: %v", dns),
+			)
 		} else {
 			if accessDns, ok := properties.GetAccessAndManageDnsOk(); ok && accessDns != nil {
 				dns = *accessDns
@@ -617,7 +857,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgManageDbaas)) {
 			manageDb = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgManageDbaas))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ManageDBaaS set: %v", manageDb))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property ManageDBaaS set: %v", manageDb),
+			)
 		} else {
 			if manageDBaaSOk, ok := properties.GetManageDBaaSOk(); ok && manageDBaaSOk != nil {
 				manageDb = *manageDBaaSOk
@@ -627,7 +870,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgManageRegistry)) {
 			manageReg = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgManageRegistry))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ManageRegistry set: %v", manageReg))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property ManageRegistry set: %v", manageReg),
+			)
 		} else {
 			if manageRegistry, ok := properties.GetManageRegistryOk(); ok && manageRegistry != nil {
 				manageReg = *manageRegistry
@@ -637,7 +883,10 @@ func getGroupUpdateInfo(oldGroup *resources.Group, c *core.CommandConfig) *resou
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgManageDataplatform)) {
 			manageData = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgManageDataplatform))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ManageDataplatform set: %v", manageData))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property ManageDataplatform set: %v", manageData),
+			)
 		} else {
 			if manageDataplatform, ok := properties.GetManageDataplatformOk(); ok && manageDataplatform != nil {
 				manageData = *manageDataplatform
@@ -709,7 +958,10 @@ func DeleteAllGroups(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Groups", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Groups",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -722,18 +974,27 @@ func DeleteAllGroups(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Group with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Group with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Groups().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/group_test.go
+++ b/commands/cloudapi-v6/group_test.go
@@ -130,551 +130,696 @@ func TestGroupCmd(t *testing.T) {
 func TestPreRunGroupList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("name=%s", testQueryParamVar)})
-		err := PreRunGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("name=%s", testQueryParamVar)},
+			)
+			err := PreRunGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunGroupList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunGroupList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		err := PreRunGroupId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			err := PreRunGroupId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunGroupId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunGroupId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupUserIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testGroupVar)
-		err := PreRunGroupUserIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testGroupVar)
+			err := PreRunGroupUserIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunGroupUserIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunGroupUserIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunGroupUserIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groups, &testResponse, nil)
-		err := RunGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groups, &testResponse, nil,
+			)
+			err := RunGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Groups{}, &testResponse, nil)
-		err := RunGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Groups{}, &testResponse, nil,
+			)
+			err := RunGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groups, nil, testGroupErr)
-		err := RunGroupList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groups, nil, testGroupErr,
+			)
+			err := RunGroupList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, &testResponse, nil)
-		err := RunGroupGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, &testResponse, nil)
+			err := RunGroupGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, nil, testGroupErr)
-		err := RunGroupGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, nil, testGroupErr)
+			err := RunGroupGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupGetResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, &testResponse, nil)
-		err := RunGroupGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, &testResponse, nil)
+			err := RunGroupGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Create(groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, &testResponse, nil)
-		err := RunGroupCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Create(
+				groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, &testResponse, nil)
+			err := RunGroupCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Create(groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, &testResponse, nil)
-		err := RunGroupCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Create(
+				groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, &testResponse, nil)
+			err := RunGroupCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Create(groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, nil, testGroupErr)
-		err := RunGroupCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Create(
+				groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, nil, testGroupErr)
+			err := RunGroupCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Create(groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunGroupCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Create(
+				groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunGroupCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolNewVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTestNew, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Update(testGroupVar, groupTestNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupNew, &testResponse, nil)
-		err := RunGroupUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateNic), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateK8s), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateDc), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreatePcc), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateSnapshot), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateBackUpUnit), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgReserveIp), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessLog), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Privilege), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCreateFlowLog), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessMonitoring), testGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAccessCerts), testGroupBoolNewVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTestNew, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().Update(
+				testGroupVar, groupTestNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupNew, &testResponse, nil)
+			err := RunGroupUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUpdateOld(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Update(testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, nil)
-		err := RunGroupUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().Update(
+				testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, nil)
+			err := RunGroupUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Update(testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, testGroupErr)
-		err := RunGroupUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().Update(
+				testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, testGroupErr)
+			err := RunGroupUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Update(testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunGroupUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().Update(
+				testGroupVar, groupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunGroupUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Get(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&groupTest, nil, testGroupErr)
-		err := RunGroupUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Get(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&groupTest, nil, testGroupErr)
+			err := RunGroupUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groupsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groupsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groupsList, nil, testGroupErr)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groupsList, nil, testGroupErr,
+			)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Groups{}, &testResponse, nil)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Groups{}, &testResponse, nil,
+			)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Groups{Groups: ionoscloud.Groups{Items: &[]ionoscloud.Group{}}}, &testResponse, nil)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Groups{Groups: ionoscloud.Groups{Items: &[]ionoscloud.Group{}}}, &testResponse, nil,
+			)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groupsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testGroupErr)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groupsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testGroupErr)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testGroupErr)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testGroupErr)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testGroupErr)
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testGroupErr)
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Group.EXPECT().Delete(testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Group.EXPECT().Delete(
+				testGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupRemoveGroupAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -39,8 +39,13 @@ import (
 )
 
 var (
-	defaultImageCols = []string{"ImageId", "Name", "ImageAliases", "Location", "LicenceType", "ImageType", "CloudInit", "CreatedDate"}
-	allImageCols     = []string{"ImageId", "Name", "ImageAliases", "Location", "Size", "LicenceType", "ImageType", "Description", "Public", "CloudInit", "CreatedDate", "CreatedBy", "CreatedByUserId"}
+	defaultImageCols = []string{
+		"ImageId", "Name", "ImageAliases", "Location", "LicenceType", "ImageType", "CloudInit", "CreatedDate",
+	}
+	allImageCols = []string{
+		"ImageId", "Name", "ImageAliases", "Location", "Size", "LicenceType", "ImageType", "Description", "Public",
+		"CloudInit", "CreatedDate", "CreatedBy", "CreatedByUserId",
+	}
 )
 
 func ImageCmd() *core.Command {
@@ -57,110 +62,180 @@ func ImageCmd() *core.Command {
 	globalFlags := imageCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultImageCols, tabheaders.ColsMessage(allImageCols))
 	_ = viper.BindPFlag(core.GetFlagName(imageCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = imageCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allImageCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = imageCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allImageCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
-		Namespace:  "image",
-		Resource:   "image",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Images",
-		LongDesc:   "Use this command to get a full list of available public Images.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ImagesFiltersUsage(),
-		Example:    listImagesExample,
-		PreCmdRun:  PreRunImageList,
-		CmdRun:     RunImageList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, imageCmd, core.CommandBuilder{
+			Namespace:  "image",
+			Resource:   "image",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Images",
+			LongDesc:   "Use this command to get a full list of available public Images.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ImagesFiltersUsage(),
+			Example:    listImagesExample,
+			PreCmdRun:  PreRunImageList,
+			CmdRun:     RunImageList,
+			InitClient: true,
+		},
+	)
 
 	deprecatedMessage := "incompatible with --max-results. Use --filters --order-by --max-results options instead!"
 
-	list.AddStringFlag(constants.FlagType, "", "", "The type of the Image", core.DeprecatedFlagOption(deprecatedMessage))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"CDROM", "HDD"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringFlag(cloudapiv6.ArgLicenceType, "", "", "The licence type of the Image", core.DeprecatedFlagOption(deprecatedMessage))
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLicenceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return constants.EnumLicenceType, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "", "The location of the Image", core.DeprecatedFlagOption(deprecatedMessage))
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringFlag(cloudapiv6.ArgImageAlias, "", "", "Image Alias or part of Image Alias to sort Images by", core.DeprecatedFlagOption(deprecatedMessage))
-	list.AddIntFlag(cloudapiv6.ArgLatest, "", 0, "Show the latest N Images, based on creation date, starting from now in descending order. If it is not set, all Images will be printed", core.DeprecatedFlagOption("Use --filters --order-by --max-results options instead!"))
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list.AddStringFlag(
+		constants.FlagType, "", "", "The type of the Image", core.DeprecatedFlagOption(deprecatedMessage),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"CDROM", "HDD"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringFlag(
+		cloudapiv6.ArgLicenceType, "", "", "The licence type of the Image", core.DeprecatedFlagOption(deprecatedMessage),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLicenceType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return constants.EnumLicenceType, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringFlag(
+		cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "", "The location of the Image",
+		core.DeprecatedFlagOption(deprecatedMessage),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringFlag(
+		cloudapiv6.ArgImageAlias, "", "", "Image Alias or part of Image Alias to sort Images by",
+		core.DeprecatedFlagOption(deprecatedMessage),
+	)
+	list.AddIntFlag(
+		cloudapiv6.ArgLatest, "", 0,
+		"Show the latest N Images, based on creation date, starting from now in descending order. If it is not set, all Images will be printed",
+		core.DeprecatedFlagOption("Use --filters --order-by --max-results options instead!"),
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImagesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
-		Namespace:  "image",
-		Resource:   "image",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a specified Image",
-		LongDesc:   "Use this command to get information about a specified Image.\n\nRequired values to run command:\n\n* Image Id",
-		Example:    getImageExample,
-		PreCmdRun:  PreRunImageId,
-		CmdRun:     RunImageGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, imageCmd, core.CommandBuilder{
+			Namespace:  "image",
+			Resource:   "image",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a specified Image",
+			LongDesc:   "Use this command to get information about a specified Image.\n\nRequired values to run command:\n\n* Image Id",
+			Example:    getImageExample,
+			PreCmdRun:  PreRunImageId,
+			CmdRun:     RunImageGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgImageId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
-	update := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
-		Namespace:  "image",
-		Resource:   "image",
-		Verb:       "update",
-		Aliases:    []string{"u", "up"},
-		ShortDesc:  "Update a specified Image",
-		LongDesc:   "Use this command to update information about a specified Image.\n\nRequired values to run command:\n\n* Image Id",
-		Example:    "ionosctl image update --image-id IMAGE_ID",
-		PreCmdRun:  PreRunImageId,
-		CmdRun:     RunImageUpdate,
-		InitClient: true,
-	})
+	update := core.NewCommand(
+		ctx, imageCmd, core.CommandBuilder{
+			Namespace:  "image",
+			Resource:   "image",
+			Verb:       "update",
+			Aliases:    []string{"u", "up"},
+			ShortDesc:  "Update a specified Image",
+			LongDesc:   "Use this command to update information about a specified Image.\n\nRequired values to run command:\n\n* Image Id",
+			Example:    "ionosctl image update --image-id IMAGE_ID",
+			PreCmdRun:  PreRunImageId,
+			CmdRun:     RunImageUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			return request.Filter("public", "false")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgImageId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					return request.Filter("public", "false")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	update.Command.Flags().SortFlags = false // Hot Plugs generate a lot of flags to scroll through, put them at the end
 
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Image update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Image update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Image update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Image update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	addPropertiesFlags := func(command *core.Command) {
 		command.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Image")
 		command.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Image")
-		command.AddSetFlag(cloudapiv6.ArgLicenceType, "", "UNKNOWN", constants.EnumLicenceType, "The OS type of this image")
+		command.AddSetFlag(
+			cloudapiv6.ArgLicenceType, "", "UNKNOWN", constants.EnumLicenceType, "The OS type of this image",
+		)
 		command.AddSetFlag(constants.FlagCloudInit, "", "V1", []string{"V1", "NONE"}, "Cloud init compatibility")
-		command.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", true, "'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
+		command.AddBoolFlag(
+			cloudapiv6.ArgCpuHotPlug, "", true,
+			"'Hot-Plug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug",
+		)
 		command.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", true, "'Hot-Plug' RAM")
 		command.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", true, "'Hot-Plug' NIC")
 		command.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", true, "'Hot-Plug' Virt-IO drive")
 		command.AddBoolFlag(cloudapiv6.ArgDiscScsiHotPlug, "", true, "'Hot-Plug' SCSI drive")
-		command.AddBoolFlag(cloudapiv6.ArgCpuHotUnplug, "", false, "'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug")
+		command.AddBoolFlag(
+			cloudapiv6.ArgCpuHotUnplug, "", false,
+			"'Hot-Unplug' CPU. It is not possible to have a hot-unplug CPU which you previously did not hot-plug",
+		)
 		command.AddBoolFlag(cloudapiv6.ArgRamHotUnplug, "", false, "'Hot-Unplug' RAM")
 		command.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "'Hot-Unplug' NIC")
 		command.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "'Hot-Unplug' Virt-IO drive")
@@ -172,29 +247,47 @@ func ImageCmd() *core.Command {
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
-		Namespace:  "image",
-		Resource:   "image",
-		Verb:       "delete",
-		Aliases:    []string{"d"},
-		ShortDesc:  "Delete an image",
-		LongDesc:   "Use this command to delete a specified Image.\n\nRequired values to run command:\n\n* Image Id",
-		Example:    "ionosctl image delete --image-id IMAGE_ID",
-		PreCmdRun:  PreRunImageDelete,
-		CmdRun:     RunImageDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			return request.Filter("public", "false")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+	deleteCmd := core.NewCommand(
+		ctx, imageCmd, core.CommandBuilder{
+			Namespace:  "image",
+			Resource:   "image",
+			Verb:       "delete",
+			Aliases:    []string{"d"},
+			ShortDesc:  "Delete an image",
+			LongDesc:   "Use this command to delete a specified Image.\n\nRequired values to run command:\n\n* Image Id",
+			Example:    "ionosctl image delete --image-id IMAGE_ID",
+			PreCmdRun:  PreRunImageDelete,
+			CmdRun:     RunImageDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgImageId, cloudapiv6.ArgIdShort, "", cloudapiv6.ImageId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgImageId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(request ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					return request.Filter("public", "false")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all non-public images")
 
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Image update to be executed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Image update [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Image update to be executed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Image update [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		upload Command
@@ -203,26 +296,52 @@ func ImageCmd() *core.Command {
 		- ftp://ftp-fkb.ionos.com/iso-images
 		https://docs.ionos.com/cloud/compute-engine/block-storage/block-storage-faq#how-do-i-upload-my-own-images-with-ftp
 	*/
-	upload := core.NewCommand(ctx, imageCmd, core.CommandBuilder{
-		Namespace:  "image",
-		Resource:   "image",
-		Verb:       "upload",
-		Aliases:    []string{"ftp-upload", "ftp", "upl"},
-		ShortDesc:  "Upload an image to FTP server",
-		LongDesc:   "Use this command to upload an HDD or ISO image.\n\nRequired values to run command:\n\n* Location\n",
-		Example:    "ionosctl img u -i kolibri.iso -l fkb,fra,vit",
-		PreCmdRun:  PreRunImageUpload,
-		CmdRun:     RunImageUpload,
-		InitClient: true,
-	})
-	upload.AddStringSliceFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, nil, "Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit", core.RequiredFlagOption())
-	upload.AddStringSliceFlag("image", "i", nil, "Slice of paths to images, can be absolute path or relative to current working directory", core.RequiredFlagOption())
-	upload.AddStringFlag("ftp-url", "", "ftp-%s.ionos.com", "URL of FTP server, with %s flag if location is embedded into url")
-	upload.AddBoolFlag(constants.FlagSkipVerify, "", false, "Skip verification of server certificate, useful if using a custom ftp-url. WARNING: You can be the target of a man-in-the-middle attack!")
-	upload.AddBoolFlag("skip-update", "", false, "After the image is uploaded to the FTP server, send a PATCH to the API with the contents of the image properties flags and emulate a \"create\" command.")
-	upload.AddStringFlag("crt-path", "", "", "(Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.")
-	upload.AddStringSliceFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, nil, "Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path")
-	upload.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, 300, "(seconds) Context Deadline. FTP connection will time out after this many seconds")
+	upload := core.NewCommand(
+		ctx, imageCmd, core.CommandBuilder{
+			Namespace:  "image",
+			Resource:   "image",
+			Verb:       "upload",
+			Aliases:    []string{"ftp-upload", "ftp", "upl"},
+			ShortDesc:  "Upload an image to FTP server",
+			LongDesc:   "Use this command to upload an HDD or ISO image.\n\nRequired values to run command:\n\n* Location\n",
+			Example:    "ionosctl img u -i kolibri.iso -l fkb,fra,vit",
+			PreCmdRun:  PreRunImageUpload,
+			CmdRun:     RunImageUpload,
+			InitClient: true,
+		},
+	)
+	upload.AddStringSliceFlag(
+		cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, nil,
+		"Location to upload to. Must be an array containing only fra, fkb, txl, lhr, las, ewr, vit",
+		core.RequiredFlagOption(),
+	)
+	upload.AddStringSliceFlag(
+		"image", "i", nil, "Slice of paths to images, can be absolute path or relative to current working directory",
+		core.RequiredFlagOption(),
+	)
+	upload.AddStringFlag(
+		"ftp-url", "", "ftp-%s.ionos.com", "URL of FTP server, with %s flag if location is embedded into url",
+	)
+	upload.AddBoolFlag(
+		constants.FlagSkipVerify, "", false,
+		"Skip verification of server certificate, useful if using a custom ftp-url. WARNING: You can be the target of a man-in-the-middle attack!",
+	)
+	upload.AddBoolFlag(
+		"skip-update", "", false,
+		"After the image is uploaded to the FTP server, send a PATCH to the API with the contents of the image properties flags and emulate a \"create\" command.",
+	)
+	upload.AddStringFlag(
+		"crt-path", "", "",
+		"(Unneeded for IONOS FTP Servers) Path to file containing server certificate. If your FTP server is self-signed, you need to add the server certificate to the list of certificate authorities trusted by the client.",
+	)
+	upload.AddStringSliceFlag(
+		cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, nil,
+		"Rename the uploaded images. These names should not contain any extension. By default, this is the base of the image path",
+	)
+	upload.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, 300,
+		"(seconds) Context Deadline. FTP connection will time out after this many seconds",
+	)
 
 	addPropertiesFlags(upload)
 
@@ -252,16 +371,24 @@ func RunImageDelete(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete image", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete image", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	imgId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deletion on image with ID: %v...", imgId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deletion on image with ID: %v...", imgId),
+	)
 
 	resp, err := c.CloudApiV6Services.Images().Delete(imgId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -284,13 +411,17 @@ func getNonPublicImages(imgs []ionoscloud.Image, verboseOut io.Writer) ([]ionosc
 	for _, i := range imgs {
 		properties, ok := i.GetPropertiesOk()
 		if !ok {
-			fmt.Fprintf(verboseOut, jsontabwriter.GenerateVerboseOutput("skipping %s: properties are nil\n", *i.GetId()))
+			fmt.Fprintf(
+				verboseOut, jsontabwriter.GenerateVerboseOutput("skipping %s: properties are nil\n", *i.GetId()),
+			)
 			continue
 		}
 
 		isPublic, ok := properties.GetPublicOk()
 		if !ok {
-			fmt.Fprintf(verboseOut, jsontabwriter.GenerateVerboseOutput("skipping %s: field `public` is nil\n", *i.GetId()))
+			fmt.Fprintf(
+				verboseOut, jsontabwriter.GenerateVerboseOutput("skipping %s: field `public` is nil\n", *i.GetId()),
+			)
 			continue
 		}
 
@@ -341,7 +472,10 @@ func DeleteAllNonPublicImages(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the images", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the images",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -350,18 +484,28 @@ func DeleteAllNonPublicImages(c *core.CommandConfig) error {
 	var multiErr error
 	for _, img := range items {
 		if id, ok := img.GetIdOk(); ok && id != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting image with id: %v...", *id))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Starting deleting image with id: %v...", *id),
+			)
 
 			resp, err = c.CloudApiV6Services.Images().Delete(*id, resources.QueryParams{})
 			if resp != nil && request.GetId(resp) != "" {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+						constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime,
+					),
+				)
 			}
 			if err != nil {
 				multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 				continue
 			}
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+			)
 
 			if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 				multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -389,62 +533,67 @@ func getDesiredImageAfterPatch(c *core.CommandConfig, useUnsetFlags bool) resour
 		flagTraverser = c.Command.Command.Flags().VisitAll
 	}
 
-	flagTraverser(func(flag *pflag.Flag) {
-		val := flag.Value.String()
-		if val == "" {
-			return
-		}
-		boolval, _ := strconv.ParseBool(val)
-		switch flag.Name {
-		case cloudapiv6.ArgName:
-			input.SetName(val)
-			break
-		case cloudapiv6.ArgDescription:
-			input.SetDescription(val)
-			break
-		case "cloud-init":
-			input.SetCloudInit(val)
-			break
-		case cloudapiv6.ArgLicenceType:
-			input.SetLicenceType(val)
-			break
-		case cloudapiv6.ArgCpuHotPlug:
-			input.SetCpuHotPlug(boolval)
-			break
-		case cloudapiv6.ArgRamHotPlug:
-			input.SetRamHotPlug(boolval)
-			break
-		case cloudapiv6.ArgNicHotPlug:
-			input.SetNicHotPlug(boolval)
-			break
-		case cloudapiv6.ArgDiscVirtioHotPlug:
-			input.SetDiscVirtioHotPlug(boolval)
-			break
-		case cloudapiv6.ArgDiscScsiHotPlug:
-			input.SetDiscScsiHotPlug(boolval)
-			break
-		case cloudapiv6.ArgCpuHotUnplug:
-			input.SetCpuHotUnplug(boolval)
-			break
-		case cloudapiv6.ArgRamHotUnplug:
-			input.SetRamHotUnplug(boolval)
-			break
-		case cloudapiv6.ArgNicHotUnplug:
-			input.SetNicHotUnplug(boolval)
-			break
-		case cloudapiv6.ArgDiscVirtioHotUnplug:
-			input.SetDiscVirtioHotUnplug(boolval)
-			break
-		case cloudapiv6.ArgDiscScsiHotUnplug:
-			input.SetDiscScsiHotUnplug(boolval)
-			break
-		default:
-			// --image-id, verbose, filters, depth, etc
-			break
-		}
+	flagTraverser(
+		func(flag *pflag.Flag) {
+			val := flag.Value.String()
+			if val == "" {
+				return
+			}
+			boolval, _ := strconv.ParseBool(val)
+			switch flag.Name {
+			case cloudapiv6.ArgName:
+				input.SetName(val)
+				break
+			case cloudapiv6.ArgDescription:
+				input.SetDescription(val)
+				break
+			case "cloud-init":
+				input.SetCloudInit(val)
+				break
+			case cloudapiv6.ArgLicenceType:
+				input.SetLicenceType(val)
+				break
+			case cloudapiv6.ArgCpuHotPlug:
+				input.SetCpuHotPlug(boolval)
+				break
+			case cloudapiv6.ArgRamHotPlug:
+				input.SetRamHotPlug(boolval)
+				break
+			case cloudapiv6.ArgNicHotPlug:
+				input.SetNicHotPlug(boolval)
+				break
+			case cloudapiv6.ArgDiscVirtioHotPlug:
+				input.SetDiscVirtioHotPlug(boolval)
+				break
+			case cloudapiv6.ArgDiscScsiHotPlug:
+				input.SetDiscScsiHotPlug(boolval)
+				break
+			case cloudapiv6.ArgCpuHotUnplug:
+				input.SetCpuHotUnplug(boolval)
+				break
+			case cloudapiv6.ArgRamHotUnplug:
+				input.SetRamHotUnplug(boolval)
+				break
+			case cloudapiv6.ArgNicHotUnplug:
+				input.SetNicHotUnplug(boolval)
+				break
+			case cloudapiv6.ArgDiscVirtioHotUnplug:
+				input.SetDiscVirtioHotUnplug(boolval)
+				break
+			case cloudapiv6.ArgDiscScsiHotUnplug:
+				input.SetDiscScsiHotUnplug(boolval)
+				break
+			default:
+				// --image-id, verbose, filters, depth, etc
+				break
+			}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property %s set: %s", flag.Name, flag.Value))
-	})
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property %s set: %s", flag.Name, flag.Value),
+			)
+		},
+	)
 	return input
 }
 
@@ -462,7 +611,10 @@ func RunImageUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -474,8 +626,10 @@ func RunImageUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Image, img.Image,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Image, img.Image,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -494,9 +648,11 @@ func PreRunImageUpload(c *core.PreCommandConfig) error {
 	validExts := []string{".iso", ".img", ".vmdk", ".vhd", ".vhdx", ".cow", ".qcow", ".qcow2", ".raw", ".vpc", ".vdi"}
 	images := viper.GetStringSlice(core.GetFlagName(c.NS, "image"))
 	invalidImages := functional.Filter(
-		functional.Map(images, func(s string) string {
-			return filepath.Ext(s)
-		}),
+		functional.Map(
+			images, func(s string) string {
+				return filepath.Ext(s)
+			},
+		),
 		func(ext string) bool {
 			return !slices.Contains(
 				validExts,
@@ -505,7 +661,9 @@ func PreRunImageUpload(c *core.PreCommandConfig) error {
 		},
 	)
 	if len(invalidImages) > 0 {
-		return fmt.Errorf("%s is an invalid image extension. Valid extensions are: %s", strings.Join(invalidImages, ","), validExts)
+		return fmt.Errorf(
+			"%s is an invalid image extension. Valid extensions are: %s", strings.Join(invalidImages, ","), validExts,
+		)
 	}
 
 	// "Locations" flag only required if ftp-url custom flag contains a %s in which to add the location ID
@@ -528,7 +686,11 @@ func PreRunImageUpload(c *core.PreCommandConfig) error {
 		},
 	)
 	if len(invalidLocs) > 0 {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("WARN: %s is an invalid location. Valid IONOS locations are: %s", strings.Join(invalidLocs, ","), locs))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"WARN: %s is an invalid location. Valid IONOS locations are: %s", strings.Join(invalidLocs, ","), locs,
+			),
+		)
 	}
 
 	aliases := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias))
@@ -558,11 +720,15 @@ func getCertificate(path string) (*x509.CertPool, error) {
 	return caCertPool, nil
 }
 
-func updateImagesAfterUpload(c *core.CommandConfig, diffImgs []ionoscloud.Image, properties resources.ImageProperties) ([]ionoscloud.Image, error) {
+func updateImagesAfterUpload(
+	c *core.CommandConfig, diffImgs []ionoscloud.Image, properties resources.ImageProperties,
+) ([]ionoscloud.Image, error) {
 	// do a patch on the uploaded images
 	var imgs []ionoscloud.Image
 	for _, diffImg := range diffImgs {
-		img, _, err := client.Must().CloudClient.ImagesApi.ImagesPatch(c.Context, *diffImg.GetId()).Image(properties.ImageProperties).Execute()
+		img, _, err := client.Must().CloudClient.ImagesApi.ImagesPatch(
+			c.Context, *diffImg.GetId(),
+		).Image(properties.ImageProperties).Execute()
 		imgs = append(imgs, img)
 		if err != nil {
 			return nil, err
@@ -592,13 +758,21 @@ func getDiffUploadedImages(c *core.CommandConfig, names, locations []string) ([]
 			if err != nil {
 				return nil, fmt.Errorf("failed listing images")
 			}
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Got images by listing: %+v", *imgs.Items))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Got images by listing: %+v", *imgs.Items),
+			)
 
 			diffImgs = append(diffImgs, *imgs.Items...)
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Total images: %+v", diffImgs))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Total images: %+v", diffImgs),
+			)
 
 			if len(diffImgs) == len(names)*len(locations) {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Success! All images found via API: %+v", diffImgs))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Success! All images found via API: %+v", diffImgs),
+				)
 				return diffImgs, nil
 			}
 
@@ -619,7 +793,9 @@ func RunImageUpload(c *core.CommandConfig) error {
 	locations := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgLocation))
 	skipVerify := viper.GetBool(core.GetFlagName(c.NS, constants.FlagSkipVerify))
 
-	ctx, cancel := context.WithTimeout(c.Context, time.Duration(viper.GetInt(core.GetFlagName(c.NS, constants.ArgTimeout)))*time.Second)
+	ctx, cancel := context.WithTimeout(
+		c.Context, time.Duration(viper.GetInt(core.GetFlagName(c.NS, constants.ArgTimeout)))*time.Second,
+	)
 	defer cancel()
 	c.Context = ctx
 
@@ -631,7 +807,9 @@ func RunImageUpload(c *core.CommandConfig) error {
 			if strings.Contains(url, "%s") {
 				url = fmt.Sprintf(url, loc) // Add the location modifier, if the URL supports it
 			}
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Uploading %s to %s", img, url))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Uploading %s to %s", img, url),
+			)
 
 			var isoOrHdd string
 			if ext := filepath.Ext(img); ext == ".iso" || ext == ".img" {
@@ -655,19 +833,23 @@ func RunImageUpload(c *core.CommandConfig) error {
 			data := bufio.NewReader(file)
 			// Catching error from goroutines. https://stackoverflow.com/questions/62387307/how-to-catch-errors-from-goroutines
 			// Uploads each image to each location.
-			eg.Go(func() error {
-				err := c.CloudApiV6Services.Images().Upload(
-					c.Context,
-					resources.UploadProperties{
-						FTPServerProperties: resources.FTPServerProperties{Url: url, Port: 21, SkipVerify: skipVerify, ServerCertificate: certPool},
-						ImageFileProperties: resources.ImageFileProperties{Path: serverFilePath, DataBuffer: data},
-					},
-				)
-				if err != nil {
-					return err
-				}
-				return file.Close()
-			})
+			eg.Go(
+				func() error {
+					err := c.CloudApiV6Services.Images().Upload(
+						c.Context,
+						resources.UploadProperties{
+							FTPServerProperties: resources.FTPServerProperties{
+								Url: url, Port: 21, SkipVerify: skipVerify, ServerCertificate: certPool,
+							},
+							ImageFileProperties: resources.ImageFileProperties{Path: serverFilePath, DataBuffer: data},
+						},
+					)
+					if err != nil {
+						return err
+					}
+					return file.Close()
+				},
+			)
 		}
 	}
 	if err := eg.Wait(); err != nil {
@@ -675,7 +857,9 @@ func RunImageUpload(c *core.CommandConfig) error {
 	}
 
 	if viper.GetBool(core.GetFlagName(c.NS, "skip-update")) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Successfully uploaded images"))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Successfully uploaded images"),
+		)
 		return nil
 	}
 
@@ -684,9 +868,11 @@ func RunImageUpload(c *core.CommandConfig) error {
 		// Returns a slice containing `alias[i] + filepath.Ext(images[i])`
 		// (i.e it gets the extensions from `images` flag, and appends them to each elem `image-alias`)
 		// Resulting slice is the full image names, as returned by `ionosctl image list` on the Name column
-		names = functional.MapIdx(aliases, func(k int, v string) string {
-			return v + filepath.Ext(images[k])
-		})
+		names = functional.MapIdx(
+			aliases, func(k int, v string) string {
+				return v + filepath.Ext(images[k])
+			},
+		)
 	}
 	diffImgs, err := getDiffUploadedImages(c, names, locations) // Get UUIDs of uploaded images
 	if err != nil {
@@ -699,13 +885,17 @@ func RunImageUpload(c *core.CommandConfig) error {
 		return fmt.Errorf("failed updating image with given properties, but uploading to FTP sucessful: %w", err)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Successfully uploaded and updated images"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Successfully uploaded and updated images"),
+	)
 	// oh my lord, we need to get rid of the `resources` wrappers...
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Image, imgs,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Image, imgs,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -735,7 +925,10 @@ func RunImageList(c *core.CommandConfig) error {
 
 	images, resp, err := c.CloudApiV6Services.Images().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -746,7 +939,9 @@ func RunImageList(c *core.CommandConfig) error {
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType)) {
-		images = sortImagesByLicenceType(images, strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType))))
+		images = sortImagesByLicenceType(
+			images, strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType))),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagType)) {
@@ -769,8 +964,10 @@ func RunImageList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Image, images.Images,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Image, images.Images,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -787,11 +984,20 @@ func RunImageGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Image with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Image with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)),
+		),
+	)
 
-	img, resp, err := c.CloudApiV6Services.Images().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)), queryParams)
+	img, resp, err := c.CloudApiV6Services.Images().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -799,8 +1005,10 @@ func RunImageGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Image, img.Image,
-		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Image, img.Image,
+		tabheaders.GetHeaders(allImageCols, defaultImageCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -883,9 +1091,11 @@ func sortImagesByTime(images resources.Images, n int) resources.Images {
 		imageItems := *items
 		if len(imageItems) > 0 {
 			// Sort Requests using time.Time, in descending order
-			sort.SliceStable(imageItems, func(i, j int) bool {
-				return imageItems[i].Metadata.CreatedDate.Time.After(imageItems[j].Metadata.CreatedDate.Time)
-			})
+			sort.SliceStable(
+				imageItems, func(i, j int) bool {
+					return imageItems[i].Metadata.CreatedDate.Time.After(imageItems[j].Metadata.CreatedDate.Time)
+				},
+			)
 		}
 		if len(imageItems) >= n {
 			imageItems = imageItems[:n]

--- a/commands/cloudapi-v6/ipblock.go
+++ b/commands/cloudapi-v6/ipblock.go
@@ -40,143 +40,213 @@ func IpblockCmd() *core.Command {
 	globalFlags := ipblockCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultIpBlockCols, tabheaders.ColsMessage(defaultIpBlockCols))
 	_ = viper.BindPFlag(core.GetFlagName(ipblockCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = ipblockCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultIpBlockCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = ipblockCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultIpBlockCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, ipblockCmd, core.CommandBuilder{
-		Namespace:  "ipblock",
-		Resource:   "ipblock",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List IpBlocks",
-		LongDesc:   "Use this command to list IpBlocks.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.IpBlocksFiltersUsage(),
-		Example:    listIpBlockExample,
-		PreCmdRun:  PreRunIpblockList,
-		CmdRun:     RunIpBlockList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, ipblockCmd, core.CommandBuilder{
+			Namespace:  "ipblock",
+			Resource:   "ipblock",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List IpBlocks",
+			LongDesc:   "Use this command to list IpBlocks.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.IpBlocksFiltersUsage(),
+			Example:    listIpBlockExample,
+			PreCmdRun:  PreRunIpblockList,
+			CmdRun:     RunIpBlockList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, ipblockCmd, core.CommandBuilder{
-		Namespace:  "ipblock",
-		Resource:   "ipblock",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get an IpBlock",
-		LongDesc:   "Use this command to retrieve the attributes of a specific IpBlock.\n\nRequired values to run command:\n\n* IpBlock Id",
-		Example:    getIpBlockExample,
-		PreCmdRun:  PreRunIpBlockId,
-		CmdRun:     RunIpBlockGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, ipblockCmd, core.CommandBuilder{
+			Namespace:  "ipblock",
+			Resource:   "ipblock",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get an IpBlock",
+			LongDesc:   "Use this command to retrieve the attributes of a specific IpBlock.\n\nRequired values to run command:\n\n* IpBlock Id",
+			Example:    getIpBlockExample,
+			PreCmdRun:  PreRunIpBlockId,
+			CmdRun:     RunIpBlockGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgIpBlockId, cloudapiv6.ArgIdShort, "", cloudapiv6.IpBlockId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, ipblockCmd, core.CommandBuilder{
-		Namespace: "ipblock",
-		Resource:  "ipblock",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create/Reserve an IpBlock",
-		LongDesc: `Use this command to create/reserve an IpBlock in a specified location that can be used by resources within any Virtual Data Centers provisioned in that same location. An IpBlock consists of one or more static IP addresses. The name, size of the IpBlock can be set.
+	create := core.NewCommand(
+		ctx, ipblockCmd, core.CommandBuilder{
+			Namespace: "ipblock",
+			Resource:  "ipblock",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create/Reserve an IpBlock",
+			LongDesc: `Use this command to create/reserve an IpBlock in a specified location that can be used by resources within any Virtual Data Centers provisioned in that same location. An IpBlock consists of one or more static IP addresses. The name, size of the IpBlock can be set.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.`,
-		Example:    createIpBlockExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunIpBlockCreate,
-		InitClient: true,
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the IpBlock. If not set, it will automatically be set")
+			Example:    createIpBlockExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunIpBlockCreate,
+			InitClient: true,
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the IpBlock. If not set, it will automatically be set",
+	)
 	create.AddStringFlag(cloudapiv6.ArgLocation, cloudapiv6.ArgLocationShort, "de/txl", "Location of the IpBlock")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddIntFlag(cloudapiv6.ArgSize, "", 2, "Size of the IpBlock")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for IpBlock creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for IpBlock creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for IpBlock creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for IpBlock creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, ipblockCmd, core.CommandBuilder{
-		Namespace: "ipblock",
-		Resource:  "ipblock",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update an IpBlock",
-		LongDesc: `Use this command to update the properties of an existing IpBlock.
+	update := core.NewCommand(
+		ctx, ipblockCmd, core.CommandBuilder{
+			Namespace: "ipblock",
+			Resource:  "ipblock",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update an IpBlock",
+			LongDesc: `Use this command to update the properties of an existing IpBlock.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * IpBlock Id`,
-		Example:    updateIpBlockExample,
-		PreCmdRun:  PreRunIpBlockId,
-		CmdRun:     RunIpBlockUpdate,
-		InitClient: true,
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgIpBlockId, cloudapiv6.ArgIdShort, "", cloudapiv6.IpBlockId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+			Example:    updateIpBlockExample,
+			PreCmdRun:  PreRunIpBlockId,
+			CmdRun:     RunIpBlockUpdate,
+			InitClient: true,
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgIpBlockId, cloudapiv6.ArgIdShort, "", cloudapiv6.IpBlockId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the IpBlock")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for IpBlock update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for IpBlock update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for IpBlock update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for IpBlock update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, ipblockCmd, core.CommandBuilder{
-		Namespace: "ipblock",
-		Resource:  "ipblock",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete an IpBlock",
-		LongDesc: `Use this command to delete a specified IpBlock.
+	deleteCmd := core.NewCommand(
+		ctx, ipblockCmd, core.CommandBuilder{
+			Namespace: "ipblock",
+			Resource:  "ipblock",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete an IpBlock",
+			LongDesc: `Use this command to delete a specified IpBlock.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
 Required values to run command:
 
 * IpBlock Id`,
-		Example:    deleteIpBlockExample,
-		PreCmdRun:  PreRunIpBlockDelete,
-		CmdRun:     RunIpBlockDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgIpBlockId, cloudapiv6.ArgIdShort, "", cloudapiv6.IpBlockId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for IpBlock deletion to be executed")
+			Example:    deleteIpBlockExample,
+			PreCmdRun:  PreRunIpBlockDelete,
+			CmdRun:     RunIpBlockDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgIpBlockId, cloudapiv6.ArgIdShort, "", cloudapiv6.IpBlockId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for IpBlock deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the IpBlocks.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for IpBlock deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for IpBlock deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return ipblockCmd
 }
@@ -193,7 +263,8 @@ func PreRunIpBlockId(c *core.PreCommandConfig) error {
 }
 
 func PreRunIpBlockDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgIpBlockId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -208,7 +279,10 @@ func RunIpBlockList(c *core.CommandConfig) error {
 
 	ipblocks, resp, err := c.CloudApiV6Services.IpBlocks().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -216,8 +290,10 @@ func RunIpBlockList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.IpBlock, ipblocks.IpBlocks,
-		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.IpBlock, ipblocks.IpBlocks,
+		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -234,12 +310,24 @@ func RunIpBlockGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Ip block with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Ip block with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId)),
+		),
+	)
 
-	i, resp, err := c.CloudApiV6Services.IpBlocks().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId)), queryParams)
+	i, resp, err := c.CloudApiV6Services.IpBlocks().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgIpBlockId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -247,8 +335,10 @@ func RunIpBlockGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.IpBlock, i.IpBlock,
-		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.IpBlock, i.IpBlock,
+		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -269,12 +359,18 @@ func RunIpBlockCreate(c *core.CommandConfig) error {
 	loc := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLocation))
 	size := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgSize))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Ip block: Name: %v, Location: %v, Size: %v", name, loc, size))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Ip block: Name: %v, Location: %v, Size: %v", name, loc, size,
+		),
+	)
 
 	i, resp, err := c.CloudApiV6Services.IpBlocks().Create(name, loc, size, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -286,8 +382,10 @@ func RunIpBlockCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.IpBlock, i.IpBlock,
-		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.IpBlock, i.IpBlock,
+		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -312,9 +410,18 @@ func RunIpBlockUpdate(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", name))
 	}
 
-	i, resp, err := c.CloudApiV6Services.IpBlocks().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId)), input, queryParams)
+	i, resp, err := c.CloudApiV6Services.IpBlocks().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgIpBlockId,
+			),
+		), input, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -326,8 +433,10 @@ func RunIpBlockUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.IpBlock, i.IpBlock,
-		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.IpBlock, i.IpBlock,
+		tabheaders.GetHeadersAllDefault(defaultIpBlockCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -354,15 +463,23 @@ func RunIpBlockDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete ipblock", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete ipblock", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Ip block with ID: %v...", ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Ip block with ID: %v...", ipBlockId),
+	)
 
 	resp, err := c.CloudApiV6Services.IpBlocks().Delete(ipBlockId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -417,7 +534,10 @@ func DeleteAllIpBlocks(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the IpBlocks", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the IpBlocks",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -430,18 +550,27 @@ func DeleteAllIpBlocks(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting IpBlock with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting IpBlock with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.IpBlocks().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/ipblock_test.go
+++ b/commands/cloudapi-v6/ipblock_test.go
@@ -92,365 +92,461 @@ func TestIpblockCmd(t *testing.T) {
 func TestPreRunIpBlockId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunIpBlockId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunIpBlockId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunIpBlockIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunIpBlockId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunIpBlockId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunIpBlockList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunIpblockList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunIpblockList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunIpBlockListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunIpblockList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunIpblockList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunIpBlockListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunIpblockList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunIpblockList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testIpBlocks, &testResponse, nil)
-		err := RunIpBlockList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				testIpBlocks, &testResponse, nil,
+			)
+			err := RunIpBlockList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.IpBlocks{}, &testResponse, nil)
-		err := RunIpBlockList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.IpBlocks{}, &testResponse, nil,
+			)
+			err := RunIpBlockList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testIpBlocks, nil, testIpBlockErr)
-		err := RunIpBlockList(cfg)
-		assert.Error(t, err)
-		assert.True(t, err == testIpBlockErr)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				testIpBlocks, nil, testIpBlockErr,
+			)
+			err := RunIpBlockList(cfg)
+			assert.Error(t, err)
+			assert.True(t, err == testIpBlockErr)
+		},
+	)
 }
 
 func TestRunIpBlockGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Get(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resTestIpBlock, &testResponse, nil)
-		err := RunIpBlockGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Get(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resTestIpBlock, &testResponse, nil)
+			err := RunIpBlockGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Get(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resTestIpBlock, nil, testIpBlockErr)
-		err := RunIpBlockGet(cfg)
-		assert.Error(t, err)
-		assert.True(t, err == testIpBlockErr)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Get(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resTestIpBlock, nil, testIpBlockErr)
+			err := RunIpBlockGet(cfg)
+			assert.Error(t, err)
+			assert.True(t, err == testIpBlockErr)
+		},
+	)
 }
 
 func TestRunIpBlockCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testIpBlockLocation)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), testIpBlockSize)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Create(testIpBlockVar, testIpBlockLocation, testIpBlockSize, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resTestIpBlock, &testResponse, nil)
-		err := RunIpBlockCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testIpBlockLocation)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), testIpBlockSize)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Create(
+				testIpBlockVar, testIpBlockLocation, testIpBlockSize, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resTestIpBlock, &testResponse, nil)
+			err := RunIpBlockCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testIpBlockLocation)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), testIpBlockSize)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Create(testIpBlockVar, testIpBlockLocation, testIpBlockSize, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resTestIpBlock, &testResponse, testIpBlockErr)
-		err := RunIpBlockCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLocation), testIpBlockLocation)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), testIpBlockSize)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Create(
+				testIpBlockVar, testIpBlockLocation, testIpBlockSize, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resTestIpBlock, &testResponse, testIpBlockErr)
+			err := RunIpBlockCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), newTestIpBlockVar)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Update(testIpBlockVar, newTestIpBlockProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&newTestIpBlock, &testResponse, nil)
-		err := RunIpBlockUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), newTestIpBlockVar)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Update(
+				testIpBlockVar, newTestIpBlockProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&newTestIpBlock, &testResponse, nil)
+			err := RunIpBlockUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), newTestIpBlockVar)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Update(testIpBlockVar, newTestIpBlockProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&newTestIpBlock, nil, testIpBlockErr)
-		err := RunIpBlockUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), newTestIpBlockVar)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Update(
+				testIpBlockVar, newTestIpBlockProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&newTestIpBlock, nil, testIpBlockErr)
+			err := RunIpBlockUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunIpBlockDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunIpBlockDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testIpBlocksList, &testResponse, nil)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunIpBlockDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				testIpBlocksList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunIpBlockDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testIpBlocksList, nil, testIpBlockErr)
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				testIpBlocksList, nil, testIpBlockErr,
+			)
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.IpBlocks{}, &testResponse, nil)
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.IpBlocks{}, &testResponse, nil,
+			)
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.IpBlocks{IpBlocks: ionoscloud.IpBlocks{Items: &[]ionoscloud.IpBlock{}}}, &testResponse, nil)
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.IpBlocks{IpBlocks: ionoscloud.IpBlocks{Items: &[]ionoscloud.IpBlock{}}}, &testResponse, nil,
+			)
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testIpBlocksList, &testResponse, nil)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testIpBlockErr)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testIpBlockErr)
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				testIpBlocksList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testIpBlockErr)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testIpBlockErr)
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testIpBlockErr)
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testIpBlockErr)
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunIpBlockDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.IpBlocks.EXPECT().Delete(
+				testIpBlockVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunIpBlockDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunIpBlockDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testIpBlockVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunIpBlockDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/ipfailover.go
+++ b/commands/cloudapi-v6/ipfailover.go
@@ -38,48 +38,74 @@ func IpfailoverCmd() *core.Command {
 		},
 	}
 	globalFlags := ipfailoverCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultIpFailoverCols, tabheaders.ColsMessage(defaultIpFailoverCols))
-	_ = viper.BindPFlag(core.GetFlagName(ipfailoverCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = ipfailoverCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultIpFailoverCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultIpFailoverCols, tabheaders.ColsMessage(defaultIpFailoverCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(ipfailoverCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = ipfailoverCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultIpFailoverCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	listCmd := core.NewCommand(ctx, ipfailoverCmd, core.CommandBuilder{
-		Namespace:  "ipfailover",
-		Resource:   "ipfailover",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List IP Failovers groups from a LAN",
-		LongDesc:   "Use this command to get a list of IP Failovers groups from a LAN.\n\nRequired values to run command:\n\n* Data Center Id\n* Lan Id",
-		Example:    listIpFailoverExample,
-		PreCmdRun:  PreRunDcLanIds,
-		CmdRun:     RunIpFailoverList,
-		InitClient: true,
-	})
+	listCmd := core.NewCommand(
+		ctx, ipfailoverCmd, core.CommandBuilder{
+			Namespace:  "ipfailover",
+			Resource:   "ipfailover",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List IP Failovers groups from a LAN",
+			LongDesc:   "Use this command to get a list of IP Failovers groups from a LAN.\n\nRequired values to run command:\n\n* Data Center Id\n* Lan Id",
+			Example:    listIpFailoverExample,
+			PreCmdRun:  PreRunDcLanIds,
+			CmdRun:     RunIpFailoverList,
+			InitClient: true,
+		},
+	)
 	listCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = listCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	listCmd.AddStringFlag(cloudapiv6.ArgLanId, "", "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = listCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(listCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	listCmd.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	listCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = listCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						listCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listCmd.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	listCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	addCmd := core.NewCommand(ctx, ipfailoverCmd, core.CommandBuilder{
-		Namespace: "ipfailover",
-		Resource:  "ipfailover",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add IP Failover group to a LAN",
-		LongDesc: `Use this command to add an IP Failover group to a LAN.
+	addCmd := core.NewCommand(
+		ctx, ipfailoverCmd, core.CommandBuilder{
+			Namespace: "ipfailover",
+			Resource:  "ipfailover",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add IP Failover group to a LAN",
+			LongDesc: `Use this command to add an IP Failover group to a LAN.
 
 Successfully setting up an IP Failover group requires three steps:
 
@@ -94,43 +120,81 @@ Required values to run command:
 * Server Id
 * Nic Id
 * IP address`,
-		Example:    addIpFailoverExample,
-		PreCmdRun:  PreRunDcLanServerNicIdsIp,
-		CmdRun:     RunIpFailoverAdd,
-		InitClient: true,
-	})
+			Example:    addIpFailoverExample,
+			PreCmdRun:  PreRunDcLanServerNicIdsIp,
+			CmdRun:     RunIpFailoverAdd,
+			InitClient: true,
+		},
+	)
 	addCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = addCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addCmd.AddStringFlag(cloudapiv6.ArgLanId, "", "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = addCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						addCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = addCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						addCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addCmd.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = addCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	addCmd.AddIpFlag(cloudapiv6.ArgIp, "", nil, "IP address to be added to IP Failover Group", core.RequiredFlagOption())
-	addCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for IP Failover creation to be executed")
-	addCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for IP Failover creation [seconds]")
-	addCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = addCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(addCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	addCmd.AddIpFlag(
+		cloudapiv6.ArgIp, "", nil, "IP address to be added to IP Failover Group", core.RequiredFlagOption(),
+	)
+	addCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for IP Failover creation to be executed",
+	)
+	addCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for IP Failover creation [seconds]",
+	)
+	addCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Remove Command
 	*/
-	removeCmd := core.NewCommand(ctx, ipfailoverCmd, core.CommandBuilder{
-		Namespace: "ipfailover",
-		Resource:  "ipfailover",
-		Verb:      "remove",
-		Aliases:   []string{"r"},
-		ShortDesc: "Remove IP Failover group from a LAN",
-		LongDesc: `Use this command to remove an IP Failover group from a LAN.
+	removeCmd := core.NewCommand(
+		ctx, ipfailoverCmd, core.CommandBuilder{
+			Namespace: "ipfailover",
+			Resource:  "ipfailover",
+			Verb:      "remove",
+			Aliases:   []string{"r"},
+			ShortDesc: "Remove IP Failover group from a LAN",
+			LongDesc: `Use this command to remove an IP Failover group from a LAN.
 
 Required values to run command:
 
@@ -139,33 +203,69 @@ Required values to run command:
 * Server Id
 * Nic Id
 * IP address`,
-		Example:    removeIpFailoverExample,
-		PreCmdRun:  PreRunDcLanServerNicIpRemove,
-		CmdRun:     RunIpFailoverRemove,
-		InitClient: true,
-	})
+			Example:    removeIpFailoverExample,
+			PreCmdRun:  PreRunDcLanServerNicIpRemove,
+			CmdRun:     RunIpFailoverRemove,
+			InitClient: true,
+		},
+	)
+	removeCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddStringFlag(cloudapiv6.ArgLanId, "", "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgNicId, "", "", cloudapiv6.NicId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNicId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NicsIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNicId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NicsIds(
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddIpFlag(cloudapiv6.ArgIp, "", nil, "Allocated IP", core.RequiredFlagOption())
-	removeCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for IP Failover deletion to be executed")
-	removeCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for IP Failover deletion [seconds]")
+	removeCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for IP Failover deletion to be executed",
+	)
+	removeCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for IP Failover deletion [seconds]",
+	)
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all IP Failovers.")
-	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	removeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return ipfailoverCmd
 }
@@ -175,14 +275,24 @@ func PreRunDcLanIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcLanServerNicIpRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgIp},
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgAll},
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+			cloudapiv6.ArgIp,
+		},
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+			cloudapiv6.ArgAll,
+		},
 	)
 }
 
 func PreRunDcLanServerNicIdsIp(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId, cloudapiv6.ArgIp)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId, cloudapiv6.ArgServerId, cloudapiv6.ArgNicId,
+		cloudapiv6.ArgIp,
+	)
 }
 
 func RunIpFailoverList(c *core.CommandConfig) error {
@@ -193,7 +303,10 @@ func RunIpFailoverList(c *core.CommandConfig) error {
 		resources.QueryParams{},
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -215,8 +328,10 @@ func RunIpFailoverList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.IpFailover, ipsFailovers,
-		tabheaders.GetHeadersAllDefault(defaultIpFailoverCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.IpFailover, ipsFailovers,
+		tabheaders.GetHeadersAllDefault(defaultIpFailoverCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -236,13 +351,19 @@ func RunIpFailoverAdd(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	lanId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding an IP Failover group to LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding an IP Failover group to LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId,
+		),
+	)
 
 	ipsFailovers := make([]ionoscloud.IPFailover, 0)
 	lanUpdated, resp, err := c.CloudApiV6Services.Lans().Update(dcId, lanId, getIpFailoverInfo(c), queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -268,8 +389,10 @@ func RunIpFailoverAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.IpFailover, ipsFailovers,
-		tabheaders.GetHeadersAllDefault(defaultIpFailoverCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.IpFailover, ipsFailovers,
+		tabheaders.GetHeadersAllDefault(defaultIpFailoverCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -297,10 +420,16 @@ func RunIpFailoverRemove(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	lanId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId))
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(
-		"Removing IP Failover group from LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateVerboseOutput(
+			"Removing IP Failover group from LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId,
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove ip failover group from lan", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove ip failover group from lan",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -321,7 +450,10 @@ func RunIpFailoverRemove(c *core.CommandConfig) error {
 
 	_, resp, err := c.CloudApiV6Services.Lans().Update(dcId, lanId, removeIpFailoverInfo(c, ipfailovers), queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -387,7 +519,10 @@ func RemoveAllIpFailovers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove all the IP Failovers", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove all the IP Failovers",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -396,14 +531,22 @@ func RemoveAllIpFailovers(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the IP Failovers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the IP Failovers..."),
+	)
 
 	if properties, ok := oldLan.GetPropertiesOk(); ok && properties != nil {
 		if ipfailovers, ok := properties.GetIpFailoverOk(); ok && ipfailovers != nil {
 			_, resp, err = c.CloudApiV6Services.Lans().Update(dcId, lanId, lanProperties, queryParams)
 			if resp != nil {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)))
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)),
+				)
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+				)
 			}
 			if err != nil {
 				return err
@@ -423,7 +566,10 @@ func getIpFailoverInfo(c *core.CommandConfig) resources.LanProperties {
 	ip := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp))
 	nicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding IpFailover with Ip: %v and NicUuid: %v", ip, nicId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Adding IpFailover with Ip: %v and NicUuid: %v", ip, nicId),
+	)
 
 	return resources.LanProperties{
 		LanProperties: ionoscloud.LanProperties{
@@ -441,7 +587,10 @@ func removeIpFailoverInfo(c *core.CommandConfig, failovers *[]ionoscloud.IPFailo
 	removeIp := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp))
 	removeNicId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNicId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing IpFailover with Ip: %v and NicUuid: %v", removeIp, removeNicId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Removing IpFailover with Ip: %v and NicUuid: %v", removeIp, removeNicId),
+	)
 
 	newIpFailover := make([]ionoscloud.IPFailover, 0)
 	for _, failover := range *failovers {

--- a/commands/cloudapi-v6/ipfailover_test.go
+++ b/commands/cloudapi-v6/ipfailover_test.go
@@ -81,456 +81,555 @@ func TestIpfailoverCmd(t *testing.T) {
 func TestPreRunDcLanIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		err := PreRunDcLanIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			err := PreRunDcLanIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLanIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcLanIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcLanIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLanServerNicIdsIp(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		err := PreRunDcLanServerNicIdsIp(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			err := PreRunDcLanServerNicIdsIp(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLanServerNicIdsIpErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcLanServerNicIdsIp(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcLanServerNicIdsIp(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, &testResponse, nil)
-		err := RunIpFailoverList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, &testResponse, nil)
+			err := RunIpFailoverList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverListPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverProperties, nil, nil)
-		err := RunIpFailoverList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverProperties, nil, nil)
+			err := RunIpFailoverList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverListGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverGet, nil, nil)
-		err := RunIpFailoverList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverGet, nil, nil)
+			err := RunIpFailoverList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, testIpFailoverErr)
-		err := RunIpFailoverList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, testIpFailoverErr)
+			err := RunIpFailoverList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, &testResponse, nil)
-		err := RunIpFailoverAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, &testResponse, nil)
+			err := RunIpFailoverAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, testIpFailoverErr)
-		err := RunIpFailoverAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, testIpFailoverErr)
+			err := RunIpFailoverAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverAddPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverProperties, nil, nil)
-		err := RunIpFailoverAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverProperties, nil, nil)
+			err := RunIpFailoverAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverGet, nil, nil)
-		err := RunIpFailoverAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverGet, nil, nil)
+			err := RunIpFailoverAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverAddWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunIpFailoverAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, testLanPropertiesIpFailover,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunIpFailoverAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, nil, nil)
+			err := RunIpFailoverRemove(cfg)
+			assert.NoError(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, nil, nil)
-		err := RunIpFailoverRemove(cfg)
-		assert.NoError(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testIpFailoverVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lansIpFailover, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testIpFailoverVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lansIpFailover, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, nil, nil)
+			err := RunIpFailoverRemove(cfg)
+			assert.NoError(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, nil, nil)
-		err := RunIpFailoverRemove(cfg)
-		assert.NoError(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemoveResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, &testResponse, testIpFailoverErr)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, &testResponse, testIpFailoverErr)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemovePropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverProperties, nil, nil)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverProperties, nil, nil)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailoverGet, nil, nil)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailoverGet, nil, nil)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverRemoveWaitReqErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, testIpFailoverErr)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, testIpFailoverErr)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpFailoverRemoveUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, nil, testIpFailoverErr)
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, nil, testIpFailoverErr)
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testLanIpFailover, nil, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
-			LanProperties: ionoscloud.LanProperties{
-				IpFailover: &[]ionoscloud.IPFailover{},
-			},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testIpFailoverVar, testIpFailoverVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testLanIpFailover, nil, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testIpFailoverVar, testIpFailoverVar, resources.LanProperties{
+					LanProperties: ionoscloud.LanProperties{
+						IpFailover: &[]ionoscloud.IPFailover{},
+					},
+				},
+				testQueryParamOther,
+			).Return(&testLanIpFailoverRemove, nil, nil)
+			err := RunIpFailoverRemove(cfg)
+			assert.NoError(t, err)
 		},
-			testQueryParamOther,
-		).Return(&testLanIpFailoverRemove, nil, nil)
-		err := RunIpFailoverRemove(cfg)
-		assert.NoError(t, err)
-	})
+	)
 }
 
 func TestRunIpFailoverRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunIpFailoverRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testIpFailoverVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testIpFailoverVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunIpFailoverRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/k8s_cluster_test.go
+++ b/commands/cloudapi-v6/k8s_cluster_test.go
@@ -172,654 +172,834 @@ func TestK8sCmd(t *testing.T) {
 func TestPreRunK8sClusterId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		err := PreRunK8sClusterId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			err := PreRunK8sClusterId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunK8sClusterId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunK8sClusterId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		err := PreRunK8sClusterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			err := PreRunK8sClusterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunK8sClusterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunK8sClusterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunK8sClusterList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunK8sClusterList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clusters, &testResponse, nil)
-		err := RunK8sClusterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clusters, &testResponse, nil,
+			)
+			err := RunK8sClusterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.K8sClusters{
-				KubernetesClusters: ionoscloud.KubernetesClusters{
-					Items: &[]ionoscloud.KubernetesCluster{},
-				},
-			}, &testResponse, nil)
-		err := RunK8sClusterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.K8sClusters{
+					KubernetesClusters: ionoscloud.KubernetesClusters{
+						Items: &[]ionoscloud.KubernetesCluster{},
+					},
+				}, &testResponse, nil,
+			)
+			err := RunK8sClusterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clusters, nil, testClusterErr)
-		err := RunK8sClusterList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clusters, nil, testClusterErr,
+			)
+			err := RunK8sClusterList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, &testResponse, nil)
-		err := RunK8sClusterGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, &testResponse, nil)
+			err := RunK8sClusterGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, testClusterErr)
-		err := RunK8sClusterGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, testClusterErr)
+			err := RunK8sClusterGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		err := RunK8sClusterGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			err := RunK8sClusterGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, testClusterErr)
-		err := RunK8sClusterGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, testClusterErr)
+			err := RunK8sClusterGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, &testResponse, nil)
-		err := RunK8sClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, &testResponse, nil)
+			err := RunK8sClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateWaitIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, nil, nil)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, nil, nil)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestId, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, testClusterErr)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestId, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, testClusterErr)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateWaitState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestId, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		err := RunK8sClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestId, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			err := RunK8sClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateWaitReqErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestId, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestId, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateVersion(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testClusterVar, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, nil, nil)
-		err := RunK8sClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testClusterVar, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, nil, nil)
+			err := RunK8sClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateVersionErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testClusterVar, nil, testClusterErr)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testClusterVar, nil, testClusterErr)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, &testResponse, testClusterErr)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, &testResponse, testClusterErr)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, nil, testClusterErr)
-		err := RunK8sClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateCluster(
+				clusterTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, nil, testClusterErr)
+			err := RunK8sClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterNew, &testResponse, nil)
-		err := RunK8sClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(
+				testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterNew, &testResponse, nil)
+			err := RunK8sClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterNew, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, testClusterErr)
-		err := RunK8sClusterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(
+				testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterNew, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, testClusterErr)
+			err := RunK8sClusterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdateWaitState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterNew, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		err := RunK8sClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(
+				testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterNew, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			err := RunK8sClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdateOldUser(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(testClusterVar, clusterTestPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTest, nil, nil)
-		err := RunK8sClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(
+				testClusterVar, clusterTestPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTest, nil, nil)
+			err := RunK8sClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterNew, nil, testClusterErr)
-		err := RunK8sClusterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateCluster(
+				testClusterVar, clusterNewTestPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterNew, nil, testClusterErr)
+			err := RunK8sClusterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&clusterTestGet, nil, testClusterErr)
-		err := RunK8sClusterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgApiSubnets), []string{testClusterNewVar})
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&clusterTestGet, nil, testClusterErr)
+			err := RunK8sClusterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clustersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clustersList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clustersList, nil, testClusterErr)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clustersList, nil, testClusterErr,
+			)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.K8sClusters{}, &testResponse, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.K8sClusters{}, &testResponse, nil,
+			)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.K8sClusters{KubernetesClusters: ionoscloud.KubernetesClusters{Items: &[]ionoscloud.KubernetesCluster{}}}, &testResponse, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.K8sClusters{KubernetesClusters: ionoscloud.KubernetesClusters{Items: &[]ionoscloud.KubernetesCluster{}}},
+				&testResponse, nil,
+			)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clustersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testClusterErr)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clustersList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testClusterErr)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteWaitReqErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testClusterErr)
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testClusterErr)
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunK8sClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteCluster(
+				testClusterVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunK8sClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sClusterDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunK8sClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunK8sClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -39,87 +39,143 @@ func K8sNodeCmd() *core.Command {
 	globalFlags := k8sCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultK8sNodeCols, tabheaders.ColsMessage(defaultK8sNodeCols))
 	_ = viper.BindPFlag(core.GetFlagName(k8sCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = k8sCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultK8sNodeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = k8sCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultK8sNodeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace:  "k8s",
-		Resource:   "node",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Kubernetes Nodes",
-		LongDesc:   "Use this command to get a list of existing Kubernetes Nodes.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.K8sNodesFiltersUsage() + "\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
-		Example:    listK8sNodesExample,
-		PreCmdRun:  PreRunK8sNodesList,
-		CmdRun:     RunK8sNodeList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace:  "k8s",
+			Resource:   "node",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Kubernetes Nodes",
+			LongDesc:   "Use this command to get a list of existing Kubernetes Nodes.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.K8sNodesFiltersUsage() + "\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
+			Example:    listK8sNodesExample,
+			PreCmdRun:  PreRunK8sNodesList,
+			CmdRun:     RunK8sNodeList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(list.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace:  "k8s",
-		Resource:   "node",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Kubernetes Node",
-		LongDesc:   "Use this command to retrieve details about a specific Kubernetes Node.You can wait for the Node to be in \"ACTIVE\" state using `--wait-for-state` flag together with `--timeout` option.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id\n* K8s Node Id",
-		Example:    getK8sNodeExample,
-		PreCmdRun:  PreRunK8sClusterNodesIds,
-		CmdRun:     RunK8sNodeGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace:  "k8s",
+			Resource:   "node",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Kubernetes Node",
+			LongDesc:   "Use this command to retrieve details about a specific Kubernetes Node.You can wait for the Node to be in \"ACTIVE\" state using `--wait-for-state` flag together with `--timeout` option.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id\n* K8s Node Id",
+			Example:    getK8sNodeExample,
+			PreCmdRun:  PreRunK8sClusterNodesIds,
+			CmdRun:     RunK8sNodeGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(get.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgK8sNodeId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodeId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sNodeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodesIds(viper.GetString(core.GetFlagName(get.NS, constants.FlagClusterId)),
-			viper.GetString(core.GetFlagName(get.NS, constants.FlagNodepoolId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Node to be in ACTIVE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Node to be in ACTIVE state [seconds]")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgK8sNodeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodesIds(
+				viper.GetString(core.GetFlagName(get.NS, constants.FlagClusterId)),
+				viper.GetString(core.GetFlagName(get.NS, constants.FlagNodepoolId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified Node to be in ACTIVE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds,
+		"Timeout option for waiting for Node to be in ACTIVE state [seconds]",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Recreate Command
 	*/
-	recreate := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "k8s",
-		Resource:  "node",
-		Verb:      "recreate",
-		Aliases:   []string{"r"},
-		ShortDesc: "Recreate a Kubernetes Node",
-		LongDesc: `You can recreate a single Kubernetes Node.
+	recreate := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "k8s",
+			Resource:  "node",
+			Verb:      "recreate",
+			Aliases:   []string{"r"},
+			ShortDesc: "Recreate a Kubernetes Node",
+			LongDesc: `You can recreate a single Kubernetes Node.
 
 Managed Kubernetes starts a process which based on the NodePool's template creates & configures a new Node, waits for status "ACTIVE", and migrates all the Pods from the faulty Node, deleting it once empty. While this operation occurs, the NodePool will have an extra billable "ACTIVE" Node.
 
@@ -128,64 +184,110 @@ Required values to run command:
 * K8s Cluster Id
 * K8s NodePool Id
 * K8s Node Id`,
-		Example:    recreateK8sNodeExample,
-		PreCmdRun:  PreRunK8sClusterNodesIds,
-		CmdRun:     RunK8sNodeRecreate,
-		InitClient: true,
-	})
+			Example:    recreateK8sNodeExample,
+			PreCmdRun:  PreRunK8sClusterNodesIds,
+			CmdRun:     RunK8sNodeRecreate,
+			InitClient: true,
+		},
+	)
+	recreate.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	recreate.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = recreate.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = recreate.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	recreate.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = recreate.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(recreate.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	recreate.AddUUIDFlag(cloudapiv6.ArgK8sNodeId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodeId, core.RequiredFlagOption())
-	_ = recreate.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sNodeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodesIds(viper.GetString(core.GetFlagName(recreate.NS, constants.FlagClusterId)),
-			viper.GetString(core.GetFlagName(recreate.NS, constants.FlagNodepoolId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	recreate.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = recreate.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						recreate.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	recreate.AddUUIDFlag(
+		cloudapiv6.ArgK8sNodeId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodeId, core.RequiredFlagOption(),
+	)
+	_ = recreate.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgK8sNodeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodesIds(
+				viper.GetString(core.GetFlagName(recreate.NS, constants.FlagClusterId)),
+				viper.GetString(core.GetFlagName(recreate.NS, constants.FlagNodepoolId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	recreate.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "k8s",
-		Resource:  "node",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Kubernetes Node",
-		LongDesc: `This command deletes a Kubernetes Node within an existing Kubernetes NodePool in a Cluster.
+	deleteCmd := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "k8s",
+			Resource:  "node",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Kubernetes Node",
+			LongDesc: `This command deletes a Kubernetes Node within an existing Kubernetes NodePool in a Cluster.
 
 Required values to run command:
 
 * K8s Cluster Id
 * K8s NodePool Id
 * K8s Node Id`,
-		Example:    deleteK8sNodeExample,
-		PreCmdRun:  PreRunK8sClusterNodesIdsAll,
-		CmdRun:     RunK8sNodeDelete,
-		InitClient: true,
-	})
+			Example:    deleteK8sNodeExample,
+			PreCmdRun:  PreRunK8sClusterNodesIdsAll,
+			CmdRun:     RunK8sNodeDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgK8sNodeId, "", "", cloudapiv6.K8sNodeId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sNodeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagClusterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagNodepoolId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Kubernetes Nodes within an existing Kubernetes NodePool in a Cluster.")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgK8sNodeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodesIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagClusterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagNodepoolId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false,
+		"Delete all the Kubernetes Nodes within an existing Kubernetes NodePool in a Cluster.",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return k8sCmd
 }
@@ -201,20 +303,27 @@ func PreRunK8sNodesList(c *core.PreCommandConfig) error {
 }
 
 func PreRunK8sClusterNodesIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgK8sNodeId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgK8sNodeId,
+	)
 }
 
 func PreRunK8sClusterNodesIdsAll(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgAll},
 		[]string{constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgK8sNodeId},
 	)
 }
 
 func RunK8sNodeList(c *core.CommandConfig) error {
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Listing Nodes from K8s NodePool ID: %v from K8s Cluster ID: %v",
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Listing Nodes from K8s NodePool ID: %v from K8s Cluster ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)),
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		),
+	)
 
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
@@ -227,7 +336,10 @@ func RunK8sNodeList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 
 	if err != nil {
@@ -236,8 +348,10 @@ func RunK8sNodeList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.K8sNode, k8ss.KubernetesNodes,
-		tabheaders.GetHeadersAllDefault(defaultK8sNodeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.K8sNode, k8ss.KubernetesNodes,
+		tabheaders.GetHeadersAllDefault(defaultK8sNodeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -254,14 +368,20 @@ func RunK8sNodeGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	if err := waitfor.WaitForState(c, waiter.K8sNodeStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sNodeId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.K8sNodeStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sNodeId)),
+	); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting K8s Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v......",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sNodeId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting K8s Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v......",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sNodeId)),
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)),
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		),
+	)
 
 	u, resp, err := c.CloudApiV6Services.K8s().GetNode(
 		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
@@ -270,7 +390,10 @@ func RunK8sNodeGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -278,8 +401,10 @@ func RunK8sNodeGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.K8sNode, u.KubernetesNode,
-		tabheaders.GetHeadersAllDefault(defaultK8sNodeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.K8sNode, u.KubernetesNode,
+		tabheaders.GetHeadersAllDefault(defaultK8sNodeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -297,7 +422,9 @@ func RunK8sNodeRecreate(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "recreate k8s node", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "recreate k8s node", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -305,19 +432,29 @@ func RunK8sNodeRecreate(c *core.CommandConfig) error {
 	k8sNodePoolId := viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))
 	k8sNodeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sNodeId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("K8sClusterId: %v, K8sNodePoolId: %v, K8sNodeId: %v",
-		k8sClusterId, k8sNodePoolId, k8sNodeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"K8sClusterId: %v, K8sNodePoolId: %v, K8sNodeId: %v",
+			k8sClusterId, k8sNodePoolId, k8sNodeId,
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Recreating Node..."))
 
 	resp, err := c.CloudApiV6Services.K8s().RecreateNode(k8sClusterId, k8sNodePoolId, k8sNodeId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: Command node recreate has been successfully executed"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Status: Command node recreate has been successfully executed"),
+	)
 
 	return nil
 }
@@ -341,22 +478,33 @@ func RunK8sNodeDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete k8s node", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete k8s node", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v...", nodeId, nodepoolId, clusterId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v...", nodeId,
+			nodepoolId, clusterId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.K8s().DeleteNode(clusterId, nodepoolId, nodeId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Node successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Node successfully deleted"),
+	)
 	return nil
 }
 
@@ -374,7 +522,9 @@ func DeleteAllK8sNodes(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("K8sNodePool ID: %v", nodepoolId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting K8sNodes..."))
 
-	k8sNodes, resp, err := c.CloudApiV6Services.K8s().ListNodes(clusterId, nodepoolId, cloudapiv6.ParentResourceListQueryParams)
+	k8sNodes, resp, err := c.CloudApiV6Services.K8s().ListNodes(
+		clusterId, nodepoolId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -406,7 +556,10 @@ func DeleteAllK8sNodes(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the K8sNodes", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the K8sNodes",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -419,19 +572,29 @@ func DeleteAllK8sNodes(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Staring deleting Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v...", *id, nodepoolId, clusterId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Staring deleting Node with ID: %v from K8s NodePool ID: %v from K8s Cluster ID: %v...", *id,
+				nodepoolId, clusterId,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.K8s().DeleteNode(clusterId, nodepoolId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
@@ -444,6 +607,8 @@ func DeleteAllK8sNodes(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodes successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodes successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/k8s_node_test.go
+++ b/commands/cloudapi-v6/k8s_node_test.go
@@ -72,420 +72,527 @@ var (
 func TestPreRunK8sClusterNodesIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		err := PreRunK8sClusterNodesIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			err := PreRunK8sClusterNodesIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterNodesIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunK8sClusterNodesIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunK8sClusterNodesIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodesList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		err := PreRunK8sNodesList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			err := PreRunK8sNodesList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodesListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunK8sNodesList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunK8sNodesList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodesListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunK8sNodesList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunK8sNodesList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodesTest, &testResponse, nil)
-		err := RunK8sNodeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodesTest, &testResponse, nil)
+			err := RunK8sNodeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.K8sNodes{}, &testResponse, nil)
-		err := RunK8sNodeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.K8sNodes{}, &testResponse, nil)
+			err := RunK8sNodeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodesTest, nil, testNodeErr)
-		err := RunK8sNodeList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodesTest, nil, testNodeErr)
+			err := RunK8sNodeList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodeTestGet, &testResponse, nil)
-		err := RunK8sNodeGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodeTestGet, &testResponse, nil)
+			err := RunK8sNodeGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodeTestGet, nil, testNodeErr)
-		err := RunK8sNodeGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodeTestGet, nil, testNodeErr)
+			err := RunK8sNodeGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodeTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodeTestGet, nil, nil)
-		err := RunK8sNodeGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodeTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodeTestGet, nil, nil)
+			err := RunK8sNodeGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodeTestGet, nil, testNodeErr)
-		err := RunK8sNodeGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodeTestGet, nil, testNodeErr)
+			err := RunK8sNodeGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeRecreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodeRecreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodeRecreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeRecreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNodeErr)
-		err := RunK8sNodeRecreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNodeErr)
+			err := RunK8sNodeRecreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeRecreateAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunK8sNodeRecreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.K8s.EXPECT().RecreateNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunK8sNodeRecreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeRecreateAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunK8sNodeRecreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunK8sNodeRecreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodesTestList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodesTestList, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodesTestList, nil, testNodeErr)
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodesTestList, nil, testNodeErr)
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.K8sNodes{}, &testResponse, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.K8sNodes{}, &testResponse, nil)
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.K8sNodes{KubernetesNodes: ionoscloud.KubernetesNodes{Items: &[]ionoscloud.KubernetesNode{}}}, &testResponse, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.K8sNodes{KubernetesNodes: ionoscloud.KubernetesNodes{Items: &[]ionoscloud.KubernetesNode{}}},
+				&testResponse, nil,
+			)
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodesTestList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNodeErr)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodes(
+				testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodesTestList, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNodeErr)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNodeErr)
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNodeErr)
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunK8sNodeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNode(
+				testNodeVar, testNodeVar, testNodeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunK8sNodeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodeDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunK8sNodeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sNodeId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodeVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunK8sNodeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -31,9 +31,12 @@ import (
 
 var (
 	defaultK8sNodePoolCols = []string{"NodePoolId", "Name", "K8sVersion", "NodeCount", "DatacenterId", "State"}
-	allK8sNodePoolCols     = []string{"NodePoolId", "Name", "K8sVersion", "DatacenterId", "NodeCount", "CpuFamily", "StorageType", "State", "LanIds",
-		"CoresCount", "RamSize", "AvailabilityZone", "StorageSize", "MaintenanceWindow", "AutoScaling", "PublicIps", "AvailableUpgradeVersions",
-		"Annotations", "Labels", "ClusterId"}
+	allK8sNodePoolCols     = []string{
+		"NodePoolId", "Name", "K8sVersion", "DatacenterId", "NodeCount", "CpuFamily", "StorageType", "State", "LanIds",
+		"CoresCount", "RamSize", "AvailabilityZone", "StorageSize", "MaintenanceWindow", "AutoScaling", "PublicIps",
+		"AvailableUpgradeVersions",
+		"Annotations", "Labels", "ClusterId",
+	}
 )
 
 func K8sNodePoolCmd() *core.Command {
@@ -50,80 +53,125 @@ func K8sNodePoolCmd() *core.Command {
 	globalFlags := k8sCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultK8sNodePoolCols, tabheaders.ColsMessage(allK8sNodePoolCols))
 	_ = viper.BindPFlag(core.GetFlagName(k8sCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = k8sCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allK8sNodePoolCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = k8sCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allK8sNodePoolCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace:  "k8s",
-		Resource:   "nodepool",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Kubernetes NodePools",
-		LongDesc:   "Use this command to get a list of all contained NodePools in a selected Kubernetes Cluster.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.K8sNodePoolsFiltersUsage() + "\n\nRequired values to run command:\n\n* K8s Cluster Id",
-		Example:    listK8sNodePoolsExample,
-		PreCmdRun:  PreRunK8sNodePoolsList,
-		CmdRun:     RunK8sNodePoolList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace:  "k8s",
+			Resource:   "nodepool",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Kubernetes NodePools",
+			LongDesc:   "Use this command to get a list of all contained NodePools in a selected Kubernetes Cluster.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.K8sNodePoolsFiltersUsage() + "\n\nRequired values to run command:\n\n* K8s Cluster Id",
+			Example:    listK8sNodePoolsExample,
+			PreCmdRun:  PreRunK8sNodePoolsList,
+			CmdRun:     RunK8sNodePoolList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace:  "k8s",
-		Resource:   "nodepool",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Kubernetes NodePool",
-		LongDesc:   "Use this command to retrieve details about a specific NodePool from an existing Kubernetes Cluster. You can wait for the Node Pool to be in \"ACTIVE\" state using `--wait-for-state` flag together with `--timeout` option.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
-		Example:    getK8sNodePoolExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolIds,
-		CmdRun:     RunK8sNodePoolGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace:  "k8s",
+			Resource:   "nodepool",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Kubernetes NodePool",
+			LongDesc:   "Use this command to retrieve details about a specific NodePool from an existing Kubernetes Cluster. You can wait for the Node Pool to be in \"ACTIVE\" state using `--wait-for-state` flag together with `--timeout` option.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
+			Example:    getK8sNodePoolExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolIds,
+			CmdRun:     RunK8sNodePoolGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(get.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified NodePool to be in ACTIVE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for NodePool to be in ACTIVE state [seconds]")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified NodePool to be in ACTIVE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds,
+		"Timeout option for waiting for NodePool to be in ACTIVE state [seconds]",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
 	jsonPropertiesExample := "{\n  \"metadata\": {},\n  \"properties\": {\n    \"name\": \"K8s-node-pool\",\n    \"datacenterId\": \"12345678-90ab-cdef-1234-567890abcdef\",\n    \"nodeCount\": 2,\n    \"cpuFamily\": \"INTEL_SKYLAKE\",\n    \"coresCount\": 4,\n    \"ramSize\": 2048,\n    \"availabilityZone\": \"AUTO\",\n    \"storageType\": \"HDD\",\n    \"storageSize\": 100,\n    \"k8sVersion\": \"1.27.6\",\n    \"maintenanceWindow\": {\n      \"dayOfTheWeek\": \"Monday\",\n      \"time\": \"13:00:00\"\n    },\n    \"autoScaling\": {\n      \"minNodeCount\": \"1\",\n      \"maxNodeCount\": \"2\"\n    },\n    \"lans\": [\n      {\n        \"id\": 1,\n        \"dhcp\": true,\n        \"routes\": [\n          {\n            \"network\": \"1.2.3.4/24\",\n            \"gatewayIp\": \"10.1.5.16\"\n          }\n        ]\n      }\n    ],\n    \"labels\": {\n      \"property1\": \"string\",\n      \"property2\": \"string\"\n    },\n    \"annotations\": {\n      \"property1\": \"string\",\n      \"property2\": \"string\"\n    },\n    \"publicIps\": [\n      \"203.0.113.1\",\n      \"203.0.113.2\",\n      \"203.0.113.3\"\n    ]\n  }\n}"
 	nodepoolViaJsonPropertiesFlag := ionoscloud.KubernetesNodePoolForPost{}
-	create := core.NewCommandWithJsonProperties(ctx, k8sCmd, jsonPropertiesExample, &nodepoolViaJsonPropertiesFlag, core.CommandBuilder{
-		Namespace: "k8s",
-		Resource:  "nodepool",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Kubernetes NodePool",
-		LongDesc: `Use this command to create a Node Pool into an existing Kubernetes Cluster. The Kubernetes Cluster must be in state "ACTIVE" before creating a Node Pool. The worker Nodes within the Node Pools will be deployed into an existing Data Center. Regarding the name for the Kubernetes NodePool, the limit is 63 characters following the rule to begin and end with an alphanumeric character with dashes, underscores, dots, and alphanumerics between. Regarding the Kubernetes Version for the NodePool, if not set via flag, it will be used the default one: ` + "`" + `ionosctl k8s version get` + "`" + `.
+	create := core.NewCommandWithJsonProperties(
+		ctx, k8sCmd, jsonPropertiesExample, &nodepoolViaJsonPropertiesFlag, core.CommandBuilder{
+			Namespace: "k8s",
+			Resource:  "nodepool",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Kubernetes NodePool",
+			LongDesc: `Use this command to create a Node Pool into an existing Kubernetes Cluster. The Kubernetes Cluster must be in state "ACTIVE" before creating a Node Pool. The worker Nodes within the Node Pools will be deployed into an existing Data Center. Regarding the name for the Kubernetes NodePool, the limit is 63 characters following the rule to begin and end with an alphanumeric character with dashes, underscores, dots, and alphanumerics between. Regarding the Kubernetes Version for the NodePool, if not set via flag, it will be used the default one: ` + "`" + `ionosctl k8s version get` + "`" + `.
 
 You can wait for the Node Pool to be in "ACTIVE" state using ` + "`" + `--wait-for-state` + "`" + ` flag together with ` + "`" + `--timeout` + "`" + ` option.
 
@@ -138,77 +186,146 @@ Required values to run a command (for Private Kubernetes Cluster):
 
 * K8s Cluster Id
 * Datacenter Id`,
-		Example: createK8sNodePoolExample,
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
-				[]string{cloudapiv6.ArgDataCenterId, constants.FlagClusterId},
-				[]string{cloudapiv6.ArgDataCenterId, constants.FlagClusterId},
-				[]string{constants.FlagJsonProperties, constants.FlagClusterId},
-				[]string{constants.FlagJsonPropertiesExample},
-			)
+			Example: createK8sNodePoolExample,
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS,
+					[]string{cloudapiv6.ArgDataCenterId, constants.FlagClusterId},
+					[]string{cloudapiv6.ArgDataCenterId, constants.FlagClusterId},
+					[]string{constants.FlagJsonProperties, constants.FlagClusterId},
+					[]string{constants.FlagJsonPropertiesExample},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				if viper.IsSet(constants.FlagJsonProperties) {
+					return RunK8sNodePoolCreateFromJSON(c, nodepoolViaJsonPropertiesFlag)
+				}
+				return RunK8sNodePoolCreate(c)
+			},
+			InitClient: true,
 		},
-		CmdRun: func(c *core.CommandConfig) error {
-			if viper.IsSet(constants.FlagJsonProperties) {
-				return RunK8sNodePoolCreateFromJSON(c, nodepoolViaJsonPropertiesFlag)
-			}
-			return RunK8sNodePoolCreate(c)
-		},
-		InitClient: true,
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "UnnamedNodePool", "The name for the K8s NodePool")
-	create.AddStringFlag(cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the NodePool. If not set, the default one will be used")
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "UnnamedNodePool", "The name for the K8s NodePool",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the NodePool. If not set, the default one will be used",
+	)
 	create.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddIntSliceFlag(cloudapiv6.ArgLanIds, "", []int{}, "Collection of LAN Ids of existing LANs to be attached to worker Nodes")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanIds, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(cloudapiv6.ArgDhcp, "", true, "Indicates if the Kubernetes Node Pool LANs will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false")
-	create.AddIntFlag(constants.FlagNodeCount, "", 1, "The number of worker Nodes that the Node Pool should contain. Min 1, Max: Determined by the resource availability")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddIntSliceFlag(
+		cloudapiv6.ArgLanIds, "", []int{}, "Collection of LAN Ids of existing LANs to be attached to worker Nodes",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanIds,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgDhcp, "", true,
+		"Indicates if the Kubernetes Node Pool LANs will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false",
+	)
+	create.AddIntFlag(
+		constants.FlagNodeCount, "", 1,
+		"The number of worker Nodes that the Node Pool should contain. Min 1, Max: Determined by the resource availability",
+	)
 	create.AddIntFlag(constants.FlagCores, "", 2, "The total number of cores for the Node")
-	create.AddStringFlag(constants.FlagRam, "", strconv.Itoa(2048), "RAM size for node, minimum size is 2048MB. Ram size must be set to multiple of 1024MB. e.g. --ram 2048 or --ram 2048MB")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagRam, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"2048MB", "3GB", "4GB", "5GB", "10GB", "50GB", "100GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	create.AddStringFlag(
+		constants.FlagRam, "", strconv.Itoa(2048),
+		"RAM size for node, minimum size is 2048MB. Ram size must be set to multiple of 1024MB. e.g. --ram 2048 or --ram 2048MB",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagRam,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"2048MB", "3GB", "4GB", "5GB", "10GB", "50GB", "100GB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(constants.FlagCpuFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Type")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
-		return completer.DatacenterCPUFamilies(create.Command.Context(), datacenterId), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO", "The compute Availability Zone in which the Node should exist")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagCpuFamily, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
+			return completer.DatacenterCPUFamilies(
+				create.Command.Context(), datacenterId,
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO",
+		"The compute Availability Zone in which the Node should exist",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagCpuFamily,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(constants.FlagStorageType, "", "HDD", "Storage Type")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagStorageType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HDD", "SSD"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.FlagStorageSize, "", strconv.Itoa(cloudapiv6.DefaultVolumeSize), "The size of the Storage in GB. e.g.: --size 10 or --size 10GB. The maximum Volume size is determined by your contract limit")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagStorageSize, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringToStringFlag(constants.FlagLabels, constants.FlagLabelsShort, map[string]string{}, "Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE")
-	create.AddStringToStringFlag(constants.FlagAnnotations, constants.FlagAnnotationsShort, map[string]string{}, "Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE")
-	create.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for the new NodePool to be in ACTIVE state")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for NodePool to be in ACTIVE state[seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagStorageType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HDD", "SSD"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.FlagStorageSize, "", strconv.Itoa(cloudapiv6.DefaultVolumeSize),
+		"The size of the Storage in GB. e.g.: --size 10 or --size 10GB. The maximum Volume size is determined by your contract limit",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagStorageSize,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringToStringFlag(
+		constants.FlagLabels, constants.FlagLabelsShort, map[string]string{},
+		"Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE",
+	)
+	create.AddStringToStringFlag(
+		constants.FlagAnnotations, constants.FlagAnnotationsShort, map[string]string{},
+		"Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for the new NodePool to be in ACTIVE state",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds,
+		"Timeout option for waiting for NodePool to be in ACTIVE state[seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "k8s",
-		Resource:  "nodepool",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Kubernetes NodePool",
-		LongDesc: `Use this command to update the number of worker Nodes, the minimum and maximum number of worker Nodes, the add labels, annotations, to update the maintenance day and time, to attach private LANs to a Node Pool within an existing Kubernetes Cluster. You can also add reserved public IP addresses to be used by the Nodes. IPs must be from same location as the Data Center used for the Node Pool. The array must contain one extra IP than maximum number of Nodes could be. The extra provided IP Will be used during rebuilding of Nodes.
+	update := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "k8s",
+			Resource:  "nodepool",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Kubernetes NodePool",
+			LongDesc: `Use this command to update the number of worker Nodes, the minimum and maximum number of worker Nodes, the add labels, annotations, to update the maintenance day and time, to attach private LANs to a Node Pool within an existing Kubernetes Cluster. You can also add reserved public IP addresses to be used by the Nodes. IPs must be from same location as the Data Center used for the Node Pool. The array must contain one extra IP than maximum number of Nodes could be. The extra provided IP Will be used during rebuilding of Nodes.
 
 You can wait for the Node Pool to be in "ACTIVE" state using ` + "`" + `--wait-for-state` + "`" + ` flag together with ` + "`" + `--timeout` + "`" + ` option.
 
@@ -218,86 +335,183 @@ Required values to run command:
 
 * K8s Cluster Id
 * K8s NodePool Id`,
-		Example:    updateK8sNodePoolExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolIds,
-		CmdRun:     RunK8sNodePoolUpdate,
-		InitClient: true,
-	})
-	update.AddStringFlag(cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the NodePool. K8s version downgrade is not supported")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sVersion,
+			Example:    updateK8sNodePoolExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolIds,
+			CmdRun:     RunK8sNodePoolUpdate,
+			InitClient: true,
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgK8sVersion, "", "", "The K8s version for the NodePool. K8s version downgrade is not supported",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgK8sVersion,
 		func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 			clusterId := viper.GetString(core.GetFlagName(update.NS, constants.FlagClusterId))
 			nodepoolId := viper.GetString(core.GetFlagName(update.NS, constants.FlagNodepoolId))
 			return completer.K8sNodePoolUpgradeVersions(clusterId, nodepoolId), cobra.ShellCompDirectiveNoFileComp
-		})
+		},
+	)
 	update.AddIntFlag(constants.FlagNodeCount, "", 1, "The number of worker Nodes that the NodePool should contain")
-	update.AddIntFlag(cloudapiv6.ArgK8sMinNodeCount, "", 1, "The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count")
-	update.AddIntFlag(cloudapiv6.ArgK8sMaxNodeCount, "", 1, "The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count")
-	update.AddStringToStringFlag(constants.FlagLabels, constants.FlagLabelsShort, map[string]string{}, "Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE")
-	update.AddStringToStringFlag(constants.FlagAnnotations, constants.FlagAnnotationsShort, map[string]string{}, "Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE")
-	update.AddStringFlag(cloudapiv6.ArgLabelKey, "", "", "Label key. Must be set together with --label-value", core.DeprecatedFlagOption("Use --labels, --annotations options instead!"))
-	update.AddStringFlag(cloudapiv6.ArgLabelValue, "", "", "Label value. Must be set together with --label-key", core.DeprecatedFlagOption("Use --labels, --annotations options instead!"))
-	update.AddStringFlag(cloudapiv6.ArgK8sAnnotationKey, "", "", "Annotation key. Must be set together with --annotation-value", core.DeprecatedFlagOption("Use --labels, --annotations options instead!"))
-	update.AddStringFlag(cloudapiv6.ArgK8sAnnotationValue, "", "", "Annotation value. Must be set together with --annotation-key", core.DeprecatedFlagOption("Use --labels, --annotations options instead!"))
-	update.AddStringFlag(cloudapiv6.ArgK8sMaintenanceDay, "", "", "The day of the week for Maintenance Window has the English day format as following: Monday or Saturday")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgK8sMaintenanceDay, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgK8sMaintenanceTime, "", "", "The time for Maintenance Window has the HH:mm:ss format as following: 08:00:00")
-	update.AddStringSliceFlag(cloudapiv6.ArgPublicIps, "", []string{}, "Reserved public IP address to be used by the Nodes. IPs must be from same location as the Data Center used for the Node Pool. Usage: --public-ips IP1,IP2")
-	update.AddIntSliceFlag(cloudapiv6.ArgLanIds, "", []int{}, "Collection of LAN Ids of existing LANs to be attached to worker Nodes. It will be added to the existing LANs attached")
-	update.AddBoolFlag(cloudapiv6.ArgDhcp, "", true, "Indicates if the Kubernetes Node Pool LANs will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false")
+	update.AddIntFlag(
+		cloudapiv6.ArgK8sMinNodeCount, "", 1,
+		"The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgK8sMaxNodeCount, "", 1,
+		"The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count",
+	)
+	update.AddStringToStringFlag(
+		constants.FlagLabels, constants.FlagLabelsShort, map[string]string{},
+		"Labels to set on a NodePool. It will overwrite the existing labels, if there are any. Use the following format: --labels KEY=VALUE,KEY=VALUE",
+	)
+	update.AddStringToStringFlag(
+		constants.FlagAnnotations, constants.FlagAnnotationsShort, map[string]string{},
+		"Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE",
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgLabelKey, "", "", "Label key. Must be set together with --label-value",
+		core.DeprecatedFlagOption("Use --labels, --annotations options instead!"),
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgLabelValue, "", "", "Label value. Must be set together with --label-key",
+		core.DeprecatedFlagOption("Use --labels, --annotations options instead!"),
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgK8sAnnotationKey, "", "", "Annotation key. Must be set together with --annotation-value",
+		core.DeprecatedFlagOption("Use --labels, --annotations options instead!"),
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgK8sAnnotationValue, "", "", "Annotation value. Must be set together with --annotation-key",
+		core.DeprecatedFlagOption("Use --labels, --annotations options instead!"),
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgK8sMaintenanceDay, "", "",
+		"The day of the week for Maintenance Window has the English day format as following: Monday or Saturday",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgK8sMaintenanceDay,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgK8sMaintenanceTime, "", "",
+		"The time for Maintenance Window has the HH:mm:ss format as following: 08:00:00",
+	)
+	update.AddStringSliceFlag(
+		cloudapiv6.ArgPublicIps, "", []string{},
+		"Reserved public IP address to be used by the Nodes. IPs must be from same location as the Data Center used for the Node Pool. Usage: --public-ips IP1,IP2",
+	)
+	update.AddIntSliceFlag(
+		cloudapiv6.ArgLanIds, "", []int{},
+		"Collection of LAN Ids of existing LANs to be attached to worker Nodes. It will be added to the existing LANs attached",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDhcp, "", true,
+		"Indicates if the Kubernetes Node Pool LANs will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false",
+	)
 	update.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(update.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for the new NodePool to be in ACTIVE state")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for NodePool to be in ACTIVE state [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for the new NodePool to be in ACTIVE state",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds,
+		"Timeout option for waiting for NodePool to be in ACTIVE state [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "k8s",
-		Resource:  "nodepool",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Kubernetes NodePool",
-		LongDesc: `This command deletes a Kubernetes Node Pool within an existing Kubernetes Cluster.
+	deleteCmd := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "k8s",
+			Resource:  "nodepool",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Kubernetes NodePool",
+			LongDesc: `This command deletes a Kubernetes Node Pool within an existing Kubernetes Cluster.
 
 Required values to run command:
 
 * K8s Cluster Id
 * K8s NodePool Id`,
-		Example:    deleteK8sNodePoolExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolDelete,
-		CmdRun:     RunK8sNodePoolDelete,
-		InitClient: true,
-	})
+			Example:    deleteK8sNodePoolExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolDelete,
+			CmdRun:     RunK8sNodePoolDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Kubernetes Node Pools within an existing Kubernetes Nodepools.")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		constants.FlagNodepoolId, cloudapiv6.ArgIdShort, "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false,
+		"Delete all the Kubernetes Node Pools within an existing Kubernetes Nodepools.",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	k8sCmd.AddCommand(K8sNodePoolLanCmd())
 
 	return k8sCmd
 }
 
-func RunK8sNodePoolCreateFromJSON(c *core.CommandConfig, propertiesFromJson ionoscloud.KubernetesNodePoolForPost) error {
-	np, _, err := client.Must().CloudClient.KubernetesApi.K8sNodepoolsPost(context.Background(),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))).KubernetesNodePool(propertiesFromJson).Execute()
+func RunK8sNodePoolCreateFromJSON(
+	c *core.CommandConfig, propertiesFromJson ionoscloud.KubernetesNodePoolForPost,
+) error {
+	np, _, err := client.Must().CloudClient.KubernetesApi.K8sNodepoolsPost(
+		context.Background(),
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+	).KubernetesNodePool(propertiesFromJson).Execute()
 	if err != nil {
 		return fmt.Errorf("failed creating nodepool from json properties: %w", err)
 	}
@@ -317,12 +531,25 @@ func RunK8sNodePoolCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Creating K8s NodePool in K8s Cluster with ID: %v", viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Creating K8s NodePool in K8s Cluster with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.K8s().CreateNodePool(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)), *newNodePool, queryParams)
+	u, resp, err := c.CloudApiV6Services.K8s().CreateNodePool(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, constants.FlagClusterId,
+			),
+		), *newNodePool, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -342,8 +569,10 @@ func handleApiResponseK8sNodepoolCreate(c *core.CommandConfig, pool ionoscloud.K
 			if err = waitfor.WaitForState(c, waiter.K8sNodePoolStateInterrogator, *id); err != nil {
 				return err
 			}
-			if pool, _, err = client.Must().CloudClient.KubernetesApi.K8sNodepoolsFindById(context.Background(),
-				viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)), *id).
+			if pool, _, err = client.Must().CloudClient.KubernetesApi.K8sNodepoolsFindById(
+				context.Background(),
+				viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)), *id,
+			).
 				Depth(viper.GetInt32(core.GetFlagName(c.NS, constants.ArgDepth))).
 				Execute(); err != nil {
 				return err
@@ -355,8 +584,10 @@ func handleApiResponseK8sNodepoolCreate(c *core.CommandConfig, pool ionoscloud.K
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(pool, uConverted,
-		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		pool, uConverted,
+		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -367,7 +598,8 @@ func handleApiResponseK8sNodepoolCreate(c *core.CommandConfig, pool ionoscloud.K
 }
 
 func PreRunK8sNodePoolsList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{constants.FlagClusterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -384,7 +616,8 @@ func PreRunK8sClusterNodePoolIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunK8sClusterNodePoolDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{constants.FlagClusterId, constants.FlagNodepoolId},
 		[]string{constants.FlagClusterId, cloudapiv6.ArgAll},
 	)
@@ -436,13 +669,18 @@ func RunK8sNodePoolListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allNodePools, allNodePoolsConverted,
-		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allNodePools, allNodePoolsConverted,
+		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -454,8 +692,12 @@ func RunK8sNodePoolList(c *core.CommandConfig) error {
 		return RunK8sNodePoolListAll(c)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting K8s NodePools from K8s Cluster with ID: %v", viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting K8s NodePools from K8s Cluster with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		),
+	)
 
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
@@ -479,9 +721,18 @@ func RunK8sNodePoolList(c *core.CommandConfig) error {
 		}
 	}
 
-	k8ss, resp, err := c.CloudApiV6Services.K8s().ListNodePools(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)), listQueryParams)
+	k8ss, resp, err := c.CloudApiV6Services.K8s().ListNodePools(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, constants.FlagClusterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -494,8 +745,10 @@ func RunK8sNodePoolList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(k8ss.KubernetesNodePools, k8ssConverted,
-		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		k8ss.KubernetesNodePools, k8ssConverted,
+		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -519,12 +772,18 @@ func RunK8sNodePoolGet(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"K8s node pool with id: %v from K8s Cluster with id: %v is getting...", k8sNodePoolId, k8sClusterId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"K8s node pool with id: %v from K8s Cluster with id: %v is getting...", k8sNodePoolId, k8sClusterId,
+		),
+	)
 
 	u, resp, err := c.CloudApiV6Services.K8s().GetNodePool(k8sClusterId, k8sNodePoolId, queryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -537,8 +796,10 @@ func RunK8sNodePoolGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(u.KubernetesNodePool, uConverted,
-		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		u.KubernetesNodePool, uConverted,
+		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -555,28 +816,39 @@ func RunK8sNodePoolUpdate(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	oldNodePool, _, err := c.CloudApiV6Services.K8s().GetNodePool(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), queryParams)
+	oldNodePool, _, err := c.CloudApiV6Services.K8s().GetNodePool(
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), queryParams,
+	)
 	if err != nil {
 		return err
 	}
 
 	newNodePool := getNewK8sNodePoolUpdated(oldNodePool, c)
-	_, resp, err := c.CloudApiV6Services.K8s().UpdateNodePool(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), newNodePool, queryParams)
+	_, resp, err := c.CloudApiV6Services.K8s().UpdateNodePool(
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), newNodePool, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	if err = waitfor.WaitForState(c, waiter.K8sNodePoolStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))); err != nil {
+	if err = waitfor.WaitForState(
+		c, waiter.K8sNodePoolStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)),
+	); err != nil {
 		return err
 	}
 
-	newNodePoolUpdated, _, err := c.CloudApiV6Services.K8s().GetNodePool(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
-		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), queryParams)
+	newNodePoolUpdated, _, err := c.CloudApiV6Services.K8s().GetNodePool(
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId)), queryParams,
+	)
 
 	newNodePoolUpdatedConverted, err := resource2table.ConvertK8sNodepoolToTable(newNodePoolUpdated.KubernetesNodePool)
 	if err != nil {
@@ -585,8 +857,10 @@ func RunK8sNodePoolUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(newNodePoolUpdated.KubernetesNodePool, newNodePoolUpdatedConverted,
-		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		newNodePoolUpdated.KubernetesNodePool, newNodePoolUpdatedConverted,
+		tabheaders.GetHeaders(allK8sNodePoolCols, defaultK8sNodePoolCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -614,22 +888,32 @@ func RunK8sNodePoolDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete k8s node pool", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete k8s node pool", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting K8s node pool with id: %v from K8s Cluster with id: %v...", k8sNodePoolId, k8sClusterId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting K8s node pool with id: %v from K8s Cluster with id: %v...", k8sNodePoolId, k8sClusterId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.K8s().DeleteNodePool(k8sClusterId, k8sNodePoolId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodepool successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodepool successfully deleted"),
+	)
 	return nil
 }
 
@@ -652,7 +936,9 @@ func getNewK8sNodePool(c *core.CommandConfig) (*resources.K8sNodePoolForPost, er
 		return nil, err
 	}
 
-	storageSize, err := utils2.ConvertSize(viper.GetString(core.GetFlagName(c.NS, constants.FlagStorageSize)), utils2.GigaBytes)
+	storageSize, err := utils2.ConvertSize(
+		viper.GetString(core.GetFlagName(c.NS, constants.FlagStorageSize)), utils2.GigaBytes,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -671,44 +957,72 @@ func getNewK8sNodePool(c *core.CommandConfig) (*resources.K8sNodePoolForPost, er
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", name))
 
 	nodePoolProperties.SetK8sVersion(k8sversion)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property K8sVersion set: %v", k8sversion))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property K8sVersion set: %v", k8sversion),
+	)
 
 	nodePoolProperties.SetNodeCount(nodeCount)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NodeCount set: %v", nodeCount))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NodeCount set: %v", nodeCount),
+	)
 
 	nodePoolProperties.SetDatacenterId(dcId)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DatacenterId set: %v", dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DatacenterId set: %v", dcId),
+	)
 
 	nodePoolProperties.SetCpuFamily(cpuFamily)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CPU Family set: %v", cpuFamily))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CPU Family set: %v", cpuFamily),
+	)
 
 	nodePoolProperties.SetCoresCount(cores)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CoresCount set: %v", cores))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CoresCount set: %v", cores),
+	)
 
 	nodePoolProperties.SetRamSize(int32(ramSize))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property RAM Size set: %vMB", int32(ramSize)))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Property RAM Size set: %vMB", int32(ramSize)),
+	)
 
 	nodePoolProperties.SetAvailabilityZone(availabilityZone)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Availability Zone set: %v", availabilityZone))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Property Availability Zone set: %v", availabilityZone),
+	)
 
 	nodePoolProperties.SetStorageSize(int32(storageSize))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Storage Size set: %vGB", int32(storageSize)))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Property Storage Size set: %vGB", int32(storageSize)),
+	)
 
 	nodePoolProperties.SetStorageType(storageType)
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Storage Type set: %v", storageType))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Property Storage Type set: %v", storageType),
+	)
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagLabels)) {
 		keyValueMapLabels := viper.GetStringMapString(core.GetFlagName(c.NS, constants.FlagLabels))
 		nodePoolProperties.SetLabels(keyValueMapLabels)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Labels set: %v", keyValueMapLabels))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Labels set: %v", keyValueMapLabels),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagAnnotations)) {
 		keyValueMapAnnotations := viper.GetStringMapString(core.GetFlagName(c.NS, constants.FlagAnnotations))
 		nodePoolProperties.SetAnnotations(keyValueMapAnnotations)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Annotations set: %v", keyValueMapAnnotations))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Annotations set: %v", keyValueMapAnnotations),
+		)
 	}
 
 	// Add LANs
@@ -720,13 +1034,19 @@ func getNewK8sNodePool(c *core.CommandConfig) (*resources.K8sNodePoolForPost, er
 		for _, lanId := range lanIds {
 			id := int32(lanId)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Lan ID set: %v", id))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Dhcp set: %v", dhcp))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Lan ID set: %v", id),
+			)
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Dhcp set: %v", dhcp),
+			)
 
-			newLans = append(newLans, ionoscloud.KubernetesNodePoolLan{
-				Id:   &id,
-				Dhcp: &dhcp,
-			})
+			newLans = append(
+				newLans, ionoscloud.KubernetesNodePoolLan{
+					Id:   &id,
+					Dhcp: &dhcp,
+				},
+			)
 		}
 
 		nodePoolProperties.SetLans(newLans)
@@ -747,7 +1067,10 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			vers := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sVersion))
 			propertiesUpdated.SetK8sVersion(vers)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property K8sVersion set: %v", vers))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property K8sVersion set: %v", vers),
+			)
 		} else {
 			if vers, ok := properties.GetK8sVersionOk(); ok && vers != nil {
 				propertiesUpdated.SetK8sVersion(*vers)
@@ -758,7 +1081,10 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			nodeCount := viper.GetInt32(core.GetFlagName(c.NS, constants.FlagNodeCount))
 			propertiesUpdated.SetNodeCount(nodeCount)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NodeCount set: %v", nodeCount))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property NodeCount set: %v", nodeCount),
+			)
 		} else {
 			if n, ok := properties.GetNodeCountOk(); ok && n != nil {
 				propertiesUpdated.SetNodeCount(*n)
@@ -773,7 +1099,10 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMinNodeCount)) {
 				minCount = viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMinNodeCount))
 
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property MinNodeCount set: %v", minCount))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Property MinNodeCount set: %v", minCount),
+				)
 			} else {
 				if m, ok := autoScaling.GetMinNodeCountOk(); ok && m != nil {
 					minCount = *m
@@ -783,25 +1112,32 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMaxNodeCount)) {
 				maxCount = viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMaxNodeCount))
 
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property MaxNodeCount set: %v", maxCount))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Property MaxNodeCount set: %v", maxCount),
+				)
 			} else {
 				if m, ok := autoScaling.GetMaxNodeCountOk(); ok && m != nil {
 					maxCount = *m
 				}
 			}
 
-			propertiesUpdated.SetAutoScaling(ionoscloud.KubernetesAutoScaling{
-				MinNodeCount: &minCount,
-				MaxNodeCount: &maxCount,
-			})
+			propertiesUpdated.SetAutoScaling(
+				ionoscloud.KubernetesAutoScaling{
+					MinNodeCount: &minCount,
+					MaxNodeCount: &maxCount,
+				},
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMaintenanceDay)) ||
 			viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgK8sMaintenanceTime)) {
 			if maintenance, ok := properties.GetMaintenanceWindowOk(); ok && maintenance != nil {
-				newMaintenanceWindow := getMaintenanceInfo(c, &resources.K8sMaintenanceWindow{
-					KubernetesMaintenanceWindow: *maintenance,
-				})
+				newMaintenanceWindow := getMaintenanceInfo(
+					c, &resources.K8sMaintenanceWindow{
+						KubernetesMaintenanceWindow: *maintenance,
+					},
+				)
 
 				propertiesUpdated.SetMaintenanceWindow(newMaintenanceWindow.KubernetesMaintenanceWindow)
 			}
@@ -811,35 +1147,51 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgK8sAnnotationValue)) {
 			key := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sAnnotationKey))
 			value := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgK8sAnnotationValue))
-			propertiesUpdated.SetAnnotations(map[string]string{
-				key: value,
-			})
+			propertiesUpdated.SetAnnotations(
+				map[string]string{
+					key: value,
+				},
+			)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Annotations set: key: %v, value: %v", key, value))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Annotations set: key: %v, value: %v", key, value),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey)) &&
 			viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue)) {
 			key := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 			value := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
-			propertiesUpdated.SetLabels(map[string]string{
-				key: value,
-			})
+			propertiesUpdated.SetLabels(
+				map[string]string{
+					key: value,
+				},
+			)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Labels set: key: %v, value: %v", key, value))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Labels set: key: %v, value: %v", key, value),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagLabels)) {
 			keyValueMapLabels := viper.GetStringMapString(core.GetFlagName(c.NS, constants.FlagLabels))
 			propertiesUpdated.SetLabels(keyValueMapLabels)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Labels set: %v", keyValueMapLabels))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Labels set: %v", keyValueMapLabels),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagAnnotations)) {
 			keyValueMapAnnotations := viper.GetStringMapString(core.GetFlagName(c.NS, constants.FlagAnnotations))
 			propertiesUpdated.SetAnnotations(keyValueMapAnnotations)
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Annotations set: %v", keyValueMapAnnotations))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Annotations set: %v", keyValueMapAnnotations),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLanIds)) {
@@ -857,12 +1209,16 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			dhcp := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDhcp))
 			for _, lanId := range lanIds {
 				id := int32(lanId)
-				newLans = append(newLans, ionoscloud.KubernetesNodePoolLan{
-					Id:   &id,
-					Dhcp: &dhcp,
-				})
+				newLans = append(
+					newLans, ionoscloud.KubernetesNodePoolLan{
+						Id:   &id,
+						Dhcp: &dhcp,
+					},
+				)
 
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Lans set: %v", id))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Lans set: %v", id),
+				)
 			}
 
 			propertiesUpdated.SetLans(newLans)
@@ -872,7 +1228,10 @@ func getNewK8sNodePoolUpdated(oldUser *resources.K8sNodePool, c *core.CommandCon
 			publicIps := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgPublicIps))
 			propertiesUpdated.SetPublicIps(publicIps)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PublicIps set: %v", publicIps))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property PublicIps set: %v", publicIps),
+			)
 		}
 	}
 
@@ -895,7 +1254,9 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("K8sCluster ID: %v", k8sClusterId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting K8sNodePools..."))
 
-	k8sNodePools, resp, err := c.CloudApiV6Services.K8s().ListNodePools(k8sClusterId, cloudapiv6.ParentResourceListQueryParams)
+	k8sNodePools, resp, err := c.CloudApiV6Services.K8s().ListNodePools(
+		k8sClusterId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -927,7 +1288,10 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the K8sNodePools", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the K8sNodePools",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -940,11 +1304,17 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting K8sNodePool with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting K8sNodePool with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.K8s().DeleteNodePool(k8sClusterId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 
 		if err != nil {
@@ -952,7 +1322,10 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
@@ -964,6 +1337,8 @@ func DeleteAllK8sNodepools(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodepools successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Nodepools successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -41,43 +41,67 @@ func K8sNodePoolLanCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace:  "nodepool",
-		Resource:   "lan",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Kubernetes NodePool LANs",
-		LongDesc:   "Use this command to get a list of all contained NodePool LANs in a selected Kubernetes Cluster.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
-		Example:    listK8sNodePoolLanExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolIds,
-		CmdRun:     RunK8sNodePoolLanList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace:  "nodepool",
+			Resource:   "lan",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Kubernetes NodePool LANs",
+			LongDesc:   "Use this command to get a list of all contained NodePool LANs in a selected Kubernetes Cluster.\n\nRequired values to run command:\n\n* K8s Cluster Id\n* K8s NodePool Id",
+			Example:    listK8sNodePoolLanExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolIds,
+			CmdRun:     RunK8sNodePoolLanList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(list.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(constants.ArgCols, "", defaultK8sNodePoolLanCols, tabheaders.ColsMessage(defaultK8sNodePoolLanCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		constants.ArgCols, "", defaultK8sNodePoolLanCols, tabheaders.ColsMessage(defaultK8sNodePoolLanCols),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	add := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "nodepool",
-		Resource:  "lan",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add a Kubernetes NodePool LAN",
-		LongDesc: `Use this command to add a Node Pool LAN into an existing Node Pool.
+	add := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "nodepool",
+			Resource:  "lan",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add a Kubernetes NodePool LAN",
+			LongDesc: `Use this command to add a Node Pool LAN into an existing Node Pool.
 
 You can wait for the Node Pool to be in "ACTIVE" state using ` + "`" + `--wait-for-state` + "`" + ` flag together with ` + "`" + `--timeout` + "`" + ` option.
 
@@ -86,71 +110,126 @@ Required values to run a command:
 * K8s Cluster Id
 * K8s NodePool Id
 * Lan Id`,
-		Example:    addK8sNodePoolLanExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolLanIds,
-		CmdRun:     RunK8sNodePoolLanAdd,
-		InitClient: true,
-	})
+			Example:    addK8sNodePoolLanExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolLanIds,
+			CmdRun:     RunK8sNodePoolLanAdd,
+			InitClient: true,
+		},
+	)
 	add.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(add.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddIntFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 0, "The unique LAN Id of existing LANs to be attached to worker Nodes", core.RequiredFlagOption())
-	add.AddBoolFlag(cloudapiv6.ArgDhcp, "", true, "Indicates if the Kubernetes Node Pool LAN will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false")
-	add.AddStringSliceFlag(cloudapiv6.ArgNetwork, "", nil, "Slice of IPv4 or IPv6 CIDRs to be routed via the interface. Must contain same number of arguments as --gateway-ip flag")
-	add.AddStringSliceFlag(cloudapiv6.ArgGatewayIp, "", nil, "Slice of IPv4 or IPv6 Gateway IPs for the routes. Must contain same number of arguments as --network flag")
-	add.AddStringSliceFlag(cloudapiv6.ArgCols, "", defaultK8sNodePoolLanCols, tabheaders.ColsMessage(defaultK8sNodePoolLanCols))
-	_ = add.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddIntFlag(
+		cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 0,
+		"The unique LAN Id of existing LANs to be attached to worker Nodes", core.RequiredFlagOption(),
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgDhcp, "", true,
+		"Indicates if the Kubernetes Node Pool LAN will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false",
+	)
+	add.AddStringSliceFlag(
+		cloudapiv6.ArgNetwork, "", nil,
+		"Slice of IPv4 or IPv6 CIDRs to be routed via the interface. Must contain same number of arguments as --gateway-ip flag",
+	)
+	add.AddStringSliceFlag(
+		cloudapiv6.ArgGatewayIp, "", nil,
+		"Slice of IPv4 or IPv6 Gateway IPs for the routes. Must contain same number of arguments as --network flag",
+	)
+	add.AddStringSliceFlag(
+		cloudapiv6.ArgCols, "", defaultK8sNodePoolLanCols, tabheaders.ColsMessage(defaultK8sNodePoolLanCols),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultK8sNodePoolLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Remove Command
 	*/
-	removeCmd := core.NewCommand(ctx, k8sCmd, core.CommandBuilder{
-		Namespace: "nodepool",
-		Resource:  "lan",
-		Verb:      "remove",
-		Aliases:   []string{"r"},
-		ShortDesc: "Remove a Kubernetes NodePool LAN",
-		LongDesc: `This command removes a Kubernetes Node Pool LAN from a Node Pool.
+	removeCmd := core.NewCommand(
+		ctx, k8sCmd, core.CommandBuilder{
+			Namespace: "nodepool",
+			Resource:  "lan",
+			Verb:      "remove",
+			Aliases:   []string{"r"},
+			ShortDesc: "Remove a Kubernetes NodePool LAN",
+			LongDesc: `This command removes a Kubernetes Node Pool LAN from a Node Pool.
 
 Required values to run command:
 
 * K8s Cluster Id
 * K8s NodePool Id
 * Lan Id`,
-		Example:    removeK8sNodePoolLanExample,
-		PreCmdRun:  PreRunK8sClusterNodePoolLanRemove,
-		CmdRun:     RunK8sNodePoolLanRemove,
-		InitClient: true,
-	})
+			Example:    removeK8sNodePoolLanExample,
+			PreCmdRun:  PreRunK8sClusterNodePoolLanRemove,
+			CmdRun:     RunK8sNodePoolLanRemove,
+			InitClient: true,
+		},
+	)
+	removeCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeCmd.AddUUIDFlag(constants.FlagClusterId, "", "", cloudapiv6.K8sClusterId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddUUIDFlag(constants.FlagNodepoolId, "", "", cloudapiv6.K8sNodePoolId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.K8sNodePoolsIds(viper.GetString(core.GetFlagName(removeCmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeCmd.AddIntFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 0, "The unique LAN Id of existing LANs to be detached from worker Nodes", core.RequiredFlagOption())
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.K8sNodePoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeCmd.AddIntFlag(
+		cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 0,
+		"The unique LAN Id of existing LANs to be detached from worker Nodes", core.RequiredFlagOption(),
+	)
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all FK8s Nodepool Lans.")
-	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	removeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return k8sCmd
 }
 
 func PreRunK8sClusterNodePoolLanIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgLanId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgLanId,
+	)
 }
 
 func PreRunK8sClusterNodePoolLanRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgLanId},
 		[]string{constants.FlagClusterId, constants.FlagNodepoolId, cloudapiv6.ArgAll},
 	)
@@ -163,7 +242,10 @@ func RunK8sNodePoolLanList(c *core.CommandConfig) error {
 		resources.QueryParams{},
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -181,8 +263,10 @@ func RunK8sNodePoolLanList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.K8sNodePoolLan, lans,
-		tabheaders.GetHeadersAllDefault(defaultK8sNodePoolLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.K8sNodePoolLan, lans,
+		tabheaders.GetHeadersAllDefault(defaultK8sNodePoolLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -216,7 +300,10 @@ func RunK8sNodePoolLanAdd(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -224,8 +311,10 @@ func RunK8sNodePoolLanAdd(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.K8sNodePoolLan, getK8sNodePoolLansForPut(ngNew),
-		tabheaders.GetHeadersAllDefault(defaultK8sNodePoolLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.K8sNodePoolLan, getK8sNodePoolLansForPut(ngNew),
+		tabheaders.GetHeadersAllDefault(defaultK8sNodePoolLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -253,7 +342,9 @@ func RunK8sNodePoolLanRemove(c *core.CommandConfig) error {
 	clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
 	nodePoolId := viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove node pool lan", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove node pool lan", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -265,13 +356,19 @@ func RunK8sNodePoolLanRemove(c *core.CommandConfig) error {
 	input := removeK8sNodePoolLanInfo(c, ng)
 	_, resp, err := c.CloudApiV6Services.K8s().UpdateNodePool(clusterId, nodePoolId, input, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Node Pool Lan successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Kubernetes Node Pool Lan successfully deleted"),
+	)
 	return nil
 }
 
@@ -289,7 +386,9 @@ func RemoveAllK8sNodePoolsLans(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("K8sNodePool ID: %v", nodePoolId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting K8sNodePool Lans..."))
 
-	k8sNodepool, resp, err := c.CloudApiV6Services.K8s().GetNodePool(clusterId, nodePoolId, cloudapiv6.ParentResourceQueryParams)
+	k8sNodepool, resp, err := c.CloudApiV6Services.K8s().GetNodePool(
+		clusterId, nodePoolId, cloudapiv6.ParentResourceQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -311,15 +410,22 @@ func RemoveAllK8sNodePoolsLans(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("K8s NodePool Lans to be removed:"))
 	for _, lan := range *lans {
 		if id, ok := lan.GetIdOk(); ok && id != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("K8s NodePool Lan Id: "+string(*id)))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("K8s NodePool Lan Id: "+string(*id)),
+			)
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove all the K8sNodePool Lans", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove all the K8sNodePool Lans",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the K8sNodePool Lans..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the K8sNodePool Lans..."),
+	)
 
 	propertiesUpdated := resources.K8sNodePoolPropertiesForPut{}
 	if n, ok := nodePoolProperties.GetNodeCountOk(); ok && n != nil {
@@ -348,13 +454,19 @@ func RemoveAllK8sNodePoolsLans(c *core.CommandConfig) error {
 
 	_, resp, err = c.CloudApiV6Services.K8s().UpdateNodePool(clusterId, nodePoolId, k8sNodePoolUpdated, queryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Kubernetes Node Pool Lans successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Kubernetes Node Pool Lans successfully deleted"),
+	)
 	return nil
 }
 
@@ -395,22 +507,38 @@ func getNewK8sNodePoolLanInfo(c *core.CommandConfig, oldNg *resources.K8sNodePoo
 				Dhcp: &dhcp,
 			}
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding a Kubernetes NodePool LAN with id: %v and dhcp: %v", lanId, dhcp))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Adding a Kubernetes NodePool LAN with id: %v and dhcp: %v", lanId, dhcp,
+				),
+			)
 
 			if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNetwork)) {
 				network := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgNetwork))
 				gatewayIp := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgGatewayIp))
 
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Network set: %v", network))
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property GatewayIp set: %v", gatewayIp))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Property Network set: %v", network),
+				)
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Property GatewayIp set: %v", gatewayIp),
+				)
 
 				if len(network) != len(gatewayIp) {
-					die.Die(fmt.Sprintf("Flags %s, %s have different number of arguments, must be the same", cloudapiv6.ArgNetwork, cloudapiv6.ArgGatewayIp))
+					die.Die(
+						fmt.Sprintf(
+							"Flags %s, %s have different number of arguments, must be the same", cloudapiv6.ArgNetwork,
+							cloudapiv6.ArgGatewayIp,
+						),
+					)
 				}
 
 				routes := make([]ionoscloud.KubernetesNodePoolLanRoutes, 0)
 				for i, net := range network {
-					routes = append(routes,
+					routes = append(
+						routes,
 						ionoscloud.KubernetesNodePoolLanRoutes{
 							Network:   pointer.From(net), // Copy the loop variable and take its address. See #289 - always same address would be used
 							GatewayIp: &gatewayIp[i],
@@ -457,7 +585,10 @@ func removeK8sNodePoolLanInfo(c *core.CommandConfig, oldNg *resources.K8sNodePoo
 			lanId := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgLanId))
 			newLans := make([]ionoscloud.KubernetesNodePoolLan, 0)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing a Kubernetes NodePool LAN with id: %v", lanId))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Removing a Kubernetes NodePool LAN with id: %v", lanId),
+			)
 
 			if existingLans, ok := properties.GetLansOk(); ok && existingLans != nil {
 				for _, existingLan := range *existingLans {

--- a/commands/cloudapi-v6/k8s_nodepool_lan_test.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan_test.go
@@ -188,267 +188,343 @@ var (
 func TestPreRunK8sClusterNodePoolLanIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanVar)
-		err := PreRunK8sClusterNodePoolLanIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanVar)
+			err := PreRunK8sClusterNodePoolLanIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterNodePoolLanIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunK8sClusterNodePoolLanIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunK8sClusterNodePoolLanIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgCols), defaultK8sNodePoolLanCols)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, &testResponse, nil)
-		err := RunK8sNodePoolLanList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.Resource, cloudapiv6.ArgCols), defaultK8sNodePoolLanCols)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, &testResponse, nil)
+			err := RunK8sNodePoolLanList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
-		err := RunK8sNodePoolLanList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
+			err := RunK8sNodePoolLanList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanListLansErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.K8sNodePool{
-			KubernetesNodePool: ionoscloud.KubernetesNodePool{
-				Id:         &testK8sNodePoolLanVar,
-				Properties: &ionoscloud.KubernetesNodePoolProperties{},
-			},
-		}, nil, nil)
-		err := RunK8sNodePoolLanList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(
+				&resources.K8sNodePool{
+					KubernetesNodePool: ionoscloud.KubernetesNodePool{
+						Id:         &testK8sNodePoolLanVar,
+						Properties: &ionoscloud.KubernetesNodePoolProperties{},
+					},
+				}, nil, nil,
+			)
+			err := RunK8sNodePoolLanList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanListPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.K8sNodePool{
-			KubernetesNodePool: ionoscloud.KubernetesNodePool{
-				Id: &testK8sNodePoolLanVar,
-			},
-		}, nil, nil)
-		err := RunK8sNodePoolLanList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(
+				&resources.K8sNodePool{
+					KubernetesNodePool: ionoscloud.KubernetesNodePool{
+						Id: &testK8sNodePoolLanVar,
+					},
+				}, nil, nil,
+			)
+			err := RunK8sNodePoolLanList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTestUpdated, &testResponse, nil)
-		err := RunK8sNodePoolLanAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTestUpdated, &testResponse, nil)
+			err := RunK8sNodePoolLanAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTestUpdated, nil, testK8sNodePoolLanErr)
-		err := RunK8sNodePoolLanAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTestUpdated, nil, testK8sNodePoolLanErr)
+			err := RunK8sNodePoolLanAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
-		err := RunK8sNodePoolLanAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetwork), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGatewayIp), testK8sNodePoolLanVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
+			err := RunK8sNodePoolLanAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTestUpdatedRemove, &testResponse, nil)
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTestUpdatedRemove, &testResponse, nil)
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemoveAll, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&k8sNodepoolLanTestUpdatedRemove, &testResponse, nil)
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemoveAll,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&k8sNodepoolLanTestUpdatedRemove, &testResponse, nil)
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemoveAsk(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTestUpdatedRemove, nil, nil)
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTestUpdatedRemove, nil, nil)
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemoveAskErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTestUpdatedRemove, nil, testK8sNodePoolLanErr)
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, inputK8sNodepoolLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTestUpdatedRemove, nil, testK8sNodePoolLanErr)
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolLanRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
-		err := RunK8sNodePoolLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testK8sNodePoolLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testK8sNodePoolLanIntVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testK8sNodePoolLanVar, testK8sNodePoolLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&k8sNodepoolLanTest, nil, testK8sNodePoolLanErr)
+			err := RunK8sNodePoolLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/k8s_nodepool_test.go
+++ b/commands/cloudapi-v6/k8s_nodepool_test.go
@@ -307,693 +307,874 @@ var (
 func TestPreRunK8sClusterNodePoolIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		err := PreRunK8sClusterNodePoolIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			err := PreRunK8sClusterNodePoolIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sClusterNodePoolIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunK8sClusterNodePoolIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunK8sClusterNodePoolIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		err := PreRunK8sNodePoolsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			err := PreRunK8sNodePoolsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolsListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunK8sNodePoolsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunK8sNodePoolsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		err := PreRunK8sClusterNodePoolDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			err := PreRunK8sClusterNodePoolDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunK8sClusterNodePoolDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunK8sClusterNodePoolDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunK8sClusterNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunK8sClusterNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunK8sNodePoolsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunK8sNodePoolsList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunK8sNodePoolsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(clustersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testClusterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepoolsList, &testResponse, nil).Times(len(getK8sClusters(clustersList)))
-		err := RunK8sNodePoolListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListClusters(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				clustersList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testClusterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepoolsList, &testResponse, nil).Times(len(getK8sClusters(clustersList)))
+			err := RunK8sNodePoolListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepools, &testResponse, nil)
-		err := RunK8sNodePoolList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepools, &testResponse, nil)
+			err := RunK8sNodePoolList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.K8sNodePools{
-				KubernetesNodePools: ionoscloud.KubernetesNodePools{
-					Items: &[]ionoscloud.KubernetesNodePool{}},
-			},
-			&testResponse, nil)
-		err := RunK8sNodePoolList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.K8sNodePools{
+					KubernetesNodePools: ionoscloud.KubernetesNodePools{
+						Items: &[]ionoscloud.KubernetesNodePool{},
+					},
+				},
+				&testResponse, nil,
+			)
+			err := RunK8sNodePoolList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepools, nil, testNodepoolErr)
-		err := RunK8sNodePoolList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepools, nil, testNodepoolErr)
+			err := RunK8sNodePoolList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, &testResponse, nil)
-		err := RunK8sNodePoolGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, &testResponse, nil)
+			err := RunK8sNodePoolGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		err := RunK8sNodePoolGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			err := RunK8sNodePoolGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, testNodepoolErr)
-		err := RunK8sNodePoolGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, testNodepoolErr)
+			err := RunK8sNodePoolGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, testNodepoolErr)
-		err := RunK8sNodePoolGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, testNodepoolErr)
+			err := RunK8sNodePoolGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTest, &testResponse, nil)
-		err := RunK8sNodePoolCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(
+				testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTest, &testResponse, nil)
+			err := RunK8sNodePoolCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolPrivateCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testNodepoolVar, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(testNodepoolVar, nodepoolTestPrivatePost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestPrivate, &testResponse, nil)
-		err := RunK8sNodePoolCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testNodepoolVar, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(
+				testNodepoolVar, nodepoolTestPrivatePost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestPrivate, &testResponse, nil)
+			err := RunK8sNodePoolCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolCreateGetK8sVersionErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testNodepoolVar, nil, testNodepoolErr)
-		err := RunK8sNodePoolCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetVersion().Return(testNodepoolVar, nil, testNodepoolErr)
+			err := RunK8sNodePoolCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolCreateWaitStateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestId, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestId, nil, testNodepoolErr)
-		err := RunK8sNodePoolCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(
+				testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestId, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestId, nil, testNodepoolErr)
+			err := RunK8sNodePoolCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
-		rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTest, nil, testNodepoolErr)
-		err := RunK8sNodePoolCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageType), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagStorageSize), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testNodepoolIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVMap)
+			rm.CloudApiV6Mocks.K8s.EXPECT().CreateNodePool(
+				testNodepoolVar, nodepoolTestPost, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTest, nil, testNodepoolErr)
+			err := RunK8sNodePoolCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGetNew, nil, nil)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar},
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGetNew, nil, nil)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdateWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestNew, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGetNew, nil, nil)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar},
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestNew, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGetNew, nil, nil)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestNew, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGetNew, nil, testNodepoolErr)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar},
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestNew, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGetNew, nil, testNodepoolErr)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdateOldUser(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testNodepoolVar, testNodepoolVar, nodepoolTestUpdateOld, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestOld, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testNodepoolVar, testNodepoolVar, nodepoolTestUpdateOld, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestOld, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestNew, nil, testNodepoolErr)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanIds), []int{int(testNodepoolIntNewVar)})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar},
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().UpdateNodePool(
+				testNodepoolVar, testNodepoolVar, nodepoolTestUpdateNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestNew, nil, testNodepoolErr)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNodepoolIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar})
-		rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nodepoolTestGet, nil, testNodepoolErr)
-		err := RunK8sNodePoolUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sVersion), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceDay), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaintenanceTime), testNodepoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAnnotations), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagLabels), testNodepoolKVNewMap)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMinNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgK8sMaxNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodeCount), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNodepoolIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), testK8sNodePoolLanBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgPublicIps), []string{testNodepoolNewVar, testNodepoolNewVar},
+			)
+			rm.CloudApiV6Mocks.K8s.EXPECT().GetNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nodepoolTestGet, nil, testNodepoolErr)
+			err := RunK8sNodePoolUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepoolsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepoolsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepoolsList, nil, testNodepoolErr)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepoolsList, nil, testNodepoolErr)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.K8sNodePools{}, &testResponse, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.K8sNodePools{}, &testResponse, nil)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.K8sNodePools{KubernetesNodePools: ionoscloud.KubernetesNodePools{Items: &[]ionoscloud.KubernetesNodePool{}}}, &testResponse, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.K8sNodePools{KubernetesNodePools: ionoscloud.KubernetesNodePools{Items: &[]ionoscloud.KubernetesNodePool{}}},
+				&testResponse, nil,
+			)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nodepoolsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNodepoolErr)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().ListNodePools(
+				testNodepoolVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nodepoolsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNodepoolErr)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNodepoolErr)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNodepoolErr)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunK8sNodePoolDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.K8s.EXPECT().DeleteNodePool(
+				testNodepoolVar, testNodepoolVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunK8sNodePoolDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunK8sNodePoolDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunK8sNodePoolDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagNodepoolId), testNodepoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testNodepoolVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunK8sNodePoolDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/label.go
+++ b/commands/cloudapi-v6/label.go
@@ -33,195 +33,355 @@ func LabelCmd() *core.Command {
 	globalFlags := labelCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultLabelCols, tabheaders.ColsMessage(defaultLabelCols))
 	_ = viper.BindPFlag(core.GetFlagName(labelCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = labelCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultLabelCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = labelCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultLabelCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	var (
-		allowedValues = []string{cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource, cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource}
+		allowedValues = []string{
+			cloudapiv6.DatacenterResource, cloudapiv6.VolumeResource, cloudapiv6.ServerResource,
+			cloudapiv6.SnapshotResource, cloudapiv6.IpBlockResource,
+		}
 	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, labelCmd, core.CommandBuilder{
-		Namespace:  "label",
-		Resource:   "label",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Labels from Resources",
-		LongDesc:   "Use this command to list all Labels from all Resources under your account. If you want to list all Labels from a specific Resource, use `--resource-type` option together with the Resource Id: `--datacenter-id`, `--server-id`, `--volume-id`.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LabelsFiltersUsage(),
-		Example:    listLabelsExample,
-		PreCmdRun:  PreRunLabelList,
-		CmdRun:     RunLabelList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, labelCmd, core.CommandBuilder{
+			Namespace:  "label",
+			Resource:   "label",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Labels from Resources",
+			LongDesc:   "Use this command to list all Labels from all Resources under your account. If you want to list all Labels from a specific Resource, use `--resource-type` option together with the Resource Id: `--datacenter-id`, `--server-id`, `--volume-id`.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LabelsFiltersUsage(),
+			Example:    listLabelsExample,
+			PreCmdRun:  PreRunLabelList,
+			CmdRun:     RunLabelList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgIpBlockId, "", "", cloudapiv6.IpBlockId)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgSnapshotId, "", "", cloudapiv6.SnapshotId)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to list labels from", core.RequiredFlagOption())
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddSetFlag(
+		cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to list labels from",
+		core.RequiredFlagOption(),
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LabelsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LabelsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LabelsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LabelsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, labelCmd, core.CommandBuilder{
-		Namespace:  "label",
-		Resource:   "label",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Label",
-		LongDesc:   "Use this command to get information about a specified Label from a specified Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key",
-		Example:    getLabelExample,
-		PreCmdRun:  PreRunResourceTypeLabelKey,
-		CmdRun:     RunLabelGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, labelCmd, core.CommandBuilder{
+			Namespace:  "label",
+			Resource:   "label",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Label",
+			LongDesc:   "Use this command to get information about a specified Label from a specified Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key",
+			Example:    getLabelExample,
+			PreCmdRun:  PreRunResourceTypeLabelKey,
+			CmdRun:     RunLabelGet,
+			InitClient: true,
+		},
+	)
 	get.AddStringFlag(cloudapiv6.ArgLabelKey, "", "", cloudapiv6.LabelKey, core.RequiredFlagOption())
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId)
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId)
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId)
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgIpBlockId, "", "", cloudapiv6.IpBlockId)
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgSnapshotId, "", "", cloudapiv6.SnapshotId)
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to get labels from", core.RequiredFlagOption())
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddSetFlag(
+		cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to get labels from",
+		core.RequiredFlagOption(),
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Get By Urn Command
 	*/
-	getByUrn := core.NewCommand(ctx, labelCmd, core.CommandBuilder{
-		Namespace:  "label",
-		Resource:   "label",
-		Verb:       "get-by-urn",
-		ShortDesc:  "Get a Label using URN",
-		LongDesc:   "Use this command to get information about a specified Label using its URN. A URN is used for uniqueness of a Label and composed using `urn:label:<resource_type>:<resource_uuid>:<key>`.\n\nRequired values to run command:\n\n* Label URN",
-		Example:    getLabelByUrnExample,
-		PreCmdRun:  PreRunLabelUrn,
-		CmdRun:     RunLabelGetByUrn,
-		InitClient: true,
-	})
-	getByUrn.AddStringFlag(cloudapiv6.ArgLabelUrn, "", "", "URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>]", core.RequiredFlagOption())
-	getByUrn.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	getByUrn := core.NewCommand(
+		ctx, labelCmd, core.CommandBuilder{
+			Namespace:  "label",
+			Resource:   "label",
+			Verb:       "get-by-urn",
+			ShortDesc:  "Get a Label using URN",
+			LongDesc:   "Use this command to get information about a specified Label using its URN. A URN is used for uniqueness of a Label and composed using `urn:label:<resource_type>:<resource_uuid>:<key>`.\n\nRequired values to run command:\n\n* Label URN",
+			Example:    getLabelByUrnExample,
+			PreCmdRun:  PreRunLabelUrn,
+			CmdRun:     RunLabelGetByUrn,
+			InitClient: true,
+		},
+	)
+	getByUrn.AddStringFlag(
+		cloudapiv6.ArgLabelUrn, "", "", "URN for the Label [urn:label:<resource_type>:<resource_uuid>:<key>]",
+		core.RequiredFlagOption(),
+	)
+	getByUrn.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	addLabel := core.NewCommand(ctx, labelCmd, core.CommandBuilder{
-		Namespace:  "label",
-		Resource:   "label",
-		Verb:       "add",
-		Aliases:    []string{"a"},
-		ShortDesc:  "Add a Label to a Resource",
-		LongDesc:   "Use this command to add a Label to a specific Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key\n* Label Value",
-		Example:    addLabelExample,
-		PreCmdRun:  PreRunResourceTypeLabelKeyValue,
-		CmdRun:     RunLabelAdd,
-		InitClient: true,
-	})
+	addLabel := core.NewCommand(
+		ctx, labelCmd, core.CommandBuilder{
+			Namespace:  "label",
+			Resource:   "label",
+			Verb:       "add",
+			Aliases:    []string{"a"},
+			ShortDesc:  "Add a Label to a Resource",
+			LongDesc:   "Use this command to add a Label to a specific Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key\n* Label Value",
+			Example:    addLabelExample,
+			PreCmdRun:  PreRunResourceTypeLabelKeyValue,
+			CmdRun:     RunLabelAdd,
+			InitClient: true,
+		},
+	)
 	addLabel.AddStringFlag(cloudapiv6.ArgLabelKey, "", "", cloudapiv6.LabelKey, core.RequiredFlagOption())
 	addLabel.AddStringFlag(cloudapiv6.ArgLabelValue, "", "", cloudapiv6.LabelValue, core.RequiredFlagOption())
 	addLabel.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId)
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addLabel.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId)
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(addLabel.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						addLabel.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addLabel.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId)
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(addLabel.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						addLabel.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addLabel.AddUUIDFlag(cloudapiv6.ArgIpBlockId, "", "", cloudapiv6.IpBlockId)
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addLabel.AddUUIDFlag(cloudapiv6.ArgSnapshotId, "", "", cloudapiv6.SnapshotId)
-	_ = addLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	addLabel.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to add labels to", core.RequiredFlagOption())
-	addLabel.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = addLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	addLabel.AddSetFlag(
+		cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to add labels to",
+		core.RequiredFlagOption(),
+	)
+	addLabel.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Remove Command
 	*/
-	removeLabel := core.NewCommand(ctx, labelCmd, core.CommandBuilder{
-		Namespace:  "label",
-		Resource:   "label",
-		Verb:       "remove",
-		Aliases:    []string{"r"},
-		ShortDesc:  "Remove a Label from a Resource",
-		LongDesc:   "Use this command to remove a Label from a Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key",
-		Example:    removeLabelExample,
-		PreCmdRun:  PreRunResourceTypeLabelKeyRemove,
-		CmdRun:     RunLabelRemove,
-		InitClient: true,
-	})
+	removeLabel := core.NewCommand(
+		ctx, labelCmd, core.CommandBuilder{
+			Namespace:  "label",
+			Resource:   "label",
+			Verb:       "remove",
+			Aliases:    []string{"r"},
+			ShortDesc:  "Remove a Label from a Resource",
+			LongDesc:   "Use this command to remove a Label from a Resource.\n\nRequired values to run command:\n\n* Resource Type\n* Resource Id: Datacenter Id, Server Id, Volume Id, IpBlock Id or Snapshot Id\n* Label Key",
+			Example:    removeLabelExample,
+			PreCmdRun:  PreRunResourceTypeLabelKeyRemove,
+			CmdRun:     RunLabelRemove,
+			InitClient: true,
+		},
+	)
+	removeLabel.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeLabel.AddStringFlag(cloudapiv6.ArgLabelKey, "", "", cloudapiv6.LabelKey, core.RequiredFlagOption())
 	removeLabel.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId)
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeLabel.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId)
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(removeLabel.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeLabel.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeLabel.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId)
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(removeLabel.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeLabel.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeLabel.AddUUIDFlag(cloudapiv6.ArgIpBlockId, "", "", cloudapiv6.IpBlockId)
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgIpBlockId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgIpBlockId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.IpBlocksIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeLabel.AddUUIDFlag(cloudapiv6.ArgSnapshotId, "", "", cloudapiv6.SnapshotId)
-	_ = removeLabel.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeLabel.AddSetFlag(cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to remove labels from", core.RequiredFlagOption())
+	_ = removeLabel.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeLabel.AddSetFlag(
+		cloudapiv6.ArgResourceType, "", "", allowedValues, "Type of resource to remove labels from",
+		core.RequiredFlagOption(),
+	)
 	removeLabel.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all Labels")
-	removeLabel.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	removeLabel.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return labelCmd
 }
@@ -241,11 +401,19 @@ func generateFlagSets(c *core.PreCommandConfig, extraFlags ...string) []core.Fla
 			Predicate:      funcResourceTypeSetAndMatches,
 			PredicateParam: cloudapiv6.DatacenterResource,
 		}, {
-			FlagNameSet:    append([]string{cloudapiv6.ArgResourceType, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgVolumeId}, extraFlags...),
+			FlagNameSet: append(
+				[]string{
+					cloudapiv6.ArgResourceType, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgVolumeId,
+				}, extraFlags...,
+			),
 			Predicate:      funcResourceTypeSetAndMatches,
 			PredicateParam: cloudapiv6.VolumeResource,
 		}, {
-			FlagNameSet:    append([]string{cloudapiv6.ArgResourceType, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId}, extraFlags...),
+			FlagNameSet: append(
+				[]string{
+					cloudapiv6.ArgResourceType, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId,
+				}, extraFlags...,
+			),
 			Predicate:      funcResourceTypeSetAndMatches,
 			PredicateParam: cloudapiv6.ServerResource,
 		}, {
@@ -265,7 +433,8 @@ func PreRunResourceTypeLabelKey(c *core.PreCommandConfig) error {
 }
 
 func PreRunResourceTypeLabelKeyRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSetsIfPredicate(c.Command, c.NS,
+	return core.CheckRequiredFlagsSetsIfPredicate(
+		c.Command, c.NS,
 		append(
 			generateFlagSets(c, cloudapiv6.ArgLabelKey),
 			generateFlagSets(c, cloudapiv6.ArgAll)...,
@@ -274,7 +443,9 @@ func PreRunResourceTypeLabelKeyRemove(c *core.PreCommandConfig) error {
 }
 
 func PreRunResourceTypeLabelKeyValue(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSetsIfPredicate(c.Command, c.NS, generateFlagSets(c, cloudapiv6.ArgLabelKey, cloudapiv6.ArgLabelValue)...)
+	return core.CheckRequiredFlagsSetsIfPredicate(
+		c.Command, c.NS, generateFlagSets(c, cloudapiv6.ArgLabelKey, cloudapiv6.ArgLabelValue)...,
+	)
 }
 
 func PreRunLabelUrn(c *core.PreCommandConfig) error {
@@ -320,8 +491,10 @@ func RunLabelList(c *core.CommandConfig) error {
 
 		cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-		out, err = jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.Labels,
-			tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+		out, err = jsontabwriter.GenerateOutput(
+			"items", jsonpaths.Label, labelDcs.Labels,
+			tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+		)
 		if err != nil {
 			return err
 		}
@@ -339,8 +512,11 @@ func RunLabelGet(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting label with label key: %v and label value: %v for %v...", labelKey, labelValue, resourceType))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting label with label key: %v and label value: %v for %v...", labelKey, labelValue, resourceType,
+		),
+	)
 
 	switch resourceType {
 	case cloudapiv6.DatacenterResource:
@@ -372,8 +548,10 @@ func RunLabelGetByUrn(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.Label,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.Label,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -405,7 +583,10 @@ func RunLabelAdd(c *core.CommandConfig) error {
 func RunLabelRemove(c *core.CommandConfig) error {
 	resourceType := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceType))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Label is removing from %v...", resourceType))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Label is removing from %v...", resourceType),
+	)
 
 	switch resourceType {
 	case cloudapiv6.DatacenterResource:

--- a/commands/cloudapi-v6/labelresource.go
+++ b/commands/cloudapi-v6/labelresource.go
@@ -25,9 +25,14 @@ func RunDataCenterLabelsList(c *core.CommandConfig) error {
 		return err
 	}
 
-	labelDcs, resp, err := c.CloudApiV6Services.Labels().DatacenterList(listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)))
+	labelDcs, resp, err := c.CloudApiV6Services.Labels().DatacenterList(
+		listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -35,8 +40,10 @@ func RunDataCenterLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Label, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -50,11 +57,17 @@ func RunDataCenterLabelGet(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Datacenter with id: %v...", labelKey, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Datacenter with id: %v...", labelKey, dcId),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().DatacenterGet(dcId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -62,8 +75,10 @@ func RunDataCenterLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -78,12 +93,18 @@ func RunDataCenterLabelAdd(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding label with key: %v and value: %v to Datacenter with id: %v...", labelKey, labelValue, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding label with key: %v and value: %v to Datacenter with id: %v...", labelKey, labelValue, dcId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().DatacenterCreate(dcId, labelKey, labelValue)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -91,8 +112,10 @@ func RunDataCenterLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -114,17 +137,25 @@ func RunDataCenterLabelRemove(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing label with key: %v for Datacenter with id: %v...", labelKey, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Removing label with key: %v for Datacenter with id: %v...", labelKey, dcId),
+	)
 
 	resp, err := c.CloudApiV6Services.Labels().DatacenterDelete(dcId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Datacenter Label successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Datacenter Label successfully deleted"),
+	)
 	return nil
 }
 
@@ -132,7 +163,9 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Labels from Datacenter..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Labels from Datacenter..."),
+	)
 
 	labels, resp, err := c.CloudApiV6Services.Labels().DatacenterList(resources.ListQueryParams{}, dcId)
 	if err != nil {
@@ -148,7 +181,10 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) error {
 		return fmt.Errorf("no Datacenter Labels found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Datacenter with ID: %v", dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Datacenter with ID: %v", dcId),
+	)
 
 	for _, label := range *labelsItems {
 		delIdAndName := ""
@@ -166,11 +202,17 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Labels from Datacenter with Id: "+dcId, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Labels from Datacenter with Id: "+dcId,
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Datacenter with Id: %v...", dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Datacenter with Id: %v...", dcId),
+	)
 
 	var multiErr error
 	for _, label := range *labelsItems {
@@ -184,18 +226,27 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key),
+		)
 
 		resp, err = c.CloudApiV6Services.Labels().DatacenterDelete(dcId, *key)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *key, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *key, err))
@@ -206,7 +257,9 @@ func RemoveAllDatacenterLabels(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Datacenter Labels successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Datacenter Labels successfully deleted"),
+	)
 	return nil
 }
 
@@ -222,7 +275,10 @@ func RunServerLabelsList(c *core.CommandConfig) error {
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -230,8 +286,10 @@ func RunServerLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Label, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -246,11 +304,17 @@ func RunServerLabelGet(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 	labelkey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Server with id: %v...", labelkey, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Server with id: %v...", labelkey, serverId),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().ServerGet(dcId, serverId, labelkey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -258,8 +322,10 @@ func RunServerLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -275,12 +341,18 @@ func RunServerLabelAdd(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding label with key: %v and value: %v to Server with id: %v...", labelKey, labelValue, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding label with key: %v and value: %v to Server with id: %v...", labelKey, labelValue, serverId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().ServerCreate(dcId, serverId, labelKey, labelValue)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -288,8 +360,10 @@ func RunServerLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -312,12 +386,18 @@ func RunServerLabelRemove(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Removing label with key: %v for Server with id: %v...", labelKey, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Removing label with key: %v for Server with id: %v...", labelKey, serverId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Labels().ServerDelete(dcId, serverId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -354,7 +434,10 @@ func RemoveAllServerLabels(c *core.CommandConfig) error {
 		return fmt.Errorf("no Server Labels found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Server with Id: %v", serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Server with Id: %v", serverId),
+	)
 
 	for _, label := range *labelsItems {
 		delIdAndName := ""
@@ -372,11 +455,17 @@ func RemoveAllServerLabels(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Labels from Server with Id: "+serverId, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Labels from Server with Id: "+serverId,
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Server with Id: %v...", serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Server with Id: %v...", serverId),
+	)
 
 	var multiErr error
 	for _, label := range *labelsItems {
@@ -390,18 +479,27 @@ func RemoveAllServerLabels(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key),
+		)
 
 		resp, err = c.CloudApiV6Services.Labels().ServerDelete(dcId, serverId, *key)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *key, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *key, err))
@@ -428,7 +526,10 @@ func RunVolumeLabelsList(c *core.CommandConfig) error {
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId)),
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -436,8 +537,10 @@ func RunVolumeLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Label, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -452,11 +555,17 @@ func RunVolumeLabelGet(c *core.CommandConfig) error {
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Volume with id: %v...", labelKey, volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting label with key: %v for Volume with id: %v...", labelKey, volumeId),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().VolumeGet(dcId, volumeId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -464,8 +573,10 @@ func RunVolumeLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -481,12 +592,18 @@ func RunVolumeLabelAdd(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding label with key: %v and value: %v to Volume with id: %v...", labelKey, labelValue, volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding label with key: %v and value: %v to Volume with id: %v...", labelKey, labelValue, volumeId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().VolumeCreate(dcId, volumeId, labelKey, labelValue)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -494,8 +611,10 @@ func RunVolumeLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -518,12 +637,18 @@ func RunVolumeLabelRemove(c *core.CommandConfig) error {
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Removing label with key: %v for Volume with id: %v...", labelKey, volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Removing label with key: %v for Volume with id: %v...", labelKey, volumeId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Labels().VolumeDelete(dcId, volumeId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -538,7 +663,10 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Volume with Id: %v", volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Volume with Id: %v", volumeId),
+	)
 
 	labels, resp, err := c.CloudApiV6Services.Labels().VolumeList(resources.ListQueryParams{}, dcId, volumeId)
 	if err != nil {
@@ -554,7 +682,10 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) error {
 		return fmt.Errorf("no Volume Labels found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Volume with Id: %v", volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Volume with Id: %v", volumeId),
+	)
 
 	for _, label := range *labelsItems {
 		delIdAndName := ""
@@ -572,11 +703,17 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Labels from Volume with Id: "+volumeId, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Labels from Volume with Id: "+volumeId,
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Volume with Id: %v...", volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Volume with Id: %v...", volumeId),
+	)
 
 	var multiErr error
 	for _, label := range *labelsItems {
@@ -590,18 +727,27 @@ func RemoveAllVolumeLabels(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key),
+		)
 
 		resp, err = c.CloudApiV6Services.Labels().VolumeDelete(dcId, volumeId, *key)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *key, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *key, err))
@@ -622,9 +768,14 @@ func RunIpBlockLabelsList(c *core.CommandConfig) error {
 		return err
 	}
 
-	labelDcs, resp, err := c.CloudApiV6Services.Labels().IpBlockList(listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId)))
+	labelDcs, resp, err := c.CloudApiV6Services.Labels().IpBlockList(
+		listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId)),
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -632,8 +783,10 @@ func RunIpBlockLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Label, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -647,12 +800,18 @@ func RunIpBlockLabelGet(c *core.CommandConfig) error {
 	ipBlockId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().IpBlockGet(ipBlockId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -660,8 +819,10 @@ func RunIpBlockLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -676,12 +837,18 @@ func RunIpBlockLabelAdd(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding label with key: %v and value: %v to IpBlock with id: %v...", labelKey, labelValue, ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding label with key: %v and value: %v to IpBlock with id: %v...", labelKey, labelValue, ipBlockId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().IpBlockCreate(ipBlockId, labelKey, labelValue)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -689,8 +856,10 @@ func RunIpBlockLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -712,11 +881,18 @@ func RunIpBlockLabelRemove(c *core.CommandConfig) error {
 	ipBlockId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIpBlockId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Removing label with key: %v for IpBlock with id: %v...", labelKey, ipBlockId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Labels().IpBlockDelete(ipBlockId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -746,7 +922,10 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) error {
 		return fmt.Errorf("no IP Block Labels found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from IpBlock with Id: %v", ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from IpBlock with Id: %v", ipBlockId),
+	)
 
 	for _, label := range *labelsItems {
 		delIdAndName := ""
@@ -764,11 +943,17 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Labels from IpBlock with Id: "+ipBlockId, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Labels from IpBlock with Id: "+ipBlockId,
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from IpBlock with Id: %v...", ipBlockId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from IpBlock with Id: %v...", ipBlockId),
+	)
 
 	var multiErr error
 	for _, label := range *labelsItems {
@@ -782,18 +967,27 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key),
+		)
 
 		resp, err = c.CloudApiV6Services.Labels().IpBlockDelete(ipBlockId, *key)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *key, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *key, err))
@@ -804,7 +998,9 @@ func RemoveAllIpBlockLabels(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("IP Block Labels successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("IP Block Labels successfully deleted"),
+	)
 	return nil
 }
 
@@ -814,9 +1010,14 @@ func RunSnapshotLabelsList(c *core.CommandConfig) error {
 		return err
 	}
 
-	labelDcs, resp, err := c.CloudApiV6Services.Labels().SnapshotList(listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)))
+	labelDcs, resp, err := c.CloudApiV6Services.Labels().SnapshotList(
+		listQueryParams, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -824,8 +1025,10 @@ func RunSnapshotLabelsList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Label, labelDcs.LabelResources,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Label, labelDcs.LabelResources,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -839,12 +1042,18 @@ func RunSnapshotLabelGet(c *core.CommandConfig) error {
 	snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting label with key: %v for Snapshot with id: %v...", labelKey, snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting label with key: %v for Snapshot with id: %v...", labelKey, snapshotId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().SnapshotGet(snapshotId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -852,8 +1061,10 @@ func RunSnapshotLabelGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -868,12 +1079,18 @@ func RunSnapshotLabelAdd(c *core.CommandConfig) error {
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 	labelValue := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelValue))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding label with key: %v and value: %v to Snapshot with id: %v...", labelKey, labelValue, snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding label with key: %v and value: %v to Snapshot with id: %v...", labelKey, labelValue, snapshotId,
+		),
+	)
 
 	labelDc, resp, err := c.CloudApiV6Services.Labels().SnapshotCreate(snapshotId, labelKey, labelValue)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -881,8 +1098,10 @@ func RunSnapshotLabelAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Label, labelDc.LabelResource,
-		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Label, labelDc.LabelResource,
+		tabheaders.GetHeadersAllDefault(defaultLabelCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -904,12 +1123,18 @@ func RunSnapshotLabelRemove(c *core.CommandConfig) error {
 	snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))
 	labelKey := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLabelKey))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Removing label with key: %v for Snapshot with id: %v...", labelKey, snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Removing label with key: %v for Snapshot with id: %v...", labelKey, snapshotId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Labels().SnapshotDelete(snapshotId, labelKey)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -922,7 +1147,10 @@ func RunSnapshotLabelRemove(c *core.CommandConfig) error {
 func RemoveAllSnapshotLabels(c *core.CommandConfig) error {
 	snapshotId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Snapshot with Id: %v", snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Snapshot with Id: %v", snapshotId),
+	)
 
 	labels, resp, err := c.CloudApiV6Services.Labels().SnapshotList(resources.ListQueryParams{}, snapshotId)
 	if err != nil {
@@ -938,7 +1166,10 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) error {
 		return fmt.Errorf("no Snapshot Labels found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Labels to be removed from Snapshot with Id: %v", snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Labels to be removed from Snapshot with Id: %v", snapshotId),
+	)
 
 	for _, label := range *labelsItems {
 		delIdAndName := ""
@@ -956,11 +1187,17 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Labels from Snapshot with Id: "+snapshotId, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Labels from Snapshot with Id: "+snapshotId,
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Snapshot with Id: %v...", snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Labels from Snapshot with Id: %v...", snapshotId),
+	)
 
 	var multiErr error
 	for _, label := range *labelsItems {
@@ -974,18 +1211,27 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Label with id: %v...", *key),
+		)
 
 		resp, err = c.CloudApiV6Services.Labels().SnapshotDelete(snapshotId, *key)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *key, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *key),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *key, err))
@@ -996,6 +1242,8 @@ func RemoveAllSnapshotLabels(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Snapshot Labels successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Snapshot Labels successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/labelresource_test.go
+++ b/commands/cloudapi-v6/labelresource_test.go
@@ -48,1098 +48,1408 @@ var (
 func TestRunDataCenterLabelsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, &testResponse, nil)
-		err := RunDataCenterLabelsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, &testResponse, nil)
+			err := RunDataCenterLabelsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterLabelsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, nil, testLabelResourceErr)
-		err := RunDataCenterLabelsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, nil, testLabelResourceErr)
+			err := RunDataCenterLabelsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterLabelGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunDataCenterLabelGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunDataCenterLabelGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDataCenterLabelGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunDataCenterLabelGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunDataCenterLabelGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunDataCenterLabelAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunDataCenterLabelAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunDataCenterLabelAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunDataCenterLabelAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, nil, testLabelResourceErr)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, nil, testLabelResourceErr)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(resources.LabelResources{}, &testResponse, nil)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(resources.LabelResources{}, &testResponse, nil)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(
-			resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}}, &testResponse, nil)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(
+				resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}},
+				&testResponse, nil,
+			)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, testLabelResourceErr)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, testLabelResourceErr)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunDatacenterLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(nil, testLabelResourceErr)
-		err := RunDataCenterLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().DatacenterDelete(testLabelResourceVar, testLabelResourceVar).Return(
+				nil, testLabelResourceErr,
+			)
+			err := RunDataCenterLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, &testResponse, nil)
-		err := RunIpBlockLabelsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, &testResponse, nil)
+			err := RunIpBlockLabelsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, nil, testLabelResourceErr)
-		err := RunIpBlockLabelsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, nil, testLabelResourceErr)
+			err := RunIpBlockLabelsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunIpBlockLabelGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunIpBlockLabelGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunIpBlockLabelGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunIpBlockLabelGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunIpBlockLabelAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunIpBlockLabelAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunIpBlockLabelAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunIpBlockLabelAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, nil, testLabelResourceErr)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, nil, testLabelResourceErr)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(resources.LabelResources{}, &testResponse, nil)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(resources.LabelResources{}, &testResponse, nil)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(
-			resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}}, &testResponse, nil)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(
+				resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}},
+				&testResponse, nil,
+			)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, testLabelResourceErr)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, testLabelResourceErr)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunIpBlockLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(nil, testLabelResourceErr)
-		err := RunIpBlockLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIpBlockId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().IpBlockDelete(testLabelResourceVar, testLabelResourceVar).Return(
+				nil, testLabelResourceErr,
+			)
+			err := RunIpBlockLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, &testResponse, nil)
-		err := RunSnapshotLabelsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, &testResponse, nil)
+			err := RunSnapshotLabelsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResources, nil, testLabelResourceErr)
-		err := RunSnapshotLabelsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResources, nil, testLabelResourceErr)
+			err := RunSnapshotLabelsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunSnapshotLabelGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunSnapshotLabelGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotGet(testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunSnapshotLabelGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotGet(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunSnapshotLabelGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunSnapshotLabelAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunSnapshotLabelAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunSnapshotLabelAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunSnapshotLabelAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, nil, testLabelResourceErr)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, nil, testLabelResourceErr)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(resources.LabelResources{}, &testResponse, nil)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(resources.LabelResources{}, &testResponse, nil)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(
-			resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}}, &testResponse, nil)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(
+				resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}},
+				&testResponse, nil,
+			)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, testLabelResourceErr)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, testLabelResourceErr)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(
+				testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(nil, testLabelResourceErr)
-		err := RunSnapshotLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().SnapshotDelete(testLabelResourceVar, testLabelResourceVar).Return(
+				nil, testLabelResourceErr,
+			)
+			err := RunSnapshotLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResources, &testResponse, nil)
-		err := RunServerLabelsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResources, &testResponse, nil)
+			err := RunServerLabelsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResources, nil, testLabelResourceErr)
-		err := RunServerLabelsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResources, nil, testLabelResourceErr)
+			err := RunServerLabelsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerGet(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunServerLabelGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerGet(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunServerLabelGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerGet(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunServerLabelGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerGet(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunServerLabelGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).
-			Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunServerLabelAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).
+				Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunServerLabelAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunServerLabelAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunServerLabelAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunServerLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunServerLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		// viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunServerLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			// viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunServerLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(resources.LabelResources{}, &testResponse, nil)
-		err := RunServerLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(resources.LabelResources{}, &testResponse, nil)
+			err := RunServerLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, nil, testLabelResourceErr)
-		err := RunServerLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, nil, testLabelResourceErr)
+			err := RunServerLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(
-			resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}}, &testResponse, nil)
-		err := RunServerLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(
+				resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}},
+				&testResponse, nil,
+			)
+			err := RunServerLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, testLabelResourceErr)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunServerLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, testLabelResourceErr)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunServerLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(nil, testLabelResourceErr)
-		err := RunServerLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().ServerDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(nil, testLabelResourceErr)
+			err := RunServerLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelsList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResources, &testResponse, nil)
-		err := RunVolumeLabelsList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResources, &testResponse, nil)
+			err := RunVolumeLabelsList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelsListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResources, nil, testLabelResourceErr)
-		err := RunVolumeLabelsList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResources, nil, testLabelResourceErr)
+			err := RunVolumeLabelsList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeGet(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunVolumeLabelGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeGet(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunVolumeLabelGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeGet(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunVolumeLabelGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeGet(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunVolumeLabelGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).
-			Return(&testLabelResourceRes, &testResponse, nil)
-		err := RunVolumeLabelAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).
+				Return(&testLabelResourceRes, &testResponse, nil)
+			err := RunVolumeLabelAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeCreate(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testLabelResourceRes, nil, testLabelResourceErr)
-		err := RunVolumeLabelAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelValue), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeCreate(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testLabelResourceRes, nil, testLabelResourceErr)
+			err := RunVolumeLabelAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunVolumeLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunVolumeLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunVolumeLabelRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunVolumeLabelRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, nil, testLabelResourceErr)
-		err := RunVolumeLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, nil, testLabelResourceErr)
+			err := RunVolumeLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(resources.LabelResources{}, &testResponse, nil)
-		err := RunVolumeLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(resources.LabelResources{}, &testResponse, nil)
+			err := RunVolumeLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(
-			resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}}, &testResponse, nil)
-		err := RunVolumeLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(
+				resources.LabelResources{LabelResources: ionoscloud.LabelResources{Items: &[]ionoscloud.LabelResource{}}},
+				&testResponse, nil,
+			)
+			err := RunVolumeLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar).Return(testLabelResourcesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, testLabelResourceErr)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(&testResponse, nil)
-		err := RunVolumeLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeList(
+				gomock.AssignableToTypeOf(testListQueryParam), testLabelResourceVar, testLabelResourceVar,
+			).Return(testLabelResourcesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, testLabelResourceErr)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(&testResponse, nil)
+			err := RunVolumeLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeLabelRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
-		rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(testLabelResourceVar, testLabelResourceVar, testLabelResourceVar).Return(nil, testLabelResourceErr)
-		err := RunVolumeLabelRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testLabelResourceVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLabelKey), testLabelResourceVar)
+			rm.CloudApiV6Mocks.Label.EXPECT().VolumeDelete(
+				testLabelResourceVar, testLabelResourceVar, testLabelResourceVar,
+			).Return(nil, testLabelResourceErr)
+			err := RunVolumeLabelRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/lan.go
+++ b/commands/cloudapi-v6/lan.go
@@ -47,76 +47,113 @@ func LanCmd() *core.Command {
 	globalFlags := lanCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultLanCols, tabheaders.ColsMessage(allLanCols))
 	_ = viper.BindPFlag(core.GetFlagName(lanCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = lanCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = lanCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, lanCmd, core.CommandBuilder{
-		Namespace:  "lan",
-		Resource:   "lan",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List LANs",
-		LongDesc:   "Use this command to retrieve a list of LANs provisioned in a specific Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LANsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listLanExample,
-		PreCmdRun:  PreRunLansList,
-		CmdRun:     RunLanList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, lanCmd, core.CommandBuilder{
+			Namespace:  "lan",
+			Resource:   "lan",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List LANs",
+			LongDesc:   "Use this command to retrieve a list of LANs provisioned in a specific Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LANsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listLanExample,
+			PreCmdRun:  PreRunLansList,
+			CmdRun:     RunLanList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LANsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, lanCmd, core.CommandBuilder{
-		Namespace:  "lan",
-		Resource:   "lan",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a LAN",
-		LongDesc:   "Use this command to retrieve information of a given LAN.\n\nRequired values to run command:\n\n* Data Center Id\n* LAN Id",
-		Example:    getLanExample,
-		PreCmdRun:  PreRunDcLanIds,
-		CmdRun:     RunLanGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, lanCmd, core.CommandBuilder{
+			Namespace:  "lan",
+			Resource:   "lan",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a LAN",
+			LongDesc:   "Use this command to retrieve information of a given LAN.\n\nRequired values to run command:\n\n* Data Center Id\n* LAN Id",
+			Example:    getLanExample,
+			PreCmdRun:  PreRunDcLanIds,
+			CmdRun:     RunLanGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddStringFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, lanCmd, core.CommandBuilder{
-		Namespace: "lan",
-		Resource:  "lan",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a LAN",
-		LongDesc: `Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Cross-Connect Id can be set.
+	create := core.NewCommand(
+		ctx, lanCmd, core.CommandBuilder{
+			Namespace: "lan",
+			Resource:  "lan",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a LAN",
+			LongDesc: `Use this command to create a new LAN within a Virtual Data Center on your account. The name, the public option and the Cross-Connect Id can be set.
 
 NOTE: IP Failover is configured after LAN creation using an update command.
 
@@ -125,36 +162,55 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 Required values to run command:
 
 * Data Center Id`,
-		Example:    createLanExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunLanCreate,
-		InitClient: true,
-	})
+			Example:    createLanExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunLanCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed LAN", "The name of the LAN")
-	create.AddBoolFlag(cloudapiv6.ArgPublic, cloudapiv6.ArgPublicShort, cloudapiv6.DefaultPublic, "Indicates if the LAN faces the public Internet (true) or not (false). E.g.: --public=true, --public=false")
+	create.AddBoolFlag(
+		cloudapiv6.ArgPublic, cloudapiv6.ArgPublicShort, cloudapiv6.DefaultPublic,
+		"Indicates if the LAN faces the public Internet (true) or not (false). E.g.: --public=true, --public=false",
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Cross-Connect the LAN will connect to")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for LAN creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for LAN creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for LAN creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for LAN creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 	create.AddStringFlag(cloudapiv6.FlagIPv6CidrBlock, "", "DISABLE", cloudapiv6.FlagIPv6CidrBlockDescriptionForLAN)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, lanCmd, core.CommandBuilder{
-		Namespace: "lan",
-		Resource:  "lan",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a LAN",
-		LongDesc: `Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Cross-Connect.
+	update := core.NewCommand(
+		ctx, lanCmd, core.CommandBuilder{
+			Namespace: "lan",
+			Resource:  "lan",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a LAN",
+			LongDesc: `Use this command to update a specified LAN. You can update the name, the public option for LAN and the Pcc Id to connect the LAN to a Cross-Connect.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -162,41 +218,70 @@ Required values to run command:
 
 * Data Center Id
 * LAN Id`,
-		Example:    updateLanExample,
-		PreCmdRun:  PreRunDcLanIds,
-		CmdRun:     RunLanUpdate,
-		InitClient: true,
-	})
+			Example:    updateLanExample,
+			PreCmdRun:  PreRunDcLanIds,
+			CmdRun:     RunLanUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name of the LAN")
 	update.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", "The unique Id of the Cross-Connect the LAN will connect to")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(cloudapiv6.ArgPublic, "", cloudapiv6.DefaultPublic, "Public option for LAN. E.g.: --public=true, --public=false")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for LAN update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for LAN update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
-	update.AddStringFlag(cloudapiv6.FlagIPv6CidrBlock, "", "DISABLE", cloudapiv6.FlagIPv6CidrBlockDescriptionForLAN+
-		` NOTE: Using an explicit Cidr to update the resource is not fully supported yet.`)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgPublic, "", cloudapiv6.DefaultPublic, "Public option for LAN. E.g.: --public=true, --public=false",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for LAN update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for LAN update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
+	update.AddStringFlag(
+		cloudapiv6.FlagIPv6CidrBlock, "", "DISABLE", cloudapiv6.FlagIPv6CidrBlockDescriptionForLAN+
+			` NOTE: Using an explicit Cidr to update the resource is not fully supported yet.`,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, lanCmd, core.CommandBuilder{
-		Namespace: "lan",
-		Resource:  "lan",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a LAN",
-		LongDesc: `Use this command to delete a specified LAN from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, lanCmd, core.CommandBuilder{
+			Namespace: "lan",
+			Resource:  "lan",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a LAN",
+			LongDesc: `Use this command to delete a specified LAN from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -204,29 +289,54 @@ Required values to run command:
 
 * Data Center Id
 * LAN Id`,
-		Example:    deleteLanExample,
-		PreCmdRun:  PreRunLanDelete,
-		CmdRun:     RunLanDelete,
-		InitClient: true,
-	})
+			Example:    deleteLanExample,
+			PreCmdRun:  PreRunLanDelete,
+			CmdRun:     RunLanDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddStringFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, "", cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for LAN deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Lans from a Virtual Data Center.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for LAN deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for LAN deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Lans from a Virtual Data Center.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for LAN deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return lanCmd
 }
 
 func PreRunLansList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -239,7 +349,8 @@ func PreRunLansList(c *core.PreCommandConfig) error {
 }
 
 func PreRunLanDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLanId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -292,13 +403,18 @@ func RunLanListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allLans, allLansConverted,
-		tabheaders.GetHeaders(allLanCols, defaultLanCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allLans, allLansConverted,
+		tabheaders.GetHeaders(allLanCols, defaultLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -318,9 +434,18 @@ func RunLanList(c *core.CommandConfig) error {
 		return err
 	}
 
-	lans, resp, err := c.CloudApiV6Services.Lans().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), listQueryParams)
+	lans, resp, err := c.CloudApiV6Services.Lans().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -328,8 +453,10 @@ func RunLanList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Lan, lans.Lans,
-		tabheaders.GetHeadersAllDefault(defaultLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Lan, lans.Lans,
+		tabheaders.GetHeadersAllDefault(defaultLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -347,8 +474,13 @@ func RunLanGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Lan with id: %v from Datacenter with id: %v is getting...",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId)), viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Lan with id: %v from Datacenter with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	l, resp, err := c.CloudApiV6Services.Lans().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -356,7 +488,10 @@ func RunLanGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -364,8 +499,10 @@ func RunLanGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Lan, l.Lan,
-		tabheaders.GetHeadersAllDefault(defaultLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Lan, l.Lan,
+		tabheaders.GetHeadersAllDefault(defaultLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -389,8 +526,11 @@ func RunLanCreate(c *core.CommandConfig) error {
 		Public: &public,
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Lan: Name: %v, Public: %v", name, public))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Lan: Name: %v, Public: %v", name, public,
+		),
+	)
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)) {
 		pcc := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))
@@ -410,7 +550,9 @@ func RunLanCreate(c *core.CommandConfig) error {
 		default:
 			cidr = strings.ToLower(cidr)
 			dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
-			dc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(), dcId).Execute()
+			dc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+				context.Background(), dcId,
+			).Execute()
 			if err != nil {
 				return err
 			}
@@ -427,7 +569,10 @@ func RunLanCreate(c *core.CommandConfig) error {
 			properties.SetIpv6CidrBlock(cidr)
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property IPv6 Cidr Block set: %v", cidr))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property IPv6 Cidr Block set: %v", cidr),
+		)
 	}
 
 	input := resources.LanPost{
@@ -436,12 +581,25 @@ func RunLanCreate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Creating LAN in Datacenter with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Creating LAN in Datacenter with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
-	l, resp, err := c.CloudApiV6Services.Lans().Create(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), input, queryParams)
+	l, resp, err := c.CloudApiV6Services.Lans().Create(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), input, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -453,8 +611,10 @@ func RunLanCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Lan, l.LanPost,
-		tabheaders.GetHeadersAllDefault(defaultLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Lan, l.LanPost,
+		tabheaders.GetHeadersAllDefault(defaultLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -484,7 +644,9 @@ func RunLanUpdate(c *core.CommandConfig) error {
 		public := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgPublic))
 		input.SetPublic(public)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Public set: %v", public))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Public set: %v", public),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)) {
@@ -505,7 +667,9 @@ func RunLanUpdate(c *core.CommandConfig) error {
 		default:
 			cidr = strings.ToLower(cidr)
 			dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
-			dc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(), dcId).Execute()
+			dc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+				context.Background(), dcId,
+			).Execute()
 			if err != nil {
 				return err
 			}
@@ -523,8 +687,13 @@ func RunLanUpdate(c *core.CommandConfig) error {
 		}
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating LAN with ID: %v from Datacenter with ID: %v...",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId)), viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating LAN with ID: %v from Datacenter with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLanId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	lanUpdated, resp, err := c.CloudApiV6Services.Lans().Update(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -533,7 +702,10 @@ func RunLanUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -545,8 +717,10 @@ func RunLanUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Lan, lanUpdated.Lan,
-		tabheaders.GetHeadersAllDefault(defaultLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Lan, lanUpdated.Lan,
+		tabheaders.GetHeadersAllDefault(defaultLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -574,16 +748,24 @@ func RunLanDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete lan", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete lan", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting LAN with ID: %v from Datacenter with ID: %v...", lanId, dcId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Lans().Delete(dcId, lanId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -640,7 +822,9 @@ func DeleteAllLans(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Lans", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Lans", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -653,18 +837,27 @@ func DeleteAllLans(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Lan with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Lan with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Lans().Delete(dcId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/lan_test.go
+++ b/commands/cloudapi-v6/lan_test.go
@@ -91,452 +91,572 @@ func TestLanCmd(t *testing.T) {
 func TestPreRunLansList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		err := PreRunLansList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			err := PreRunLansList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunLansListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunLansList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunLansList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunLansListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunLansList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunLansList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lansList, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunLanListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lansList, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunLanListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ls, &testResponse, nil)
-		err := RunLanList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				ls, &testResponse, nil,
+			)
+			err := RunLanList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Lans{}, &testResponse, nil)
-		err := RunLanList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testLanVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Lans{}, &testResponse, nil)
+			err := RunLanList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ls, nil, testLanErr)
-		err := RunLanList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				ls, nil, testLanErr,
+			)
+			err := RunLanList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Lan{Lan: l}, &testResponse, nil)
-		err := RunLanGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Lan{Lan: l}, &testResponse, nil)
+			err := RunLanGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanGet_Err(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Lan{Lan: l}, nil, testLanErr)
-		err := RunLanGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Lan{Lan: l}, nil, testLanErr)
+			err := RunLanGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Create(testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther).Return(&resources.LanPost{LanPost: lp}, &testResponse, nil)
-		err := RunLanCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Create(
+				testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther,
+			).Return(&resources.LanPost{LanPost: lp}, &testResponse, nil)
+			err := RunLanCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Create(testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther).Return(&resources.LanPost{LanPost: lp}, nil, testLanErr)
-		err := RunLanCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Create(
+				testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther,
+			).Return(&resources.LanPost{LanPost: lp}, nil, testLanErr)
+			err := RunLanCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Create(testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther).Return(&resources.LanPost{LanPost: lp}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLanCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Create(
+				testLanVar, resources.LanPost{LanPost: lanPostTest}, testQueryParamOther,
+			).Return(&resources.LanPost{LanPost: lp}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLanCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNew, &testResponse, nil)
-		err := RunLanUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNew, &testResponse, nil)
+			err := RunLanUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNew, nil, testLanErr)
-		err := RunLanUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNew, nil, testLanErr)
+			err := RunLanUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanUpdateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNew, &testResponse, testLanErr)
-		err := RunLanUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNew, &testResponse, testLanErr)
+			err := RunLanUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Update(testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLanUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLanNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPublic), publicNewLan)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testLanNewVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Update(
+				testLanVar, testLanVar, lanProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLanUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLanDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLanDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lansList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLanDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testLanVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lansList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLanDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lansList, nil, testLanErr)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testLanVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lansList, nil, testLanErr)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Lans{}, &testResponse, nil)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testLanVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Lans{}, &testResponse, nil)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Lans{Lans: ionoscloud.Lans{Items: &[]ionoscloud.Lan{}}}, &testResponse, nil)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Lans{Lans: ionoscloud.Lans{Items: &[]ionoscloud.Lan{}}}, &testResponse, nil,
+			)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().List(testLanVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lansList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testLanErr)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().List(
+				testLanVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lansList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testLanErr)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testLanErr)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testLanErr)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Delete(testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunLanDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Delete(
+				testLanVar, testLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunLanDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLanDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunLanDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunLanDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/loadbalancer.go
+++ b/commands/cloudapi-v6/loadbalancer.go
@@ -42,109 +42,168 @@ func LoadBalancerCmd() *core.Command {
 		},
 	}
 	globalFlags := loadbalancerCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultLoadbalancerCols, tabheaders.ColsMessage(allLoadbalancerCols))
-	_ = viper.BindPFlag(core.GetFlagName(loadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = loadbalancerCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allLoadbalancerCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultLoadbalancerCols, tabheaders.ColsMessage(allLoadbalancerCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(loadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = loadbalancerCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allLoadbalancerCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, loadbalancerCmd, core.CommandBuilder{
-		Namespace:  "loadbalancer",
-		Resource:   "loadbalancer",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Load Balancers",
-		LongDesc:   "Use this command to retrieve a list of Load Balancers within a Virtual Data Center on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LoadbalancersFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listLoadbalancerExample,
-		PreCmdRun:  PreRunLoadBalancerList,
-		CmdRun:     RunLoadBalancerList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, loadbalancerCmd, core.CommandBuilder{
+			Namespace:  "loadbalancer",
+			Resource:   "loadbalancer",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Load Balancers",
+			LongDesc:   "Use this command to retrieve a list of Load Balancers within a Virtual Data Center on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.LoadbalancersFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listLoadbalancerExample,
+			PreCmdRun:  PreRunLoadBalancerList,
+			CmdRun:     RunLoadBalancerList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LoadBalancersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, loadbalancerCmd, core.CommandBuilder{
-		Namespace:  "loadbalancer",
-		Resource:   "loadbalancer",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Load Balancer",
-		LongDesc:   "Use this command to retrieve information about a Load Balancer instance.\n\nRequired values to run command:\n\n* Data Center Id\n* Load Balancer Id",
-		Example:    getLoadbalancerExample,
-		PreCmdRun:  PreRunDcLoadBalancerIds,
-		CmdRun:     RunLoadBalancerGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, loadbalancerCmd, core.CommandBuilder{
+			Namespace:  "loadbalancer",
+			Resource:   "loadbalancer",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Load Balancer",
+			LongDesc:   "Use this command to retrieve information about a Load Balancer instance.\n\nRequired values to run command:\n\n* Data Center Id\n* Load Balancer Id",
+			Example:    getLoadbalancerExample,
+			PreCmdRun:  PreRunDcLoadBalancerIds,
+			CmdRun:     RunLoadBalancerGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LoadbalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LoadbalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, loadbalancerCmd, core.CommandBuilder{
-		Namespace: "loadbalancer",
-		Resource:  "loadbalancer",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Load Balancer",
-		LongDesc: `Use this command to create a new Load Balancer within the Virtual Data Center. Load balancers can be used for public or private IP traffic. The name, IP and DHCP for the Load Balancer can be set.
+	create := core.NewCommand(
+		ctx, loadbalancerCmd, core.CommandBuilder{
+			Namespace: "loadbalancer",
+			Resource:  "loadbalancer",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Load Balancer",
+			LongDesc: `Use this command to create a new Load Balancer within the Virtual Data Center. Load balancers can be used for public or private IP traffic. The name, IP and DHCP for the Load Balancer can be set.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Data Center Id`,
-		Example:    createLoadbalancerExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunLoadBalancerCreate,
-		InitClient: true,
-	})
+			Example:    createLoadbalancerExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunLoadBalancerCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Load Balancer", "Name of the Load Balancer")
-	create.AddBoolFlag(cloudapiv6.ArgDhcp, "", cloudapiv6.DefaultDhcp, "Indicates if the Load Balancer will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Load Balancer creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Load Balancer creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		cloudapiv6.ArgDhcp, "", cloudapiv6.DefaultDhcp,
+		"Indicates if the Load Balancer will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Load Balancer creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Load Balancer creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, loadbalancerCmd, core.CommandBuilder{
-		Namespace: "loadbalancer",
-		Resource:  "loadbalancer",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Load Balancer",
-		LongDesc: `Use this command to update the configuration of a specified Load Balancer.
+	update := core.NewCommand(
+		ctx, loadbalancerCmd, core.CommandBuilder{
+			Namespace: "loadbalancer",
+			Resource:  "loadbalancer",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Load Balancer",
+			LongDesc: `Use this command to update the configuration of a specified Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -152,36 +211,63 @@ Required values to run command:
 
 * Data Center Id
 * Load Balancer Id`,
-		Example:    updateLoadbalancerExample,
-		PreCmdRun:  PreRunDcLoadBalancerIds,
-		CmdRun:     RunLoadBalancerUpdate,
-		InitClient: true,
-	})
+			Example:    updateLoadbalancerExample,
+			PreCmdRun:  PreRunDcLoadBalancerIds,
+			CmdRun:     RunLoadBalancerUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LoadbalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LoadbalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Load Balancer")
 	update.AddIpFlag(cloudapiv6.ArgIp, "", nil, "The IP of the Load Balancer")
-	update.AddBoolFlag(cloudapiv6.ArgDhcp, "", cloudapiv6.DefaultDhcp, "Indicates if the Load Balancer will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Load Balancer update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Load Balancer update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDhcp, "", cloudapiv6.DefaultDhcp,
+		"Indicates if the Load Balancer will reserve an IP using DHCP. E.g.: --dhcp=true, --dhcp=false",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Load Balancer update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Load Balancer update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, loadbalancerCmd, core.CommandBuilder{
-		Namespace: "loadbalancer",
-		Resource:  "loadbalancer",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Load Balancer",
-		LongDesc: `Use this command to delete the specified Load Balancer.
+	deleteCmd := core.NewCommand(
+		ctx, loadbalancerCmd, core.CommandBuilder{
+			Namespace: "loadbalancer",
+			Resource:  "loadbalancer",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Load Balancer",
+			LongDesc: `Use this command to delete the specified Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -189,23 +275,49 @@ Required values to run command:
 
 * Data Center Id
 * Load Balancer Id`,
-		Example:    deleteLoadbalancerExample,
-		PreCmdRun:  PreRunDcLoadBalancerDelete,
-		CmdRun:     RunLoadBalancerDelete,
-		InitClient: true,
-	})
+			Example:    deleteLoadbalancerExample,
+			PreCmdRun:  PreRunDcLoadBalancerDelete,
+			CmdRun:     RunLoadBalancerDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LoadbalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for Load Balancer deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the LoadBlancers from a virtual Datacenter.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Load Balancer deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.LoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LoadbalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for Load Balancer deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the LoadBlancers from a virtual Datacenter.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Load Balancer deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	loadbalancerCmd.AddCommand(LoadBalancerNicCmd())
 
@@ -213,7 +325,8 @@ Required values to run command:
 }
 
 func PreRunLoadBalancerList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -230,7 +343,8 @@ func PreRunDcLoadBalancerIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcLoadBalancerDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgLoadBalancerId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -284,13 +398,18 @@ func RunLoadBalancerListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allLoadbalancers, allLoadbalancersConverted,
-		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allLoadbalancers, allLoadbalancersConverted,
+		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -305,17 +424,30 @@ func RunLoadBalancerList(c *core.CommandConfig) error {
 		return RunLoadBalancerListAll(c)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting LoadBalancers from Datacenter with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting LoadBalancers from Datacenter with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	listQueryParams, err := query.GetListQueryParams(c)
 	if err != nil {
 		return err
 	}
 
-	lbs, resp, err := c.CloudApiV6Services.Loadbalancers().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), listQueryParams)
+	lbs, resp, err := c.CloudApiV6Services.Loadbalancers().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -323,8 +455,10 @@ func RunLoadBalancerList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.LoadBalancer, lbs.Loadbalancers,
-		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.LoadBalancer, lbs.Loadbalancers,
+		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -342,8 +476,12 @@ func RunLoadBalancerGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Load balancer with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Load balancer with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLoadBalancerId)),
+		),
+	)
 
 	lb, resp, err := c.CloudApiV6Services.Loadbalancers().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -351,7 +489,10 @@ func RunLoadBalancerGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -359,8 +500,10 @@ func RunLoadBalancerGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.LoadBalancer, lb.Loadbalancer,
-		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.LoadBalancer, lb.Loadbalancer,
+		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -381,12 +524,18 @@ func RunLoadBalancerCreate(c *core.CommandConfig) error {
 	name := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))
 	dhcp := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDhcp))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the load balancer: Name: %v, Dhcp: %v", name, dhcp))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the load balancer: Name: %v, Dhcp: %v", name, dhcp,
+		),
+	)
 
 	lb, resp, err := c.CloudApiV6Services.Loadbalancers().Create(dcId, name, dhcp, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -398,8 +547,10 @@ func RunLoadBalancerCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.LoadBalancer, lb.Loadbalancer,
-		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.LoadBalancer, lb.Loadbalancer,
+		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -446,7 +597,10 @@ func RunLoadBalancerUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -458,8 +612,10 @@ func RunLoadBalancerUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.LoadBalancer, lb.Loadbalancer,
-		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.LoadBalancer, lb.Loadbalancer,
+		tabheaders.GetHeaders(allLoadbalancerCols, defaultLoadbalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -487,16 +643,24 @@ func RunLoadBalancerDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete loadbalancer", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete loadbalancer", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Load balancer with id: %v is deleting...", loadBalancerId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Load balancer with id: %v is deleting...", loadBalancerId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Loadbalancers().Delete(dcid, loadBalancerId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -522,7 +686,9 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcid))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting LoadBalancers..."))
 
-	loadBalancers, resp, err := c.CloudApiV6Services.Loadbalancers().List(dcid, cloudapiv6.ParentResourceListQueryParams)
+	loadBalancers, resp, err := c.CloudApiV6Services.Loadbalancers().List(
+		dcid, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -554,11 +720,16 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the LoadBalancers", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the LoadBalancers",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the LoadBalancers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the LoadBalancers..."),
+	)
 
 	var multiErr error
 	for _, lb := range *loadBalancersItems {
@@ -567,18 +738,27 @@ func DeleteAllLoadBalancers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Load balancer with id: %v ...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Load balancer with id: %v ...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Loadbalancers().Delete(dcid, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/loadbalancer_test.go
+++ b/commands/cloudapi-v6/loadbalancer_test.go
@@ -75,476 +75,610 @@ func TestLoadBalancerCmd(t *testing.T) {
 func TestPreRunDcLoadBalancerIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		err := PreRunDcLoadBalancerIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			err := PreRunDcLoadBalancerIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLoadBalancerIdsRequiredFlagsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcLoadBalancerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcLoadBalancerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLoadBalancerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		err := PreRunLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			err := PreRunLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLoadBalancerListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcLoadBalancerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunLoadBalancerList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunLoadBalancerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lbList, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunLoadBalancerListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lbList, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunLoadBalancerListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(loadbs, &testResponse, nil)
-		err := RunLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(loadbs, &testResponse, nil)
+			err := RunLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Loadbalancers{}, &testResponse, nil)
-		err := RunLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Loadbalancers{}, &testResponse, nil)
+			err := RunLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(loadbs, nil, testLoadbalancerErr)
-		err := RunLoadBalancerList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(loadbs, nil, testLoadbalancerErr)
+			err := RunLoadBalancerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Get(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
-		err := RunLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Get(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
+			err := RunLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Get(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Loadbalancer{Loadbalancer: loadb}, nil, testLoadbalancerErr)
-		err := RunLoadBalancerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Get(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Loadbalancer{Loadbalancer: loadb}, nil, testLoadbalancerErr)
+			err := RunLoadBalancerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
-		err := RunLoadBalancerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(
+				testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
+			err := RunLoadBalancerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Loadbalancer{Loadbalancer: loadb}, nil, testLoadbalancerErr)
-		err := RunLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(
+				testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Loadbalancer{Loadbalancer: loadb}, nil, testLoadbalancerErr)
+			err := RunLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancer)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Create(
+				testLoadbalancerVar, testLoadbalancerVar, dhcpLoadbalancer,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Loadbalancer{Loadbalancer: loadb}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&loadbalancerNew, &testResponse, nil)
-		err := RunLoadBalancerUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(
+				testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&loadbalancerNew, &testResponse, nil)
+			err := RunLoadBalancerUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&loadbalancerNew, nil, testLoadbalancerErr)
-		err := RunLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(
+				testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&loadbalancerNew, nil, testLoadbalancerErr)
+			err := RunLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerUpdateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&loadbalancerNew, &testResponse, testLoadbalancerErr)
-		err := RunLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(
+				testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&loadbalancerNew, &testResponse, testLoadbalancerErr)
+			err := RunLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&loadbalancerNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpLoadbalancerNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testLoadbalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Update(
+				testLoadbalancerVar, testLoadbalancerVar, loadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&loadbalancerNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lbList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lbList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lbList, nil, testLanErr)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lbList, nil, testLanErr)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Loadbalancers{}, &testResponse, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Loadbalancers{}, &testResponse, nil)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Loadbalancers{Loadbalancers: ionoscloud.Loadbalancers{Items: &[]ionoscloud.Loadbalancer{}}}, &testResponse, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.Loadbalancers{Loadbalancers: ionoscloud.Loadbalancers{Items: &[]ionoscloud.Loadbalancer{}}},
+				&testResponse, nil,
+			)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(lbList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testLoadbalancerErr)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().List(
+				testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(lbList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testLoadbalancerErr)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testLoadbalancerErr)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testLoadbalancerErr)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().Delete(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/natgateway.go
+++ b/commands/cloudapi-v6/natgateway.go
@@ -42,80 +42,129 @@ func NatgatewayCmd() *core.Command {
 		},
 	}
 	globalFlags := natgatewayCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultNatGatewayCols, tabheaders.ColsMessage(defaultNatGatewayCols))
-	_ = viper.BindPFlag(core.GetFlagName(natgatewayCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = natgatewayCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultNatGatewayCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultNatGatewayCols, tabheaders.ColsMessage(defaultNatGatewayCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(natgatewayCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = natgatewayCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultNatGatewayCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, natgatewayCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "natgateway",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List NAT Gateways",
-		LongDesc:   "Use this command to list NAT Gateways from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NATGatewaysFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listNatGatewayExample,
-		PreCmdRun:  PreRunNATGatewayList,
-		CmdRun:     RunNatGatewayList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, natgatewayCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "natgateway",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List NAT Gateways",
+			LongDesc:   "Use this command to list NAT Gateways from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NATGatewaysFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listNatGatewayExample,
+			PreCmdRun:  PreRunNATGatewayList,
+			CmdRun:     RunNatGatewayList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NATGatewaysFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, natgatewayCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "natgateway",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a NAT Gateway",
-		LongDesc:   "Use this command to get information about a specified NAT Gateway from a Virtual Data Center. You can also wait for NAT Gateway to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
-		Example:    getNatGatewayExample,
-		PreCmdRun:  PreRunDcNatGatewayIds,
-		CmdRun:     RunNatGatewayGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, natgatewayCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "natgateway",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a NAT Gateway",
+			LongDesc:   "Use this command to get information about a specified NAT Gateway from a Virtual Data Center. You can also wait for NAT Gateway to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
+			Example:    getNatGatewayExample,
+			PreCmdRun:  PreRunDcNatGatewayIds,
+			CmdRun:     RunNatGatewayGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified NAT Gateway to be in AVAILABLE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds]")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified NAT Gateway to be in AVAILABLE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for waiting for NAT Gateway to be in AVAILABLE state [seconds]",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, natgatewayCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "natgateway",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a NAT Gateway",
-		LongDesc: `Use this command to create a NAT Gateway in a specified Virtual Data Center.
+	create := core.NewCommand(
+		ctx, natgatewayCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "natgateway",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a NAT Gateway",
+			LongDesc: `Use this command to create a NAT Gateway in a specified Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -123,31 +172,47 @@ Required values to run command:
 
 * Data Center Id
 * IPs`,
-		Example:    createNatGatewayExample,
-		PreCmdRun:  PreRunDcIdsNatGatewayIps,
-		CmdRun:     RunNatGatewayCreate,
-		InitClient: true,
-	})
+			Example:    createNatGatewayExample,
+			PreCmdRun:  PreRunDcIdsNatGatewayIps,
+			CmdRun:     RunNatGatewayCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "NAT Gateway", "Name of the NAT Gateway")
-	create.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of public reserved IP addresses of the NAT Gateway", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddStringSliceFlag(
+		cloudapiv6.ArgIps, "", nil, "Collection of public reserved IP addresses of the NAT Gateway",
+		core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, natgatewayCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "natgateway",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a NAT Gateway",
-		LongDesc: `Use this command to update a specified NAT Gateway from a Virtual Data Center.
+	update := core.NewCommand(
+		ctx, natgatewayCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "natgateway",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a NAT Gateway",
+			LongDesc: `Use this command to update a specified NAT Gateway from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -155,35 +220,62 @@ Required values to run command:
 
 * Data Center Id
 * NAT Gateway Id`,
-		Example:    updateNatGatewayExample,
-		PreCmdRun:  PreRunDcNatGatewayIds,
-		CmdRun:     RunNatGatewayUpdate,
-		InitClient: true,
-	})
+			Example:    updateNatGatewayExample,
+			PreCmdRun:  PreRunDcNatGatewayIds,
+			CmdRun:     RunNatGatewayUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the NAT Gateway")
-	update.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of public reserved IP addresses of the NAT Gateway. This will overwrite the current values")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddStringSliceFlag(
+		cloudapiv6.ArgIps, "", nil,
+		"Collection of public reserved IP addresses of the NAT Gateway. This will overwrite the current values",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, natgatewayCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "natgateway",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a NAT Gateway",
-		LongDesc: `Use this command to delete a specified NAT Gateway from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, natgatewayCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "natgateway",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a NAT Gateway",
+			LongDesc: `Use this command to delete a specified NAT Gateway from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -191,23 +283,47 @@ Required values to run command:
 
 * Data Center Id
 * NAT Gateway Id`,
-		Example:    deleteNatGatewayExample,
-		PreCmdRun:  PreRunNatGatewayDelete,
-		CmdRun:     RunNatGatewayDelete,
-		InitClient: true,
-	})
+			Example:    deleteNatGatewayExample,
+			PreCmdRun:  PreRunNatGatewayDelete,
+			CmdRun:     RunNatGatewayDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIdShort, "", cloudapiv6.NatGatewayId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Natgateways.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	natgatewayCmd.AddCommand(NatgatewayRuleCmd())
 	natgatewayCmd.AddCommand(NatgatewayLanCmd())
@@ -217,7 +333,8 @@ Required values to run command:
 }
 
 func PreRunNATGatewayList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -238,7 +355,8 @@ func PreRunDcNatGatewayIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunNatGatewayDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -291,13 +409,18 @@ func RunNatGatewayListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allNatGateways, allNatGatewaysConverted,
-		tabheaders.GetHeaders(allNatGatewayCols, defaultNatGatewayCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allNatGateways, allNatGatewaysConverted,
+		tabheaders.GetHeaders(allNatGatewayCols, defaultNatGatewayCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -316,9 +439,18 @@ func RunNatGatewayList(c *core.CommandConfig) error {
 		return err
 	}
 
-	natgateways, resp, err := c.CloudApiV6Services.NatGateways().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), listQueryParams)
+	natgateways, resp, err := c.CloudApiV6Services.NatGateways().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -326,8 +458,10 @@ func RunNatGatewayList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.NatGateway, natgateways.NatGateways,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.NatGateway, natgateways.NatGateways,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -345,12 +479,17 @@ func RunNatGatewayGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if err := waitfor.WaitForState(c, waiter.NatGatewayStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNatGatewayId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.NatGatewayStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNatGatewayId)),
+	); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"NAT Gateway with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNatGatewayId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"NAT Gateway with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNatGatewayId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NatGateways().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -358,7 +497,10 @@ func RunNatGatewayGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -366,8 +508,10 @@ func RunNatGatewayGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGateway, ng.NatGateway,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGateway, ng.NatGateway,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -401,7 +545,10 @@ func RunNatGatewayCreate(c *core.CommandConfig) error {
 	)
 
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -413,8 +560,10 @@ func RunNatGatewayCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGateway, ng.NatGateway,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGateway, ng.NatGateway,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -440,7 +589,10 @@ func RunNatGatewayUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -452,8 +604,10 @@ func RunNatGatewayUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGateway, ng.NatGateway,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGateway, ng.NatGateway,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -481,15 +635,23 @@ func RunNatGatewayDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete nat gateway", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete nat gateway", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starring deleting NAT Gateway with id: %v...", natGatewayId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starring deleting NAT Gateway with id: %v...", natGatewayId),
+	)
 
 	resp, err := c.CloudApiV6Services.NatGateways().Delete(dcId, natGatewayId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -517,7 +679,10 @@ func getNewNatGatewayInfo(c *core.CommandConfig) *resources.NatGatewayProperties
 		publicIps := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgIps))
 		input.SetPublicIps(publicIps)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PublicIps set: %v", publicIps))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property PublicIps set: %v", publicIps),
+		)
 	}
 
 	return &resources.NatGatewayProperties{
@@ -569,11 +734,16 @@ func DeleteAllNatgateways(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the NAT Gateways", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the NAT Gateways",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NAT Gateways..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NAT Gateways..."),
+	)
 
 	var multiErr error
 	for _, natGateway := range *natGatewayItems {
@@ -582,18 +752,27 @@ func DeleteAllNatgateways(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting NAT Gateway with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting NAT Gateway with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.NatGateways().Delete(dcId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/natgateway_flowlog.go
+++ b/commands/cloudapi-v6/natgateway_flowlog.go
@@ -38,85 +38,139 @@ func NatgatewayFlowLogCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, natgatewayFlowLogCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "flowlog",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List NAT Gateway FlowLogs",
-		LongDesc:   "Use this command to list NAT Gateway FlowLogs from a specified NAT Gateway.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
-		Example:    listNatGatewayFlowLogExample,
-		PreCmdRun:  PreRunNATGatewayFlowLogList,
-		CmdRun:     RunNatGatewayFlowLogList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, natgatewayFlowLogCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "flowlog",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List NAT Gateway FlowLogs",
+			LongDesc:   "Use this command to list NAT Gateway FlowLogs from a specified NAT Gateway.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
+			Example:    listNatGatewayFlowLogExample,
+			PreCmdRun:  PreRunNATGatewayFlowLogList,
+			CmdRun:     RunNatGatewayFlowLogList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, natgatewayFlowLogCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "flowlog",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a NAT Gateway FlowLog",
-		LongDesc:   "Use this command to get information about a specified NAT Gateway FlowLog from a NAT Gateway.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id\n* NAT Gateway FlowLog Id",
-		Example:    getNatGatewayFlowLogExample,
-		PreCmdRun:  PreRunDcNatGatewayFlowLogIds,
-		CmdRun:     RunNatGatewayFlowLogGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, natgatewayFlowLogCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "flowlog",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a NAT Gateway FlowLog",
+			LongDesc:   "Use this command to get information about a specified NAT Gateway FlowLog from a NAT Gateway.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id\n* NAT Gateway FlowLog Id",
+			Example:    getNatGatewayFlowLogExample,
+			PreCmdRun:  PreRunDcNatGatewayFlowLogIds,
+			CmdRun:     RunNatGatewayFlowLogGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayFlowLogsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayFlowLogsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, natgatewayFlowLogCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "flowlog",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a NAT Gateway FlowLog",
-		LongDesc: `Use this command to create a NAT Gateway FlowLog in a specified NAT Gateway.
+	create := core.NewCommand(
+		ctx, natgatewayFlowLogCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "flowlog",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a NAT Gateway FlowLog",
+			LongDesc: `Use this command to create a NAT Gateway FlowLog in a specified NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -125,47 +179,84 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * Bucket Name`,
-		Example:    createNatGatewayFlowLogExample,
-		PreCmdRun:  PreRunNatGatewayFlowLogCreate,
-		CmdRun:     RunNatGatewayFlowLogCreate,
-		InitClient: true,
-	})
+			Example:    createNatGatewayFlowLogExample,
+			PreCmdRun:  PreRunNatGatewayFlowLogCreate,
+			CmdRun:     RunNatGatewayFlowLogCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed FlowLog", "The name for the FlowLog")
 	create.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "ALL", "Specifies the traffic Action pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL", "Specifies the traffic Direction pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway FlowLog creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway FlowLog creation [seconds]")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL",
+		"Specifies the traffic Direction pattern",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket",
+		core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway FlowLog creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway FlowLog creation [seconds]",
+	)
 	create.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = create.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, natgatewayFlowLogCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "flowlog",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a NAT Gateway FlowLog",
-		LongDesc: `Use this command to update a specified NAT Gateway FlowLog from a NAT Gateway.
+	update := core.NewCommand(
+		ctx, natgatewayFlowLogCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "flowlog",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a NAT Gateway FlowLog",
+			LongDesc: `Use this command to update a specified NAT Gateway FlowLog from a NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -174,52 +265,94 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * NAT Gateway FlowLog Id`,
-		Example:    updateNatGatewayFlowLogExample,
-		PreCmdRun:  PreRunDcNatGatewayFlowLogIds,
-		CmdRun:     RunNatGatewayFlowLogUpdate,
-		InitClient: true,
-	})
+			Example:    updateNatGatewayFlowLogExample,
+			PreCmdRun:  PreRunDcNatGatewayFlowLogIds,
+			CmdRun:     RunNatGatewayFlowLogUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayFlowLogsIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayFlowLogsIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the NAT Gateway FlowLog")
 	update.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "", "Specifies the traffic Action pattern")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic Direction pattern")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway FlowLog update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway FlowLog update [seconds]")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic Direction pattern",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway FlowLog update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway FlowLog update [seconds]",
+	)
 	update.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = update.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, natgatewayFlowLogCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "flowlog",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a NAT Gateway FlowLog",
-		LongDesc: `Use this command to delete a specified NAT Gateway FlowLog from a NAT Gateway.
+	deleteCmd := core.NewCommand(
+		ctx, natgatewayFlowLogCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "flowlog",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a NAT Gateway FlowLog",
+			LongDesc: `Use this command to delete a specified NAT Gateway FlowLog from a NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -228,38 +361,72 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * NAT Gateway FlowLog Id`,
-		Example:    deleteNatGatewayFlowLogExample,
-		PreCmdRun:  PreRunNatGatewayFlowlogDelete,
-		CmdRun:     RunNatGatewayFlowLogDelete,
-		InitClient: true,
-	})
+			Example:    deleteNatGatewayFlowLogExample,
+			PreCmdRun:  PreRunNatGatewayFlowlogDelete,
+			CmdRun:     RunNatGatewayFlowLogDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayFlowLogsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayFlowLogsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway FlowLog deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway FlowLog deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Natgateway flowlogs.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway FlowLog deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway FlowLog deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return natgatewayFlowLogCmd
 }
 
 func PreRunNATGatewayFlowLogList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -269,18 +436,23 @@ func PreRunNATGatewayFlowLogList(c *core.PreCommandConfig) error {
 }
 
 func PreRunNatGatewayFlowLogCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgS3Bucket)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgS3Bucket,
+	)
 }
 
 func PreRunNatGatewayFlowlogDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgFlowLogId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunDcNatGatewayFlowLogIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgFlowLogId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgFlowLogId,
+	)
 }
 
 func RunNatGatewayFlowLogList(c *core.CommandConfig) error {
@@ -296,7 +468,10 @@ func RunNatGatewayFlowLogList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -304,8 +479,10 @@ func RunNatGatewayFlowLogList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Flowlog, natgatewayFlowLogs.FlowLogs,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Flowlog, natgatewayFlowLogs.FlowLogs,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -323,8 +500,12 @@ func RunNatGatewayFlowLogGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"NatGatewayFlowLogGet with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"NatGatewayFlowLogGet with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NatGateways().GetFlowLog(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -333,7 +514,10 @@ func RunNatGatewayFlowLogGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -341,8 +525,10 @@ func RunNatGatewayFlowLogGet(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -372,7 +558,10 @@ func RunNatGatewayFlowLogCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -384,8 +573,10 @@ func RunNatGatewayFlowLogCreate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -412,7 +603,10 @@ func RunNatGatewayFlowLogUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -424,8 +618,10 @@ func RunNatGatewayFlowLogUpdate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -454,15 +650,24 @@ func RunNatGatewayFlowLogDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete nat gateway flowlog", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete nat gateway flowlog",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayFlowLog with id: %v...", flowlogId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayFlowLog with id: %v...", flowlogId),
+	)
 
 	resp, err := c.CloudApiV6Services.NatGateways().DeleteFlowLog(dcId, natgatewayId, flowlogId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -472,7 +677,9 @@ func RunNatGatewayFlowLogDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Flowlog successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Flowlog successfully deleted"),
+	)
 	return nil
 }
 
@@ -490,7 +697,9 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NatGateway ID: %v", natgatewayId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting NatGatewayFlowLogs..."))
 
-	flowlogs, resp, err := c.CloudApiV6Services.NatGateways().ListFlowLogs(dcId, natgatewayId, cloudapiv6.ParentResourceListQueryParams)
+	flowlogs, resp, err := c.CloudApiV6Services.NatGateways().ListFlowLogs(
+		dcId, natgatewayId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -522,11 +731,16 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the NatGatewayFlowLogs", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the NatGatewayFlowLogs",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NatGatewayFlowLogs..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NatGatewayFlowLogs..."),
+	)
 
 	var multiErr error
 	for _, natgateway := range *natgatewaysItems {
@@ -535,17 +749,26 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayFlowLog with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayFlowLog with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.NatGateways().DeleteFlowLog(dcId, natgatewayId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -556,6 +779,8 @@ func DeleteAllNatGatewayFlowLogs(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Flowlogs successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Flowlogs successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/natgateway_flowlog_test.go
+++ b/commands/cloudapi-v6/natgateway_flowlog_test.go
@@ -23,508 +23,632 @@ var testNatGatewayFlowLogErr = errors.New("natgateway-rule test error")
 func TestPreRunNatGatewayFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		err := PreRunNATGatewayFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			err := PreRunNATGatewayFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayFlowLogListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNATGatewayFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNATGatewayFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNATGatewayFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNATGatewayFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		err := PreRunNatGatewayFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			err := PreRunNatGatewayFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunNatGatewayFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunNatGatewayFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayFlowLogIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		err := PreRunDcNatGatewayFlowLogIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			err := PreRunDcNatGatewayFlowLogIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayFlowLogIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNatGatewayFlowLogIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNatGatewayFlowLogIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		err := RunNatGatewayFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			err := RunNatGatewayFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunNatGatewayFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunNatGatewayFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, testNatGatewayFlowLogErr)
-		err := RunNatGatewayFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, testNatGatewayFlowLogErr)
+			err := RunNatGatewayFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunNatGatewayFlowLogGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunNatGatewayFlowLogGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testNatGatewayFlowLogErr)
-		err := RunNatGatewayFlowLogGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testNatGatewayFlowLogErr)
+			err := RunNatGatewayFlowLogGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunNatGatewayFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunNatGatewayFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, testFlowLogErr)
-		err := RunNatGatewayFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, testFlowLogErr)
+			err := RunNatGatewayFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testNatGatewayFlowLogErr)
-		err := RunNatGatewayFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testNatGatewayFlowLogErr)
+			err := RunNatGatewayFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, &testResponse, nil)
-		err := RunNatGatewayFlowLogUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, &testResponse, nil)
+			err := RunNatGatewayFlowLogUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, nil, testNatGatewayFlowLogErr)
-		err := RunNatGatewayFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, nil, testNatGatewayFlowLogErr)
+			err := RunNatGatewayFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, nil, testFlowLogErr)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, nil, testFlowLogErr)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil,
+			)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testFlowLogErr)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testFlowLogErr)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNatGatewayFlowLogErr)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNatGatewayFlowLogErr)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayFlowLogDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNatGatewayFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNatGatewayFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/natgateway_lan.go
+++ b/commands/cloudapi-v6/natgateway_lan.go
@@ -40,47 +40,69 @@ func NatgatewayLanCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, natgatewayLanCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "lan",
-		Verb:      "list",
-		Aliases:   []string{"l", "ls"},
-		ShortDesc: "List NAT Gateway Lans",
-		LongDesc: `Use this command to list NAT Gateway Lans from a specified NAT Gateway.
+	list := core.NewCommand(
+		ctx, natgatewayLanCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "lan",
+			Verb:      "list",
+			Aliases:   []string{"l", "ls"},
+			ShortDesc: "List NAT Gateway Lans",
+			LongDesc: `Use this command to list NAT Gateway Lans from a specified NAT Gateway.
 
 Required values to run command:
 
 * Data Center Id
 * NAT Gateway Id`,
-		Example:    listNatGatewayLanExample,
-		PreCmdRun:  PreRunDcNatGatewayIds,
-		CmdRun:     RunNatGatewayLanList,
-		InitClient: true,
-	})
+			Example:    listNatGatewayLanExample,
+			PreCmdRun:  PreRunDcNatGatewayIds,
+			CmdRun:     RunNatGatewayLanList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	add := core.NewCommand(ctx, natgatewayLanCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "lan",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add a NAT Gateway Lan",
-		LongDesc: `Use this command to add a NAT Gateway Lan in a specified NAT Gateway.
+	add := core.NewCommand(
+		ctx, natgatewayLanCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "lan",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add a NAT Gateway Lan",
+			LongDesc: `Use this command to add a NAT Gateway Lan in a specified NAT Gateway.
 
 If IPs are not set manually, using ` + "`" + `--ips` + "`" + ` option, an IP will be automatically assigned. IPs must contain valid subnet mask. If user will not provide any IP then system will generate an IP with /24 subnet.
 
@@ -91,42 +113,80 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * Lan Id`,
-		Example:    addNatGatewayLanExample,
-		PreCmdRun:  PreRunDcNatGatewayLanIds,
-		CmdRun:     RunNatGatewayLanAdd,
-		InitClient: true,
-	})
+			Example:    addNatGatewayLanExample,
+			PreCmdRun:  PreRunDcNatGatewayLanIds,
+			CmdRun:     RunNatGatewayLanAdd,
+			InitClient: true,
+		},
+	)
 	add.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddIntFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 1, cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of Gateway IPs. If not set, it will automatically reserve public IPs")
-	add.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway Lan addition to be executed")
-	add.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway Lan addition [seconds]")
-	add.AddStringSliceFlag(constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols))
-	_ = add.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddStringSliceFlag(
+		cloudapiv6.ArgIps, "", nil, "Collection of Gateway IPs. If not set, it will automatically reserve public IPs",
+	)
+	add.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway Lan addition to be executed",
+	)
+	add.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway Lan addition [seconds]",
+	)
+	add.AddStringSliceFlag(
+		constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Remove Command
 	*/
-	removeCmd := core.NewCommand(ctx, natgatewayLanCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "lan",
-		Verb:      "remove",
-		Aliases:   []string{"r"},
-		ShortDesc: "Remove a NAT Gateway Lan",
-		LongDesc: `Use this command to remove a specified NAT Gateway Lan from a NAT Gateway.
+	removeCmd := core.NewCommand(
+		ctx, natgatewayLanCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "lan",
+			Verb:      "remove",
+			Aliases:   []string{"r"},
+			ShortDesc: "Remove a NAT Gateway Lan",
+			LongDesc: `Use this command to remove a specified NAT Gateway Lan from a NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -135,41 +195,80 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * Lan Id`,
-		Example:    removeNatGatewayLanExample,
-		PreCmdRun:  PreRunDcNatGatewayLanRemove,
-		CmdRun:     RunNatGatewayLanRemove,
-		InitClient: true,
-	})
+			Example:    removeNatGatewayLanExample,
+			PreCmdRun:  PreRunDcNatGatewayLanRemove,
+			CmdRun:     RunNatGatewayLanRemove,
+			InitClient: true,
+		},
+	)
+	removeCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddIntFlag(cloudapiv6.ArgLanId, cloudapiv6.ArgIdShort, 1, cloudapiv6.LanId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LansIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway Lan deletion to be executed")
-	removeCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway Lan deletion [seconds]")
-	removeCmd.AddStringSliceFlag(constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols))
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway Lan deletion to be executed",
+	)
+	removeCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway Lan deletion [seconds]",
+	)
+	removeCmd.AddStringSliceFlag(
+		constants.ArgCols, "", defaultNatGatewayLanCols, tabheaders.ColsMessage(defaultNatGatewayLanCols),
+	)
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultNatGatewayLanCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all NAT Gateway Lans.")
-	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	removeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return natgatewayLanCmd
 }
 
 func PreRunDcNatGatewayLanIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgLanId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgLanId,
+	)
 }
 
 func PreRunDcNatGatewayLanRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgLanId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgAll},
 	)
@@ -182,7 +281,10 @@ func RunNatGatewayLanList(c *core.CommandConfig) error {
 		resources.QueryParams{},
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -190,8 +292,10 @@ func RunNatGatewayLanList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("properties.lans", jsonpaths.NatGatewayLan, ng.NatGateway,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"properties.lans", jsonpaths.NatGatewayLan, ng.NatGateway,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -216,13 +320,19 @@ func RunNatGatewayLanAdd(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding NatGateway with id %v to Datacenter with id: %v", natGatewayId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding NatGateway with id %v to Datacenter with id: %v", natGatewayId, dcId,
+		),
+	)
 
 	input := getNewNatGatewayLanInfo(c, ng)
 	ng, resp, err := c.CloudApiV6Services.NatGateways().Update(dcId, natGatewayId, *input, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -234,8 +344,10 @@ func RunNatGatewayLanAdd(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("properties.lans", jsonpaths.NatGatewayLan, ng.NatGateway,
-		tabheaders.GetHeadersAllDefault(defaultNatGatewayLanCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"properties.lans", jsonpaths.NatGatewayLan, ng.NatGateway,
+		tabheaders.GetHeadersAllDefault(defaultNatGatewayLanCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -260,7 +372,10 @@ func RunNatGatewayLanRemove(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove nat gateway lan", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove nat gateway lan",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -272,13 +387,19 @@ func RunNatGatewayLanRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Removing NatGateway with id %v to Datacenter with id: %v", natGatewayId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Removing NatGateway with id %v to Datacenter with id: %v", natGatewayId, dcId,
+		),
+	)
 
 	input := removeNatGatewayLanInfo(c, ng)
 	ng, resp, err := c.CloudApiV6Services.NatGateways().Update(dcId, natGatewayId, *input, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -288,7 +409,9 @@ func RunNatGatewayLanRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Lan successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Lan successfully deleted"),
+	)
 	return nil
 }
 
@@ -306,7 +429,9 @@ func RemoveAllNatGatewayLans(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NatGateway ID: %v", natGatewayId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting NatGateway..."))
 
-	natGateway, resp, err := c.CloudApiV6Services.NatGateways().Get(dcId, natGatewayId, cloudapiv6.ParentResourceQueryParams)
+	natGateway, resp, err := c.CloudApiV6Services.NatGateways().Get(
+		dcId, natGatewayId, cloudapiv6.ParentResourceQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -328,15 +453,22 @@ func RemoveAllNatGatewayLans(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("NAT Gateway Lans to be removed:"))
 	for _, lan := range *lansOk {
 		if id, ok := lan.GetIdOk(); ok && id != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("NAT Gateway Lan Id: %v", string(*id)))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("NAT Gateway Lan Id: %v", string(*id)),
+			)
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove all the NAT Gateways Lans", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove all the NAT Gateways Lans",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the NAT Gateways Lans..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the NAT Gateways Lans..."),
+	)
 
 	proper := make([]ionoscloud.NatGatewayLanProperties, 0)
 	if natGateway != nil {
@@ -347,9 +479,15 @@ func RemoveAllNatGatewayLans(c *core.CommandConfig) error {
 				},
 			}
 
-			natGateway, resp, err = c.CloudApiV6Services.NatGateways().Update(dcId, natGatewayId, *natGatewaysProps, queryParams)
+			natGateway, resp, err = c.CloudApiV6Services.NatGateways().Update(
+				dcId, natGatewayId, *natGatewaysProps, queryParams,
+			)
 			if resp != nil && request.GetId(resp) != "" {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+						constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime,
+					),
+				)
 			}
 			if err != nil {
 				return err
@@ -361,7 +499,9 @@ func RemoveAllNatGatewayLans(c *core.CommandConfig) error {
 		}
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Lans successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Lans successfully deleted"),
+	)
 	return nil
 }
 
@@ -388,7 +528,10 @@ func getNewNatGatewayLanInfo(c *core.CommandConfig, oldNg *resources.NatGateway)
 		gatewayIps := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgIps))
 		input.SetGatewayIps(gatewayIps)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property GatewayIps set: %v", gatewayIps))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property GatewayIps set: %v", gatewayIps),
+		)
 	}
 
 	proper = append(proper, input)

--- a/commands/cloudapi-v6/natgateway_lan_test.go
+++ b/commands/cloudapi-v6/natgateway_lan_test.go
@@ -87,261 +87,343 @@ var (
 func TestPreRunDcNatGatewayLanIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanVar)
-		err := PreRunDcNatGatewayLanIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanVar)
+			err := PreRunDcNatGatewayLanIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayLanIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNatGatewayLanIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNatGatewayLanIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayLanCols)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, &testResponse, nil)
-		err := RunNatGatewayLanList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayLanCols)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, &testResponse, nil)
+			err := RunNatGatewayLanList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
-		err := RunNatGatewayLanList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
+			err := RunNatGatewayLanList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayLanNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTestUpdated, &testResponse, nil)
-		err := RunNatGatewayLanAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayLanNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTestUpdated, &testResponse, nil)
+			err := RunNatGatewayLanAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTestUpdated, nil, testNatGatewayLanErr)
-		err := RunNatGatewayLanAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTestUpdated, nil, testNatGatewayLanErr)
+			err := RunNatGatewayLanAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
-		err := RunNatGatewayLanAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
+			err := RunNatGatewayLanAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanAddWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTestUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayLanAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayLanNewVar})
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestProper,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTestUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayLanAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemoveAll, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemoveAll,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, testNatGatewayLanErr)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayLanTest, nil, nil)
-		err := RunNatGatewayLanRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayLanVar, testNatGatewayLanVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayLanVar, testNatGatewayLanVar, natgatewayLanTestRemove,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayLanTest, nil, nil)
+			err := RunNatGatewayLanRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayLanRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNatGatewayLanRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayLanVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), testNatGatewayLanNewIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNatGatewayLanRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/natgateway_rule.go
+++ b/commands/cloudapi-v6/natgateway_rule.go
@@ -25,8 +25,13 @@ import (
 )
 
 var (
-	defaultNatGatewayRuleCols = []string{"NatGatewayRuleId", "Name", "Protocol", "SourceSubnet", "PublicIp", "TargetSubnet", "State"}
-	allNatGatewayRuleCols     = []string{"NatGatewayRuleId", "Name", "Type", "Protocol", "SourceSubnet", "PublicIp", "TargetSubnet", "TargetPortRangeStart", "TargetPortRangeEnd", "State"}
+	defaultNatGatewayRuleCols = []string{
+		"NatGatewayRuleId", "Name", "Protocol", "SourceSubnet", "PublicIp", "TargetSubnet", "State",
+	}
+	allNatGatewayRuleCols = []string{
+		"NatGatewayRuleId", "Name", "Type", "Protocol", "SourceSubnet", "PublicIp", "TargetSubnet",
+		"TargetPortRangeStart", "TargetPortRangeEnd", "State",
+	}
 )
 
 func NatgatewayRuleCmd() *core.Command {
@@ -41,86 +46,141 @@ func NatgatewayRuleCmd() *core.Command {
 		},
 	}
 	globalFlags := natgatewayRuleCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultNatGatewayRuleCols, tabheaders.ColsMessage(allNatGatewayRuleCols))
-	_ = viper.BindPFlag(core.GetFlagName(natgatewayRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = natgatewayRuleCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allNatGatewayRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultNatGatewayRuleCols, tabheaders.ColsMessage(allNatGatewayRuleCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(natgatewayRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = natgatewayRuleCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allNatGatewayRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, natgatewayRuleCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "rule",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List NAT Gateway Rules",
-		LongDesc:   "Use this command to list NAT Gateway Rules from a specified NAT Gateway.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NATGatewayRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
-		Example:    listNatGatewayRuleExample,
-		PreCmdRun:  PreRunNATGatewayRuleList,
-		CmdRun:     RunNatGatewayRuleList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, natgatewayRuleCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "rule",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List NAT Gateway Rules",
+			LongDesc:   "Use this command to list NAT Gateway Rules from a specified NAT Gateway.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NATGatewayRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id",
+			Example:    listNatGatewayRuleExample,
+			PreCmdRun:  PreRunNATGatewayRuleList,
+			CmdRun:     RunNatGatewayRuleList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NATGatewayRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, natgatewayRuleCmd, core.CommandBuilder{
-		Namespace:  "natgateway",
-		Resource:   "rule",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a NAT Gateway Rule",
-		LongDesc:   "Use this command to get information about a specified NAT Gateway Rule from a NAT Gateway.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id\n* NAT Gateway Rule Id",
-		Example:    getNatGatewayRuleExample,
-		PreCmdRun:  PreRunDcNatGatewayRuleIds,
-		CmdRun:     RunNatGatewayRuleGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, natgatewayRuleCmd, core.CommandBuilder{
+			Namespace:  "natgateway",
+			Resource:   "rule",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a NAT Gateway Rule",
+			LongDesc:   "Use this command to get information about a specified NAT Gateway Rule from a NAT Gateway.\n\nRequired values to run command:\n\n* Data Center Id\n* NAT Gateway Id\n* NAT Gateway Rule Id",
+			Example:    getNatGatewayRuleExample,
+			PreCmdRun:  PreRunDcNatGatewayRuleIds,
+			CmdRun:     RunNatGatewayRuleGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.RuleId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayRulesIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, natgatewayRuleCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "rule",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a NAT Gateway Rule",
-		LongDesc: `Use this command to create a NAT Gateway Rule in a specified NAT Gateway.
+	create := core.NewCommand(
+		ctx, natgatewayRuleCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "rule",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a NAT Gateway Rule",
+			LongDesc: `Use this command to create a NAT Gateway Rule in a specified NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -130,43 +190,80 @@ Required values to run command:
 * NAT Gateway Id
 * Public IP
 * Source Subnet`,
-		Example:    createNatGatewayRuleExample,
-		PreCmdRun:  PreRunNatGatewayRuleCreate,
-		CmdRun:     RunNatGatewayRuleCreate,
-		InitClient: true,
-	})
+			Example:    createNatGatewayRuleExample,
+			PreCmdRun:  PreRunNatGatewayRuleCreate,
+			CmdRun:     RunNatGatewayRuleCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Rule", "Name of the NAT Gateway Rule")
-	create.AddStringFlag(cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, string(ionoscloud.ALL), "Protocol of the NAT Gateway Rule. If protocol is 'ICMP' then targetPortRange start and end cannot be set", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{string(ionoscloud.TCP), string(ionoscloud.UDP), string(ionoscloud.ICMP), string(ionoscloud.ALL)}, cobra.ShellCompDirectiveNoFileComp
-	})
+	create.AddStringFlag(
+		cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, string(ionoscloud.ALL),
+		"Protocol of the NAT Gateway Rule. If protocol is 'ICMP' then targetPortRange start and end cannot be set",
+		core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				string(ionoscloud.TCP), string(ionoscloud.UDP), string(ionoscloud.ICMP), string(ionoscloud.ALL),
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddIpFlag(cloudapiv6.ArgIp, "", nil, "Public IP address of the NAT Gateway Rule", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgSourceSubnet, "", "", "Source subnet of the NAT Gateway Rule", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgTargetSubnet, "", "", "Target subnet or destination subnet of the NAT Gateway Rule")
-	create.AddIntFlag(cloudapiv6.ArgPortRangeStart, "", 1, "Target port range start associated with the NAT Gateway Rule")
+	create.AddStringFlag(
+		cloudapiv6.ArgSourceSubnet, "", "", "Source subnet of the NAT Gateway Rule", core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgTargetSubnet, "", "", "Target subnet or destination subnet of the NAT Gateway Rule",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgPortRangeStart, "", 1, "Target port range start associated with the NAT Gateway Rule",
+	)
 	create.AddIntFlag(cloudapiv6.ArgPortRangeEnd, "", 1, "Target port range end associated with the NAT Gateway Rule")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway Rule creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway Rule creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway Rule creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway Rule creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, natgatewayRuleCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "rule",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a NAT Gateway Rule",
-		LongDesc: `Use this command to update a specified NAT Gateway Rule from a NAT Gateway.
+	update := core.NewCommand(
+		ctx, natgatewayRuleCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "rule",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a NAT Gateway Rule",
+			LongDesc: `Use this command to update a specified NAT Gateway Rule from a NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -175,48 +272,87 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * NAT Gateway Rule Id`,
-		Example:    updateNatGatewayRuleExample,
-		PreCmdRun:  PreRunDcNatGatewayRuleIds,
-		CmdRun:     RunNatGatewayRuleUpdate,
-		InitClient: true,
-	})
+			Example:    updateNatGatewayRuleExample,
+			PreCmdRun:  PreRunDcNatGatewayRuleIds,
+			CmdRun:     RunNatGatewayRuleUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.RuleId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayRulesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayRulesIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the NAT Gateway Rule")
-	update.AddStringFlag(cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, "", "Protocol of the NAT Gateway Rule. If protocol is 'ICMP' then targetPortRange start and end cannot be set")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{string(ionoscloud.TCP), string(ionoscloud.UDP), string(ionoscloud.ICMP), string(ionoscloud.ALL)}, cobra.ShellCompDirectiveNoFileComp
-	})
+	update.AddStringFlag(
+		cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, "",
+		"Protocol of the NAT Gateway Rule. If protocol is 'ICMP' then targetPortRange start and end cannot be set",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				string(ionoscloud.TCP), string(ionoscloud.UDP), string(ionoscloud.ICMP), string(ionoscloud.ALL),
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddIpFlag(cloudapiv6.ArgIp, "", nil, "Public IP address of the NAT Gateway Rule")
 	update.AddStringFlag(cloudapiv6.ArgSourceSubnet, "", "", "Source subnet of the NAT Gateway Rule")
-	update.AddStringFlag(cloudapiv6.ArgTargetSubnet, "", "", "Target subnet or destination subnet of the NAT Gateway Rule")
-	update.AddIntFlag(cloudapiv6.ArgPortRangeStart, "", 1, "Target port range start associated with the NAT Gateway Rule")
+	update.AddStringFlag(
+		cloudapiv6.ArgTargetSubnet, "", "", "Target subnet or destination subnet of the NAT Gateway Rule",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgPortRangeStart, "", 1, "Target port range start associated with the NAT Gateway Rule",
+	)
 	update.AddIntFlag(cloudapiv6.ArgPortRangeEnd, "", 1, "Target port range end associated with the NAT Gateway Rule")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway Rule update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway Rule update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway Rule update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway Rule update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, natgatewayRuleCmd, core.CommandBuilder{
-		Namespace: "natgateway",
-		Resource:  "rule",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a NAT Gateway Rule",
-		LongDesc: `Use this command to delete a specified NAT Gateway Rule from a NAT Gateway.
+	deleteCmd := core.NewCommand(
+		ctx, natgatewayRuleCmd, core.CommandBuilder{
+			Namespace: "natgateway",
+			Resource:  "rule",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a NAT Gateway Rule",
+			LongDesc: `Use this command to delete a specified NAT Gateway Rule from a NAT Gateway.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -225,34 +361,63 @@ Required values to run command:
 * Data Center Id
 * NAT Gateway Id
 * NAT Gateway Rule Id`,
-		Example:    deleteNatGatewayRuleExample,
-		PreCmdRun:  PreRunDcNatGatewayRuleDelete,
-		CmdRun:     RunNatGatewayRuleDelete,
-		InitClient: true,
-	})
+			Example:    deleteNatGatewayRuleExample,
+			PreCmdRun:  PreRunDcNatGatewayRuleDelete,
+			CmdRun:     RunNatGatewayRuleDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNatGatewayId, "", "", cloudapiv6.NatGatewayId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNatGatewayId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewaysIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNatGatewayId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewaysIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.RuleId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NatGatewayRulesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNatGatewayId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway Rule deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NatGatewayRulesIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNatGatewayId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for NAT Gateway Rule deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all NAT Gateway Rules.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway Rule deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for NAT Gateway Rule deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return natgatewayRuleCmd
 }
 
 func PreRunNATGatewayRuleList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -262,15 +427,21 @@ func PreRunNATGatewayRuleList(c *core.PreCommandConfig) error {
 }
 
 func PreRunNatGatewayRuleCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIp, cloudapiv6.ArgSourceSubnet)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgIp,
+		cloudapiv6.ArgSourceSubnet,
+	)
 }
 
 func PreRunDcNatGatewayRuleIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgRuleId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgRuleId,
+	)
 }
 
 func PreRunDcNatGatewayRuleDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgRuleId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNatGatewayId, cloudapiv6.ArgAll},
 	)
@@ -289,7 +460,10 @@ func RunNatGatewayRuleList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -297,8 +471,10 @@ func RunNatGatewayRuleList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.NatGatewayRule, natgatewayRules.NatGatewayRules,
-		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.NatGatewayRule, natgatewayRules.NatGatewayRules,
+		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -316,8 +492,11 @@ func RunNatGatewayRuleGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"atGatewayRule with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"atGatewayRule with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NatGateways().GetRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -326,7 +505,10 @@ func RunNatGatewayRuleGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -334,8 +516,10 @@ func RunNatGatewayRuleGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
-		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
+		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -356,14 +540,28 @@ func RunNatGatewayRuleCreate(c *core.CommandConfig) error {
 
 	if !proper.HasName() {
 		proper.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	if !proper.HasProtocol() {
-		proper.SetProtocol(ionoscloud.NatGatewayRuleProtocol(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
+		proper.SetProtocol(
+			ionoscloud.NatGatewayRuleProtocol(
+				viper.GetString(
+					core.GetFlagName(
+						c.NS, cloudapiv6.ArgProtocol,
+					),
+				),
+			),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)),
+			),
+		)
 	}
 
 	ng, resp, err := c.CloudApiV6Services.NatGateways().CreateRule(
@@ -377,7 +575,10 @@ func RunNatGatewayRuleCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -389,8 +590,10 @@ func RunNatGatewayRuleCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
-		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
+		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -416,7 +619,10 @@ func RunNatGatewayRuleUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -428,8 +634,10 @@ func RunNatGatewayRuleUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
-		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NatGatewayRule, ng.NatGatewayRule,
+		tabheaders.GetHeaders(allNatGatewayRuleCols, defaultNatGatewayRuleCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -458,15 +666,24 @@ func RunNatGatewayRuleDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete nat gateway rule", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete nat gateway rule",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayRule with id: %v...", ruleId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayRule with id: %v...", ruleId),
+	)
 
 	resp, err := c.CloudApiV6Services.NatGateways().DeleteRule(dcId, natGatewayId, ruleId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -476,7 +693,9 @@ func RunNatGatewayRuleDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Rule successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Rule successfully deleted"),
+	)
 	return nil
 }
 
@@ -494,28 +713,37 @@ func getNewNatGatewayRuleInfo(c *core.CommandConfig) *resources.NatGatewayRulePr
 		publicIp := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp))
 		input.SetPublicIp(publicIp)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PublicIp set: %v", publicIp))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PublicIp set: %v", publicIp),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)) {
 		protocol := strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)))
 		input.SetProtocol(ionoscloud.NatGatewayRuleProtocol(protocol))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", protocol))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Protocol set: %v", protocol),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSourceSubnet)) {
 		sourceSubnet := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSourceSubnet))
 		input.SetSourceSubnet(sourceSubnet)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SourceSubnet set: %v", sourceSubnet))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property SourceSubnet set: %v", sourceSubnet),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgTargetSubnet)) {
 		targetSubnet := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetSubnet))
 		input.SetTargetSubnet(targetSubnet)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", targetSubnet))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", targetSubnet),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPortRangeStart)) &&
@@ -529,8 +757,11 @@ func getNewNatGatewayRuleInfo(c *core.CommandConfig) *resources.NatGatewayRulePr
 		inputPortRange.SetEnd(portRangeStop)
 		input.SetTargetPortRange(inputPortRange)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property TargetPortRang set with start: %v and stop: %v", portRangeStart, portRangeStop))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property TargetPortRang set with start: %v and stop: %v", portRangeStart, portRangeStop,
+			),
+		)
 	}
 
 	return &resources.NatGatewayRuleProperties{
@@ -552,7 +783,9 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NatGateway ID: %v", natGatewayId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting NatGateway Rules..."))
 
-	natGatewayRules, resp, err := c.CloudApiV6Services.NatGateways().ListRules(dcId, natGatewayId, cloudapiv6.ParentResourceListQueryParams)
+	natGatewayRules, resp, err := c.CloudApiV6Services.NatGateways().ListRules(
+		dcId, natGatewayId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -584,11 +817,16 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the NatGatewayRules", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the NatGatewayRules",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NatGatewayRules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the NatGatewayRules..."),
+	)
 
 	var multiErr error
 	for _, natGateway := range *natGatewayRuleItems {
@@ -597,16 +835,25 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayRule with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting NatGatewayRule with id: %v...", *id),
+		)
 		resp, err = c.CloudApiV6Services.NatGateways().DeleteRule(dcId, natGatewayId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -617,6 +864,8 @@ func DeleteAllNatgatewayRules(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Rules successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("NAT Gateway Rules successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/natgateway_rule_test.go
+++ b/commands/cloudapi-v6/natgateway_rule_test.go
@@ -87,530 +87,673 @@ var (
 func TestPreRunNatGatewayRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		err := PreRunNATGatewayRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			err := PreRunNATGatewayRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayRuleListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNATGatewayRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNATGatewayRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNATGatewayRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNATGatewayRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
-		err := PreRunNatGatewayRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
+			err := PreRunNatGatewayRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNatGatewayRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunNatGatewayRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunNatGatewayRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayRuleIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		err := PreRunDcNatGatewayRuleIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			err := PreRunDcNatGatewayRuleIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayRuleIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNatGatewayRuleIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNatGatewayRuleIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewayRules, &testResponse, nil)
-		err := RunNatGatewayRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewayRules, &testResponse, nil)
+			err := RunNatGatewayRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.NatGatewayRules{}, &testResponse, nil)
-		err := RunNatGatewayRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.NatGatewayRules{}, &testResponse, nil)
+			err := RunNatGatewayRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewayRules, nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewayRules, nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().GetRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&natgatewayRuleTestGet, &testResponse, nil)
-		err := RunNatGatewayRuleGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().GetRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&natgatewayRuleTestGet, &testResponse, nil)
+			err := RunNatGatewayRuleGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().GetRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleTestGet, nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().GetRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleTestGet, nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&natgatewayRuleTestGet, &testResponse, nil)
-		err := RunNatGatewayRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&natgatewayRuleTestGet, &testResponse, nil)
+			err := RunNatGatewayRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleTestGet, &testResponse, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleTestGet, &testResponse, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleTestGet, nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleTestGet, nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleTestGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().CreateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleTest,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleTestGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&natgatewayRuleNew, &testResponse, nil)
-		err := RunNatGatewayRuleUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&natgatewayRuleNew, &testResponse, nil)
+			err := RunNatGatewayRuleUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleNew, nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleNew, nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayRuleNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), string(testNatGatewayRuleNewProtocol))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSourceSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetSubnet), testNatGatewayRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeStart), testNatGatewayRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPortRangeEnd), testNatGatewayRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().UpdateRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, natgatewayRuleProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayRuleNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewayRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewayRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 func TestRunNatGatewayRuleDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewayRulesList, nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewayRulesList, nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 func TestRunNatGatewayRuleDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.NatGatewayRules{}, &testResponse, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.NatGatewayRules{}, &testResponse, nil,
+			)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 func TestRunNatGatewayRuleDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.NatGatewayRules{NatGatewayRules: ionoscloud.NatGatewayRules{Items: &[]ionoscloud.NatGatewayRule{}}}, &testResponse, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.NatGatewayRules{NatGatewayRules: ionoscloud.NatGatewayRules{Items: &[]ionoscloud.NatGatewayRule{}}},
+				&testResponse, nil,
+			)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewayRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNatGatewayRuleErr)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().ListRules(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewayRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNatGatewayRuleErr)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNatGatewayRuleErr)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNatGatewayRuleErr)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().DeleteRule(
+				testNatGatewayRuleVar, testNatGatewayRuleVar, testNatGatewayRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayRuleDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNatGatewayRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNatGatewayRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNatGatewayRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/natgateway_test.go
+++ b/commands/cloudapi-v6/natgateway_test.go
@@ -86,516 +86,660 @@ func TestNatgatewayCmd(t *testing.T) {
 func TestPreRunNATGatewayList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		err := PreRunNATGatewayList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			err := PreRunNATGatewayList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNATGatewayListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNATGatewayList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNATGatewayList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNATGatewayListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNATGatewayList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNATGatewayList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcIdsNatGatewayProperties(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayVar)
-		err := PreRunDcIdsNatGatewayIps(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayVar)
+			err := PreRunDcIdsNatGatewayIps(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcIdsNatGatewayPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcIdsNatGatewayIps(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcIdsNatGatewayIps(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		err := PreRunDcNatGatewayIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			err := PreRunDcNatGatewayIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNatGatewayIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNatGatewayIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNatGatewayIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewaysList, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunNatGatewayListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewaysList, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunNatGatewayListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayCols)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgateways, &testResponse, nil)
-		err := RunNatGatewayList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayCols)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgateways, &testResponse, nil)
+			err := RunNatGatewayList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayCols)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.NatGateways{}, &testResponse, nil)
-		err := RunNatGatewayList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.Resource, constants.ArgCols), defaultNatGatewayCols)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.NatGateways{}, &testResponse, nil)
+			err := RunNatGatewayList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgateways, nil, testNatGatewayErr)
-		err := RunNatGatewayList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgateways, nil, testNatGatewayErr)
+			err := RunNatGatewayList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTestGet, &testResponse, nil)
-		err := RunNatGatewayGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTestGet, &testResponse, nil)
+			err := RunNatGatewayGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTestGet, nil, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTestGet, nil, nil)
-		err := RunNatGatewayGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTestGet, nil, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTestGet, nil, nil)
+			err := RunNatGatewayGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTestGet, nil, testNatGatewayErr)
-		err := RunNatGatewayGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTestGet, nil, testNatGatewayErr)
+			err := RunNatGatewayGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTestGet, nil, testNatGatewayErr)
-		err := RunNatGatewayGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Get(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTestGet, nil, testNatGatewayErr)
+			err := RunNatGatewayGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTest, &testResponse, nil)
-		err := RunNatGatewayCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(
+				testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTest, &testResponse, nil)
+			err := RunNatGatewayCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTest, &testResponse, testNatGatewayErr)
-		err := RunNatGatewayCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(
+				testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTest, &testResponse, testNatGatewayErr)
+			err := RunNatGatewayCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTest, nil, testNatGatewayErr)
-		err := RunNatGatewayCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(
+				testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTest, nil, testNatGatewayErr)
+			err := RunNatGatewayCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayVar})
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Create(
+				testNatGatewayVar, natgatewayTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayNewVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayVar, testNatGatewayVar, natgatewayProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayNew, &testResponse, nil)
-		err := RunNatGatewayUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNatGatewayNewVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayVar, testNatGatewayVar, natgatewayProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayNew, &testResponse, nil)
+			err := RunNatGatewayUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayNewVar})
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayVar, testNatGatewayVar, natgatewayProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayNew, nil, testNatGatewayErr)
-		err := RunNatGatewayUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayNewVar})
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayVar, testNatGatewayVar, natgatewayProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayNew, nil, testNatGatewayErr)
+			err := RunNatGatewayUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayNewVar})
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(testNatGatewayVar, testNatGatewayVar, natgatewayProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&natgatewayNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNatGatewayNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), []string{testNatGatewayNewVar})
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Update(
+				testNatGatewayVar, testNatGatewayVar, natgatewayProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&natgatewayNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewaysList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewaysList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewaysList, nil, testNatGatewayErr)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewaysList, nil, testNatGatewayErr)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.NatGateways{}, &testResponse, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.NatGateways{}, &testResponse, nil)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.NatGateways{NatGateways: ionoscloud.NatGateways{Items: &[]ionoscloud.NatGateway{}}}, &testResponse, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.NatGateways{NatGateways: ionoscloud.NatGateways{Items: &[]ionoscloud.NatGateway{}}},
+				&testResponse, nil,
+			)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().List(testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(natgatewaysList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNatGatewayErr)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().List(
+				testNatGatewayVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(natgatewaysList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNatGatewayErr)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNatGatewayErr)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNatGatewayErr)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNatGatewayDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NatGateway.EXPECT().Delete(
+				testNatGatewayVar, testNatGatewayVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNatGatewayDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNatGatewayDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNatGatewayDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNatGatewayVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNatGatewayId), testNatGatewayVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNatGatewayDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/networkloadbalancer.go
+++ b/commands/cloudapi-v6/networkloadbalancer.go
@@ -26,8 +26,12 @@ import (
 )
 
 var (
-	defaultNetworkLoadBalancerCols = []string{"NetworkLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "LbPrivateIps", "State"}
-	allNetworkLoadBalancerCols     = []string{"NetworkLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "LbPrivateIps", "State", "DatacenterId"}
+	defaultNetworkLoadBalancerCols = []string{
+		"NetworkLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "LbPrivateIps", "State",
+	}
+	allNetworkLoadBalancerCols = []string{
+		"NetworkLoadBalancerId", "Name", "ListenerLan", "Ips", "TargetLan", "LbPrivateIps", "State", "DatacenterId",
+	}
 )
 
 func NetworkloadbalancerCmd() *core.Command {
@@ -42,114 +46,182 @@ func NetworkloadbalancerCmd() *core.Command {
 		},
 	}
 	globalFlags := networkloadbalancerCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultNetworkLoadBalancerCols, tabheaders.ColsMessage(defaultNetworkLoadBalancerCols))
-	_ = viper.BindPFlag(core.GetFlagName(networkloadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = networkloadbalancerCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultNetworkLoadBalancerCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultNetworkLoadBalancerCols, tabheaders.ColsMessage(defaultNetworkLoadBalancerCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(networkloadbalancerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = networkloadbalancerCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultNetworkLoadBalancerCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, networkloadbalancerCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "networkloadbalancer",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Network Load Balancers",
-		LongDesc:   "Use this command to list Network Load Balancers from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NlbsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listNetworkLoadBalancerExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerList,
-		CmdRun:     RunNetworkLoadBalancerList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, networkloadbalancerCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "networkloadbalancer",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Network Load Balancers",
+			LongDesc:   "Use this command to list Network Load Balancers from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NlbsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listNetworkLoadBalancerExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerList,
+			CmdRun:     RunNetworkLoadBalancerList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NlbsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, networkloadbalancerCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "networkloadbalancer",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Network Load Balancer",
-		LongDesc:   "Use this command to get information about a specified Network Load Balancer from a Virtual Data Center. You can also wait for Network Load Balancer to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
-		Example:    getNetworkLoadBalancerExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerIds,
-		CmdRun:     RunNetworkLoadBalancerGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, networkloadbalancerCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "networkloadbalancer",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Network Load Balancer",
+			LongDesc:   "Use this command to get information about a specified Network Load Balancer from a Virtual Data Center. You can also wait for Network Load Balancer to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
+			Example:    getNetworkLoadBalancerExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerIds,
+			CmdRun:     RunNetworkLoadBalancerGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Network Load Balancer to be in AVAILABLE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds]")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified Network Load Balancer to be in AVAILABLE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for waiting for Network Load Balancer to be in AVAILABLE state [seconds]",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, networkloadbalancerCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "networkloadbalancer",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Network Load Balancer",
-		LongDesc: `Use this command to create a Network Load Balancer in a specified Virtual Data Center.
+	create := core.NewCommand(
+		ctx, networkloadbalancerCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "networkloadbalancer",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Network Load Balancer",
+			LongDesc: `Use this command to create a Network Load Balancer in a specified Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Data Center Id`,
-		Example:    createNetworkLoadBalancerExample,
-		PreCmdRun:  PreRunDataCenterId,
-		CmdRun:     RunNetworkLoadBalancerCreate,
-		InitClient: true,
-	})
+			Example:    createNetworkLoadBalancerExample,
+			PreCmdRun:  PreRunDataCenterId,
+			CmdRun:     RunNetworkLoadBalancerCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Network Load Balancer", "Name of the Network Load Balancer")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Network Load Balancer", "Name of the Network Load Balancer",
+	)
 	create.AddIntFlag(cloudapiv6.ArgListenerLan, "", 2, "Id of the listening LAN")
 	create.AddIntFlag(cloudapiv6.ArgTargetLan, "", 1, "Id of the balanced private target LAN")
 	create.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of IP addresses of the Network Load Balancer")
-	create.AddStringSliceFlag(cloudapiv6.ArgPrivateIps, "", nil, "Collection of private IP addresses with subnet mask of the Network Load Balancer")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddStringSliceFlag(
+		cloudapiv6.ArgPrivateIps, "", nil,
+		"Collection of private IP addresses with subnet mask of the Network Load Balancer",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, networkloadbalancerCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "networkloadbalancer",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Network Load Balancer",
-		LongDesc: `Use this command to update a specified Network Load Balancer from a Virtual Data Center.
+	update := core.NewCommand(
+		ctx, networkloadbalancerCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "networkloadbalancer",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Network Load Balancer",
+			LongDesc: `Use this command to update a specified Network Load Balancer from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -157,38 +229,68 @@ Required values to run command:
 
 * Data Center Id
 * Network Load Balancer Id`,
-		Example:    updateNetworkLoadBalancerExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerIds,
-		CmdRun:     RunNetworkLoadBalancerUpdate,
-		InitClient: true,
-	})
+			Example:    updateNetworkLoadBalancerExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerIds,
+			CmdRun:     RunNetworkLoadBalancerUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Network Load Balancer", "Name of the Network Load Balancer")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Network Load Balancer", "Name of the Network Load Balancer",
+	)
 	update.AddIntFlag(cloudapiv6.ArgListenerLan, "", 2, "Id of the listening LAN")
 	update.AddIntFlag(cloudapiv6.ArgTargetLan, "", 1, "Id of the balanced private target LAN")
 	update.AddStringSliceFlag(cloudapiv6.ArgIps, "", nil, "Collection of IP addresses of the Network Load Balancer")
-	update.AddStringSliceFlag(cloudapiv6.ArgPrivateIps, "", nil, "Collection of private IP addresses with subnet mask of the Network Load Balancer")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddStringSliceFlag(
+		cloudapiv6.ArgPrivateIps, "", nil,
+		"Collection of private IP addresses with subnet mask of the Network Load Balancer",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, networkloadbalancerCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "networkloadbalancer",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Network Load Balancer",
-		LongDesc: `Use this command to delete a specified Network Load Balancer from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, networkloadbalancerCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "networkloadbalancer",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Network Load Balancer",
+			LongDesc: `Use this command to delete a specified Network Load Balancer from a Virtual Data Center.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -196,23 +298,48 @@ Required values to run command:
 
 * Data Center Id
 * Network Load Balancer Id`,
-		Example:    deleteNetworkLoadBalancerExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerDelete,
-		CmdRun:     RunNetworkLoadBalancerDelete,
-		InitClient: true,
-	})
+			Example:    deleteNetworkLoadBalancerExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerDelete,
+			CmdRun:     RunNetworkLoadBalancerDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgIdShort, "", cloudapiv6.NetworkLoadBalancerId,
+		core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Network Load Balancers.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	networkloadbalancerCmd.AddCommand(NetworkloadbalancerFlowLogCmd())
 	networkloadbalancerCmd.AddCommand(NetworkloadbalancerRuleCmd())
@@ -221,7 +348,8 @@ Required values to run command:
 }
 
 func PreRunNetworkLoadBalancerList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -238,7 +366,8 @@ func PreRunDcNetworkLoadBalancerIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcNetworkLoadBalancerDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -266,7 +395,9 @@ func RunNetworkLoadBalancerListAll(c *core.CommandConfig) error {
 			return fmt.Errorf("could not retrieve Datacenter Id")
 		}
 
-		NetworkLoadBalancers, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().List(*dc.GetId(), listQueryParams)
+		NetworkLoadBalancers, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().List(
+			*dc.GetId(), listQueryParams,
+		)
 		if err != nil {
 			return err
 		}
@@ -292,13 +423,18 @@ func RunNetworkLoadBalancerListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allNetworkLoadBalancers, allNetworkLoadBalancersConverted,
-		tabheaders.GetHeadersAllDefault(defaultNetworkLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allNetworkLoadBalancers, allNetworkLoadBalancersConverted,
+		tabheaders.GetHeadersAllDefault(defaultNetworkLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -323,7 +459,10 @@ func RunNetworkLoadBalancerList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -331,8 +470,10 @@ func RunNetworkLoadBalancerList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.NetworkLoadBalancer, networkloadbalancers.NetworkLoadBalancers,
-		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.NetworkLoadBalancer, networkloadbalancers.NetworkLoadBalancers,
+		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -349,12 +490,19 @@ func RunNetworkLoadBalancerGet(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	if err := waitfor.WaitForState(c, waiter.NetworkLoadBalancerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.NetworkLoadBalancerStateInterrogator,
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+	); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Network Load Balancer with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Network Load Balancer with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -363,7 +511,10 @@ func RunNetworkLoadBalancerGet(c *core.CommandConfig) error {
 	)
 
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -371,8 +522,10 @@ func RunNetworkLoadBalancerGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
-		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
+		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -413,7 +566,10 @@ func RunNetworkLoadBalancerCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -425,8 +581,10 @@ func RunNetworkLoadBalancerCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
-		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
+		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -452,7 +610,10 @@ func RunNetworkLoadBalancerUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -464,8 +625,10 @@ func RunNetworkLoadBalancerUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
-		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancer, ng.NetworkLoadBalancer,
+		tabheaders.GetHeaders(allNetworkLoadBalancerCols, defaultNetworkLoadBalancerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -493,15 +656,24 @@ func RunNetworkLoadBalancerDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete network load balancer", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete network load balancer",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer with id: %v...", nlbId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer with id: %v...", nlbId),
+	)
 
 	resp, err := c.CloudApiV6Services.NetworkLoadBalancers().Delete(dcId, nlbId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -511,7 +683,9 @@ func RunNetworkLoadBalancerDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer successfully deleted"),
+	)
 	return nil
 }
 
@@ -536,21 +710,30 @@ func getNewNetworkLoadBalancerInfo(c *core.CommandConfig) *resources.NetworkLoad
 		listenerLan := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerLan))
 		input.SetListenerLan(listenerLan)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerLan set: %v", listenerLan))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property ListenerLan set: %v", listenerLan),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan)) {
 		targetLan := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgTargetLan))
 		input.SetTargetLan(targetLan)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property TargetLan set: %v", targetLan))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property TargetLan set: %v", targetLan),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps)) {
 		privateIps := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgPrivateIps))
 		input.SetLbPrivateIps(privateIps)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property PrivateIps set: %v", privateIps))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property PrivateIps set: %v", privateIps),
+		)
 	}
 
 	return &resources.NetworkLoadBalancerProperties{
@@ -568,9 +751,13 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) error {
 	dcId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancers..."),
+	)
 
-	networkLoadBalancers, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().List(dcId, cloudapiv6.ParentResourceListQueryParams)
+	networkLoadBalancers, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().List(
+		dcId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -584,7 +771,9 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) error {
 		return fmt.Errorf("no Network Load Balancers found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Network Load Balancers to be deleted:"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Network Load Balancers to be deleted:"),
+	)
 
 	for _, networkLoadBalancer := range *nlbItems {
 		delIdAndName := ""
@@ -602,11 +791,17 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Network Load Balancers", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Network Load Balancers",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancers..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancers..."),
+	)
 
 	var multiErr error
 	for _, networkLoadBalancer := range *nlbItems {
@@ -615,18 +810,27 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.NetworkLoadBalancers().Delete(dcId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -637,6 +841,8 @@ func DeleteAllNetworkLoadBalancers(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancers successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancers successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog.go
@@ -38,85 +38,143 @@ func NetworkloadbalancerFlowLogCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "flowlog",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Network Load Balancer FlowLogs",
-		LongDesc:   "Use this command to list Network Load Balancer FlowLogs from a specified Network Load Balancer.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
-		Example:    listNetworkLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunNetworkLoadBalacerFlowLogList,
-		CmdRun:     RunNetworkLoadBalancerFlowLogList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "flowlog",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Network Load Balancer FlowLogs",
+			LongDesc:   "Use this command to list Network Load Balancer FlowLogs from a specified Network Load Balancer.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.FlowLogsFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
+			Example:    listNetworkLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunNetworkLoadBalacerFlowLogList,
+			CmdRun:     RunNetworkLoadBalancerFlowLogList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.FlowLogsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "flowlog",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Network Load Balancer FlowLog",
-		LongDesc:   "Use this command to get information about a specified Network Load Balancer FlowLog from a Network Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Network Load Balancer FlowLog Id",
-		Example:    getNetworkLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerFlowLogIds,
-		CmdRun:     RunNetworkLoadBalancerFlowLogGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "flowlog",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Network Load Balancer FlowLog",
+			LongDesc:   "Use this command to get information about a specified Network Load Balancer FlowLog from a Network Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Network Load Balancer FlowLog Id",
+			Example:    getNetworkLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerFlowLogIds,
+			CmdRun:     RunNetworkLoadBalancerFlowLogGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Network Load Balancer FlowLog",
-		LongDesc: `Use this command to create a Network Load Balancer FlowLog in a specified Network Load Balancer.
+	create := core.NewCommand(
+		ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Network Load Balancer FlowLog",
+			LongDesc: `Use this command to create a Network Load Balancer FlowLog in a specified Network Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -125,47 +183,86 @@ Required values to run command:
 * Data Center Id
 * Network Load Balancer Id
 * Bucket Name`,
-		Example:    createNetworkLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerFlowLogCreate,
-		CmdRun:     RunNetworkLoadBalancerFlowLogCreate,
-		InitClient: true,
-	})
+			Example:    createNetworkLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerFlowLogCreate,
+			CmdRun:     RunNetworkLoadBalancerFlowLogCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed FlowLog", "The name for the FlowLog")
 	create.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "ALL", "Specifies the traffic Action pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL", "Specifies the traffic Direction pattern")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer FlowLog creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer FlowLog creation [seconds]")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "BIDIRECTIONAL",
+		"Specifies the traffic Direction pattern",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket",
+		core.RequiredFlagOption(),
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer FlowLog creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer FlowLog creation [seconds]",
+	)
 	create.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = create.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Network Load Balancer FlowLog",
-		LongDesc: `Use this command to update a specified Network Load Balancer FlowLog from a Network Load Balancer.
+	update := core.NewCommand(
+		ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Network Load Balancer FlowLog",
+			LongDesc: `Use this command to update a specified Network Load Balancer FlowLog from a Network Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -174,52 +271,96 @@ Required values to run command:
 * Data Center Id
 * Network Load Balancer Id
 * Network Load Balancer FlowLog Id`,
-		Example:    updateNetworkLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerFlowLogIds,
-		CmdRun:     RunNetworkLoadBalancerFlowLogUpdate,
-		InitClient: true,
-	})
+			Example:    updateNetworkLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerFlowLogIds,
+			CmdRun:     RunNetworkLoadBalancerFlowLogUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Network Load Balancer FlowLog")
 	update.AddStringFlag(cloudapiv6.ArgAction, cloudapiv6.ArgActionShort, "", "Specifies the traffic Action pattern")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAction, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic Direction pattern")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer FlowLog update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer FlowLog update [seconds]")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAction,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ALL", "REJECTED", "ACCEPTED"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgDirection, cloudapiv6.ArgDirectionShort, "", "Specifies the traffic Direction pattern",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDirection,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer FlowLog update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer FlowLog update [seconds]",
+	)
 	update.AddStringSliceFlag(constants.ArgCols, "", defaultFlowLogCols, tabheaders.ColsMessage(defaultFlowLogCols))
-	_ = update.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultFlowLogCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "flowlog",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Network Load Balancer FlowLog",
-		LongDesc: `Use this command to delete a specified Network Load Balancer FlowLog from a Network Load Balancer.
+	deleteCmd := core.NewCommand(
+		ctx, networkloadbalancerFlowLogCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "flowlog",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Network Load Balancer FlowLog",
+			LongDesc: `Use this command to delete a specified Network Load Balancer FlowLog from a Network Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -228,34 +369,69 @@ Required values to run command:
 * Data Center Id
 * Network Load Balancer Id
 * Network Load Balancer FlowLog Id`,
-		Example:    deleteNetworkLoadBalancerFlowLogExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerFlowLogDelete,
-		CmdRun:     RunNetworkLoadBalancerFlowLogDelete,
-		InitClient: true,
-	})
+			Example:    deleteNetworkLoadBalancerFlowLogExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerFlowLogDelete,
+			CmdRun:     RunNetworkLoadBalancerFlowLogDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFlowLogId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancerFlowLogsIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer FlowLog deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Network Load Balancer FlowLogs.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer FlowLog deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgFlowLogId, cloudapiv6.ArgIdShort, "", cloudapiv6.FlowLogId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFlowLogId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancerFlowLogsIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Network Load Balancer FlowLog deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Network Load Balancer FlowLogs.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Network Load Balancer FlowLog deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return networkloadbalancerFlowLogCmd
 }
 
 func PreRunNetworkLoadBalacerFlowLogList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -265,18 +441,23 @@ func PreRunNetworkLoadBalacerFlowLogList(c *core.PreCommandConfig) error {
 }
 
 func PreRunNetworkLoadBalancerFlowLogCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgS3Bucket)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgS3Bucket,
+	)
 }
 
 func PreRunNetworkLoadBalancerFlowLogDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgFlowLogId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunDcNetworkLoadBalancerFlowLogIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgFlowLogId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgFlowLogId,
+	)
 }
 
 func RunNetworkLoadBalancerFlowLogList(c *core.CommandConfig) error {
@@ -292,7 +473,10 @@ func RunNetworkLoadBalancerFlowLogList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -300,8 +484,10 @@ func RunNetworkLoadBalancerFlowLogList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Flowlog, networkloadbalancerFlowLogs.FlowLogs,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Flowlog, networkloadbalancerFlowLogs.FlowLogs,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -319,8 +505,12 @@ func RunNetworkLoadBalancerFlowLogGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Network Load Balancer FlowLog with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Network Load Balancer FlowLog with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFlowLogId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().GetFlowLog(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -329,7 +519,10 @@ func RunNetworkLoadBalancerFlowLogGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -337,8 +530,10 @@ func RunNetworkLoadBalancerFlowLogGet(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -372,7 +567,10 @@ func RunNetworkLoadBalancerFlowLogCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -384,8 +582,10 @@ func RunNetworkLoadBalancerFlowLogCreate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -412,7 +612,10 @@ func RunNetworkLoadBalancerFlowLogUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -424,8 +627,10 @@ func RunNetworkLoadBalancerFlowLogUpdate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Flowlog, ng.FlowLog,
-		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Flowlog, ng.FlowLog,
+		tabheaders.GetHeadersAllDefault(defaultFlowLogCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -454,15 +659,26 @@ func RunNetworkLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete network load balancer flowlog", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete network load balancer flowlog",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer FlowLog with id: %v...", flowLogId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer FlowLog with id: %v...", flowLogId),
+	)
 
-	resp, err := c.CloudApiV6Services.NetworkLoadBalancers().DeleteFlowLog(dcId, networkLoadBalancerId, flowLogId, queryParams)
+	resp, err := c.CloudApiV6Services.NetworkLoadBalancers().DeleteFlowLog(
+		dcId, networkLoadBalancerId, flowLogId, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -472,7 +688,10 @@ func RunNetworkLoadBalancerFlowLogDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer FlowLog successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer FlowLog successfully deleted"),
+	)
 	return nil
 }
 
@@ -487,10 +706,18 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) error {
 	networkLoadBalancerId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Network Load Balancer ID: %v", networkLoadBalancerId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancer FlowLogs..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Network Load Balancer ID: %v", networkLoadBalancerId),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancer FlowLogs..."),
+	)
 
-	flowLogs, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().ListFlowLogs(dcId, networkLoadBalancerId, cloudapiv6.ParentResourceListQueryParams)
+	flowLogs, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().ListFlowLogs(
+		dcId, networkLoadBalancerId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -504,7 +731,9 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) error {
 		return fmt.Errorf("no Network Load Balancer FlowLogs found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Network Load BalancerFlowLogs to be deleted:"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Network Load BalancerFlowLogs to be deleted:"),
+	)
 
 	for _, flowLog := range *flowLogsItems {
 		delIdAndName := ""
@@ -522,11 +751,17 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Network Load Balancer FlowLogs", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Network Load Balancer FlowLogs",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancer FlowLogs..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancer FlowLogs..."),
+	)
 
 	var multiErr error
 	for _, flowLog := range *flowLogsItems {
@@ -535,18 +770,29 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer FlowLog with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Network Load Balancer FlowLog with id: %v...", *id),
+		)
 
-		resp, err = c.CloudApiV6Services.NetworkLoadBalancers().DeleteFlowLog(dcId, networkLoadBalancerId, *id, queryParams)
+		resp, err = c.CloudApiV6Services.NetworkLoadBalancers().DeleteFlowLog(
+			dcId, networkLoadBalancerId, *id, queryParams,
+		)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -557,6 +803,9 @@ func DeleteAllNetworkLoadBalancerFlowLogs(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer FlowLogs successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer FlowLogs successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/networkloadbalancer_flowlog_test.go
+++ b/commands/cloudapi-v6/networkloadbalancer_flowlog_test.go
@@ -23,509 +23,633 @@ var testNetworkLoadBalancerFlowLogErr = errors.New("networkloadbalancer-rule tes
 func TestPreRunNetworkLoadBalancerFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		err := PreRunNetworkLoadBalacerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			err := PreRunNetworkLoadBalacerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerFlowLogListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNetworkLoadBalacerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalacerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNetworkLoadBalacerFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalacerFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		err := PreRunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			err := PreRunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerFlowLogIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		err := PreRunDcNetworkLoadBalancerFlowLogIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			err := PreRunDcNetworkLoadBalancerFlowLogIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerFlowLogIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNetworkLoadBalancerFlowLogIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNetworkLoadBalancerFlowLogIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogs, nil, testNetworkLoadBalancerFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogs, nil, testNetworkLoadBalancerFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testNetworkLoadBalancerFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testNetworkLoadBalancerFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, testFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, testFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, nil, testNetworkLoadBalancerFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, nil, testNetworkLoadBalancerFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testFlowLog, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerFlowLogCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateFlowLog(
+				testFlowLogVar, testFlowLogVar, testInputFlowLog, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testFlowLog, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerFlowLogCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).
-			Return(&testFlowLogUpdated, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).
+				Return(&testFlowLogUpdated, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, nil, testNetworkLoadBalancerFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, nil, testNetworkLoadBalancerFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther).Return(&testFlowLogUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAction), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDirection), testFlowLogNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3Bucket), testFlowLogNewVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, &testFlowLogProperties, testQueryParamOther,
+			).Return(&testFlowLogUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerFlowLogUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, nil, testFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, nil, testFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.FlowLogs{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.FlowLogs{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.FlowLogs{FlowLogs: ionoscloud.FlowLogs{Items: &[]ionoscloud.FlowLog{}}}, &testResponse, nil,
+			)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testFlowLogsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testFlowLogErr)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListFlowLogs(
+				testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testFlowLogsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testFlowLogErr)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNetworkLoadBalancerFlowLogErr)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNetworkLoadBalancerFlowLogErr)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteFlowLog(
+				testFlowLogVar, testFlowLogVar, testFlowLogVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerFlowLogDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNetworkLoadBalancerFlowLogDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testFlowLogVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFlowLogId), testFlowLogVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNetworkLoadBalancerFlowLogDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/networkloadbalancer_rule.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule.go
@@ -25,9 +25,13 @@ import (
 )
 
 var (
-	defaultForwardingRuleCols = []string{"ForwardingRuleId", "Name", "Algorithm", "Protocol", "ListenerIp", "ListenerPort", "State"}
-	allForwardingRuleCols     = []string{"ForwardingRuleId", "Name", "Algorithm", "Protocol", "ListenerIp", "ListenerPort", "State",
-		"ClientTimeout", "ConnectTimeout", "TargetTimeout", "Retries"}
+	defaultForwardingRuleCols = []string{
+		"ForwardingRuleId", "Name", "Algorithm", "Protocol", "ListenerIp", "ListenerPort", "State",
+	}
+	allForwardingRuleCols = []string{
+		"ForwardingRuleId", "Name", "Algorithm", "Protocol", "ListenerIp", "ListenerPort", "State",
+		"ClientTimeout", "ConnectTimeout", "TargetTimeout", "Retries",
+	}
 )
 
 func NetworkloadbalancerRuleCmd() *core.Command {
@@ -42,86 +46,145 @@ func NetworkloadbalancerRuleCmd() *core.Command {
 		},
 	}
 	globalFlags := nlbRuleCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultForwardingRuleCols, tabheaders.ColsMessage(allForwardingRuleCols))
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultForwardingRuleCols, tabheaders.ColsMessage(allForwardingRuleCols),
+	)
 	_ = viper.BindPFlag(core.GetFlagName(nlbRuleCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = nlbRuleCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = nlbRuleCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allForwardingRuleCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, nlbRuleCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "rule",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Network Load Balancer Forwarding Rules",
-		LongDesc:   "Use this command to list Network Load Balancer Forwarding Rules from a specified Network Load Balancer.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NlbRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
-		Example:    listNetworkLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerRuleList,
-		CmdRun:     RunNetworkLoadBalancerForwardingRuleList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, nlbRuleCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "rule",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Network Load Balancer Forwarding Rules",
+			LongDesc:   "Use this command to list Network Load Balancer Forwarding Rules from a specified Network Load Balancer.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.NlbRulesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id",
+			Example:    listNetworkLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerRuleList,
+			CmdRun:     RunNetworkLoadBalancerForwardingRuleList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NlbRulesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, nlbRuleCmd, core.CommandBuilder{
-		Namespace:  "networkloadbalancer",
-		Resource:   "rule",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Network Load Balancer Forwarding Rule",
-		LongDesc:   "Use this command to get information about a specified Network Load Balancer Forwarding Rule from a Network Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Forwarding Rule Id",
-		Example:    getNetworkLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
-		CmdRun:     RunNetworkLoadBalancerForwardingRuleGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, nlbRuleCmd, core.CommandBuilder{
+			Namespace:  "networkloadbalancer",
+			Resource:   "rule",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Network Load Balancer Forwarding Rule",
+			LongDesc:   "Use this command to get information about a specified Network Load Balancer Forwarding Rule from a Network Load Balancer.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Forwarding Rule Id",
+			Example:    getNetworkLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
+			CmdRun:     RunNetworkLoadBalancerForwardingRuleGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, nlbRuleCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "rule",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Network Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to create a Network Load Balancer Forwarding Rule in a specified Network Load Balancer. You can also set Health Check Settings for Forwarding Rule.
+	create := core.NewCommand(
+		ctx, nlbRuleCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "rule",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Network Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to create a Network Load Balancer Forwarding Rule in a specified Network Load Balancer. You can also set Health Check Settings for Forwarding Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -131,44 +194,89 @@ Required values to run command:
 * Network Load Balancer Id
 * Listener Ip
 * Listener Port`,
-		Example:    createNetworkLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerForwardingRuleCreate,
-		CmdRun:     RunNetworkLoadBalancerForwardingRuleCreate,
-		InitClient: true,
-	})
+			Example:    createNetworkLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerForwardingRuleCreate,
+			CmdRun:     RunNetworkLoadBalancerForwardingRuleCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Forwarding Rule", "The name for the Forwarding Rule")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Forwarding Rule", "The name for the Forwarding Rule",
+	)
 	create.AddIpFlag(cloudapiv6.ArgListenerIp, "", nil, "Listening IP", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgListenerPort, "", "", "Listening port number. Range: 1 to 65535", core.RequiredFlagOption())
-	create.AddIntFlag(cloudapiv6.ArgRetries, "", 3, "[Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535")
-	create.AddIntFlag(cloudapiv6.ArgClientTimeout, "", 5000, "[Health Check] ClientTimeout is expressed in milliseconds. This inactivity timeout applies when the client is expected to acknowledge or send data")
-	create.AddIntFlag(cloudapiv6.ArgConnectionTimeout, "", 5000, "[Health Check] It specifies the maximum time (in milliseconds) to wait for a connection attempt to a target VM to succeed")
-	create.AddIntFlag(cloudapiv6.ArgTargetTimeout, "", 5000, "[Health Check] TargetTimeout specifies the maximum inactivity time (in milliseconds) on the target VM side")
+	create.AddStringFlag(
+		cloudapiv6.ArgListenerPort, "", "", "Listening port number. Range: 1 to 65535", core.RequiredFlagOption(),
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgRetries, "", 3,
+		"[Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgClientTimeout, "", 5000,
+		"[Health Check] ClientTimeout is expressed in milliseconds. This inactivity timeout applies when the client is expected to acknowledge or send data",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgConnectionTimeout, "", 5000,
+		"[Health Check] It specifies the maximum time (in milliseconds) to wait for a connection attempt to a target VM to succeed",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgTargetTimeout, "", 5000,
+		"[Health Check] TargetTimeout specifies the maximum inactivity time (in milliseconds) on the target VM side",
+	)
 	create.AddStringFlag(cloudapiv6.ArgAlgorithm, "", "ROUND_ROBIN", "Algorithm for the balancing")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAlgorithm, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ROUND_ROBIN", "RANDOM", "SOURCE_IP", "LEAST_CONNECTION"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Forwarding Rule creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAlgorithm,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"ROUND_ROBIN", "RANDOM", "SOURCE_IP", "LEAST_CONNECTION",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, nlbRuleCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "rule",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Network Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to update a specified Network Load Balancer Forwarding Rule from a Network Load Balancer. You can also update Health Check settings.
+	update := core.NewCommand(
+		ctx, nlbRuleCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "rule",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Network Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to update a specified Network Load Balancer Forwarding Rule from a Network Load Balancer. You can also update Health Check settings.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -177,49 +285,99 @@ Required values to run command:
 * Data Center Id
 * Network Load Balancer Id
 * Forwarding Rule Id`,
-		Example:    updateNetworkLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
-		CmdRun:     RunNetworkLoadBalancerForwardingRuleUpdate,
-		InitClient: true,
-	})
+			Example:    updateNetworkLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
+			CmdRun:     RunNetworkLoadBalancerForwardingRuleUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the Forwarding Rule")
 	update.AddIpFlag(cloudapiv6.ArgListenerIp, "", nil, "Listening IP", core.RequiredFlagOption())
-	update.AddStringFlag(cloudapiv6.ArgListenerPort, "", "", "Listening port number. Range: 1 to 65535", core.RequiredFlagOption())
+	update.AddStringFlag(
+		cloudapiv6.ArgListenerPort, "", "", "Listening port number. Range: 1 to 65535", core.RequiredFlagOption(),
+	)
 	update.AddStringFlag(cloudapiv6.ArgAlgorithm, "", "ROUND_ROBIN", "Algorithm for the balancing")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAlgorithm, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ROUND_ROBIN", "RANDOM", "SOURCE_IP", "LEAST_CONNECTION"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddIntFlag(cloudapiv6.ArgRetries, "", 3, "[Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535")
-	update.AddIntFlag(cloudapiv6.ArgClientTimeout, "", 5000, "[Health Check] ClientTimeout is expressed in milliseconds. This inactivity timeout applies when the client is expected to acknowledge or send data")
-	update.AddIntFlag(cloudapiv6.ArgConnectionTimeout, "", 5000, "[Health Check] It specifies the maximum time (in milliseconds) to wait for a connection attempt to a target VM to succeed")
-	update.AddIntFlag(cloudapiv6.ArgTargetTimeout, "", 5000, "[Health Check] TargetTimeout specifies the maximum inactivity time (in milliseconds) on the target VM side")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Forwarding Rule update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAlgorithm,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"ROUND_ROBIN", "RANDOM", "SOURCE_IP", "LEAST_CONNECTION",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgRetries, "", 3,
+		"[Health Check] Retries specifies the number of retries to perform on a target VM after a connection failure. Range: 0 to 65535",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgClientTimeout, "", 5000,
+		"[Health Check] ClientTimeout is expressed in milliseconds. This inactivity timeout applies when the client is expected to acknowledge or send data",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgConnectionTimeout, "", 5000,
+		"[Health Check] It specifies the maximum time (in milliseconds) to wait for a connection attempt to a target VM to succeed",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgTargetTimeout, "", 5000,
+		"[Health Check] TargetTimeout specifies the maximum inactivity time (in milliseconds) on the target VM side",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, nlbRuleCmd, core.CommandBuilder{
-		Namespace: "networkloadbalancer",
-		Resource:  "rule",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Network Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to delete a specified Network Load Balancer Forwarding Rule from a Network Load Balancer.
+	deleteCmd := core.NewCommand(
+		ctx, nlbRuleCmd, core.CommandBuilder{
+			Namespace: "networkloadbalancer",
+			Resource:  "rule",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Network Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to delete a specified Network Load Balancer Forwarding Rule from a Network Load Balancer.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -228,28 +386,61 @@ Required values to run command:
 * Data Center Id
 * Network Load Balancer Id
 * Forwarding Rule Id`,
-		Example:    deleteNetworkLoadBalancerForwardingRuleExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleDelete,
-		CmdRun:     RunNetworkLoadBalancerForwardingRuleDelete,
-		InitClient: true,
-	})
+			Example:    deleteNetworkLoadBalancerForwardingRuleExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleDelete,
+			CmdRun:     RunNetworkLoadBalancerForwardingRuleDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Network Load Balancer Forwarding Rule.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Forwarding Rule deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgRuleId, cloudapiv6.ArgIdShort, "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Network Load Balancer Forwarding Rule.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	nlbRuleCmd.AddCommand(NlbRuleTargetCmd())
 
@@ -257,7 +448,9 @@ Required values to run command:
 }
 
 func PreRunNetworkLoadBalancerRuleList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId); err != nil {
+	if err := core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId,
+	); err != nil {
 		return err
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFilters)) {
@@ -267,15 +460,21 @@ func PreRunNetworkLoadBalancerRuleList(c *core.PreCommandConfig) error {
 }
 
 func PreRunNetworkLoadBalancerForwardingRuleCreate(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgListenerIp, cloudapiv6.ArgListenerPort)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgListenerIp,
+		cloudapiv6.ArgListenerPort,
+	)
 }
 
 func PreRunDcNetworkLoadBalancerForwardingRuleIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId,
+	)
 }
 
 func PreRunDcNetworkLoadBalancerForwardingRuleDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgAll},
 	)
@@ -294,7 +493,10 @@ func RunNetworkLoadBalancerForwardingRuleList(c *core.CommandConfig) error {
 		listQueryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -302,8 +504,11 @@ func RunNetworkLoadBalancerForwardingRuleList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.NetworkLoadBalancerRule,
-		nlbForwardingRules.NetworkLoadBalancerForwardingRules, tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.NetworkLoadBalancerRule,
+		nlbForwardingRules.NetworkLoadBalancerForwardingRules,
+		tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -318,8 +523,12 @@ func RunNetworkLoadBalancerForwardingRuleGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Network Load Balancer Forwarding Rule with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Network Load Balancer Forwarding Rule with id: %v is getting...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	ng, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().GetForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -328,7 +537,10 @@ func RunNetworkLoadBalancerForwardingRuleGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -336,8 +548,11 @@ func RunNetworkLoadBalancerForwardingRuleGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancerRule,
-		ng.NetworkLoadBalancerForwardingRule, tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancerRule,
+		ng.NetworkLoadBalancerForwardingRule,
+		tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -381,7 +596,10 @@ func RunNetworkLoadBalancerForwardingRuleCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -393,8 +611,11 @@ func RunNetworkLoadBalancerForwardingRuleCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancerRule,
-		ng.NetworkLoadBalancerForwardingRule, tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancerRule,
+		ng.NetworkLoadBalancerForwardingRule,
+		tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -422,7 +643,10 @@ func RunNetworkLoadBalancerForwardingRuleUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -434,8 +658,11 @@ func RunNetworkLoadBalancerForwardingRuleUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancerRule,
-		ng.NetworkLoadBalancerForwardingRule, tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancerRule,
+		ng.NetworkLoadBalancerForwardingRule,
+		tabheaders.GetHeaders(allForwardingRuleCols, defaultForwardingRuleCols, cols),
+	)
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
 
@@ -461,16 +688,27 @@ func RunNetworkLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete network load balancer forwarding rule", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete network load balancer forwarding rule",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Network Load Balancer Forwarding Rule with id: %v...", ruleId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Network Load Balancer Forwarding Rule with id: %v...", ruleId,
+		),
+	)
 
-	resp, err := c.CloudApiV6Services.NetworkLoadBalancers().DeleteForwardingRule(dcId, loadBalancerId, ruleId, queryParams)
+	resp, err := c.CloudApiV6Services.NetworkLoadBalancers().DeleteForwardingRule(
+		dcId, loadBalancerId, ruleId, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -480,7 +718,10 @@ func RunNetworkLoadBalancerForwardingRuleDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule successfully deleted"),
+	)
 	return nil
 }
 
@@ -498,21 +739,30 @@ func getForwardingRulePropertiesSet(c *core.CommandConfig) *resources.NetworkLoa
 		algorithm := strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)))
 		input.SetAlgorithm(algorithm)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Algorithm set: %v", algorithm))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Algorithm set: %v", algorithm),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp)) {
 		listenerIp := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgListenerIp))
 		input.SetListenerIp(listenerIp)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerIp set: %v", listenerIp))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property ListenerIp set: %v", listenerIp),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort)) {
 		listenerPort := viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgListenerPort))
 		input.SetListenerPort(listenerPort)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ListenerPort set: %v", listenerPort))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property ListenerPort set: %v", listenerPort),
+		)
 	}
 
 	return &resources.NetworkLoadBalancerForwardingRuleProperties{
@@ -555,10 +805,18 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) error {
 	loadBalancerId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNetworkLoadBalancerId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Network Load Balancer ID: %v", loadBalancerId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancer Forwarding Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Network Load Balancer ID: %v", loadBalancerId),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting Network Load Balancer Forwarding Rules..."),
+	)
 
-	nlbForwardingRules, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().ListForwardingRules(dcId, loadBalancerId, cloudapiv6.ParentResourceListQueryParams)
+	nlbForwardingRules, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().ListForwardingRules(
+		dcId, loadBalancerId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -572,7 +830,10 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) error {
 		return fmt.Errorf("no Network Load Balancer Forwarding Rules found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rules to be deleted:"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rules to be deleted:"),
+	)
 
 	for _, nlbForwardingRule := range *nlbForwardingRulesItems {
 		delIdAndName := ""
@@ -590,11 +851,17 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Network Load Balancer Forwarding Rules", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Network Load Balancer Forwarding Rules",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancer Forwarding Rules..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Deleting all the Network Load Balancer Forwarding Rules..."),
+	)
 
 	var multiErr error
 	for _, nlbForwardingRule := range *nlbForwardingRulesItems {
@@ -603,18 +870,29 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Network Load Balancer Forwarding Rule with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Network Load Balancer Forwarding Rule with id: %v...", *id,
+			),
+		)
 
-		resp, err = c.CloudApiV6Services.NetworkLoadBalancers().DeleteForwardingRule(dcId, loadBalancerId, *id, queryParams)
+		resp, err = c.CloudApiV6Services.NetworkLoadBalancers().DeleteForwardingRule(
+			dcId, loadBalancerId, *id, queryParams,
+		)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -625,6 +903,9 @@ func DeleteAllNetworkLoadBalancerForwardingRules(c *core.CommandConfig) error {
 		return multiErr
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rules successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rules successfully deleted"),
+	)
 	return nil
 }

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target.go
@@ -40,54 +40,86 @@ func NlbRuleTargetCmd() *core.Command {
 		},
 	}
 	globalFlags := nlbRuleTargetCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultRuleTargetCols, tabheaders.ColsMessage(defaultRuleTargetCols))
-	_ = viper.BindPFlag(core.GetFlagName(nlbRuleTargetCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = nlbRuleTargetCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultRuleTargetCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultRuleTargetCols, tabheaders.ColsMessage(defaultRuleTargetCols),
+	)
+	_ = viper.BindPFlag(
+		core.GetFlagName(nlbRuleTargetCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = nlbRuleTargetCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultRuleTargetCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, nlbRuleTargetCmd, core.CommandBuilder{
-		Namespace:  "forwardingrule",
-		Resource:   "target",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Network Load Balancer Forwarding Rule Targets",
-		LongDesc:   "Use this command to list Targets of a Network Load Balancer Forwarding Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Forwarding Rule Id",
-		Example:    listNetworkLoadBalancerRuleTargetExample,
-		PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
-		CmdRun:     RunNlbRuleTargetList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, nlbRuleTargetCmd, core.CommandBuilder{
+			Namespace:  "forwardingrule",
+			Resource:   "target",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Network Load Balancer Forwarding Rule Targets",
+			LongDesc:   "Use this command to list Targets of a Network Load Balancer Forwarding Rule.\n\nRequired values to run command:\n\n* Data Center Id\n* Network Load Balancer Id\n* Forwarding Rule Id",
+			Example:    listNetworkLoadBalancerRuleTargetExample,
+			PreCmdRun:  PreRunDcNetworkLoadBalancerForwardingRuleIds,
+			CmdRun:     RunNlbRuleTargetList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						list.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(list.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Add Command
 	*/
-	add := core.NewCommand(ctx, nlbRuleTargetCmd, core.CommandBuilder{
-		Namespace: "forwardingrule",
-		Resource:  "target",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add a Network Load Balancer Forwarding Rule Target",
-		LongDesc: `Use this command to add a Forwarding Rule Target in a specified Network Load Balancer Forwarding Rule. You can also set Health Check Settings for Forwarding Rule Target. The Check parameter for Health Check Settings specifies whether the target VM's health is checked. If turned off, a target VM is always considered available. If turned on, the target VM is available when accepting periodic TCP connections, to ensure that it is really able to serve requests. The address and port to send the tests to are those of the target VM. The health check only consists of a connection attempt.
+	add := core.NewCommand(
+		ctx, nlbRuleTargetCmd, core.CommandBuilder{
+			Namespace: "forwardingrule",
+			Resource:  "target",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add a Network Load Balancer Forwarding Rule Target",
+			LongDesc: `Use this command to add a Forwarding Rule Target in a specified Network Load Balancer Forwarding Rule. You can also set Health Check Settings for Forwarding Rule Target. The Check parameter for Health Check Settings specifies whether the target VM's health is checked. If turned off, a target VM is always considered available. If turned on, the target VM is available when accepting periodic TCP connections, to ensure that it is really able to serve requests. The address and port to send the tests to are those of the target VM. The health check only consists of a connection attempt.
 
 Regarding the Weight parameter, this parameter is used to adjust the target VM's weight relative to other target VMs. All target VMs will receive a load proportional to their weight relative to the sum of all weights, so the higher the weight, the higher the load. The default weight is 1, and the maximal value is 256. A value of 0 means the target VM will not participate in load-balancing but will still accept persistent connections. If this parameter is used to distribute the load according to target VM's capacity, it is recommended to start with values which can both grow and shrink, for instance between 10 and 100 to leave enough room above and below for later adjustments.
 
@@ -100,45 +132,87 @@ Required values to run command:
 * Forwarding Rule Id
 * Target Ip
 * Target Port`,
-		Example:    addNetworkLoadBalancerRuleTargetExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerRuleTarget,
-		CmdRun:     RunNlbRuleTargetAdd,
-		InitClient: true,
-	})
+			Example:    addNetworkLoadBalancerRuleTargetExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerRuleTarget,
+			CmdRun:     RunNlbRuleTargetAdd,
+			InitClient: true,
+		},
+	)
 	add.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	add.AddUUIDFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	add.AddUUIDFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						add.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddStringFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
-		), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(add.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddIpFlag(cloudapiv6.ArgIp, "", nil, "IP of a balanced target VM", core.RequiredFlagOption())
-	add.AddStringFlag(cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, "", "Port of the balanced target service. Range: 1 to 65535", core.RequiredFlagOption())
-	add.AddIntFlag(cloudapiv6.ArgWeight, cloudapiv6.ArgWeightShort, 1, "Weight parameter is used to adjust the target VM's weight relative to other target VMs. Maximum: 256")
-	add.AddIntFlag(cloudapiv6.ArgCheckInterval, "", 2000, "[Health Check] CheckInterval determines the duration (in milliseconds) between consecutive health checks")
-	add.AddBoolFlag(cloudapiv6.ArgCheck, "", true, "[Health Check] Check specifies whether the target VM's health is checked")
-	add.AddBoolFlag(cloudapiv6.ArgMaintenance, "", false, "[Health Check]  Maintenance specifies if a target VM should be marked as down, even if it is not")
-	add.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule Target creation to be executed")
-	add.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Forwarding Rule Target creation [seconds]")
-	add.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	add.AddStringFlag(
+		cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, "", "Port of the balanced target service. Range: 1 to 65535",
+		core.RequiredFlagOption(),
+	)
+	add.AddIntFlag(
+		cloudapiv6.ArgWeight, cloudapiv6.ArgWeightShort, 1,
+		"Weight parameter is used to adjust the target VM's weight relative to other target VMs. Maximum: 256",
+	)
+	add.AddIntFlag(
+		cloudapiv6.ArgCheckInterval, "", 2000,
+		"[Health Check] CheckInterval determines the duration (in milliseconds) between consecutive health checks",
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgCheck, "", true, "[Health Check] Check specifies whether the target VM's health is checked",
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgMaintenance, "", false,
+		"[Health Check]  Maintenance specifies if a target VM should be marked as down, even if it is not",
+	)
+	add.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule Target creation to be executed",
+	)
+	add.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule Target creation [seconds]",
+	)
+	add.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Remove Command
 	*/
-	removeCmd := core.NewCommand(ctx, nlbRuleTargetCmd, core.CommandBuilder{
-		Namespace: "forwardingrule",
-		Resource:  "target",
-		Verb:      "remove",
-		Aliases:   []string{"r"},
-		ShortDesc: "Remove a Target from a Network Load Balancer Forwarding Rule",
-		LongDesc: `Use this command to remove a specified Target from Network Load Balancer Forwarding Rule.
+	removeCmd := core.NewCommand(
+		ctx, nlbRuleTargetCmd, core.CommandBuilder{
+			Namespace: "forwardingrule",
+			Resource:  "target",
+			Verb:      "remove",
+			Aliases:   []string{"r"},
+			ShortDesc: "Remove a Target from a Network Load Balancer Forwarding Rule",
+			LongDesc: `Use this command to remove a specified Target from Network Load Balancer Forwarding Rule.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -149,42 +223,83 @@ Required values to run command:
 * Forwarding Rule Id
 * Target Ip
 * Target Port`,
-		Example:    removeNetworkLoadBalancerRuleTargetExample,
-		PreCmdRun:  PreRunNetworkLoadBalancerRuleTargetRemove,
-		CmdRun:     RunNlbRuleTargetRemove,
-		InitClient: true,
-	})
+			Example:    removeNetworkLoadBalancerRuleTargetExample,
+			PreCmdRun:  PreRunNetworkLoadBalancerRuleTargetRemove,
+			CmdRun:     RunNlbRuleTargetRemove,
+			InitClient: true,
+		},
+	)
+	removeCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeCmd.AddStringFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeCmd.AddStringFlag(cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgNetworkLoadBalancerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.NetworkLoadBalancersIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeCmd.AddStringFlag(
+		cloudapiv6.ArgNetworkLoadBalancerId, "", "", cloudapiv6.NetworkLoadBalancerId, core.RequiredFlagOption(),
+	)
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgNetworkLoadBalancerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.NetworkLoadBalancersIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddStringFlag(cloudapiv6.ArgRuleId, "", "", cloudapiv6.ForwardingRuleId, core.RequiredFlagOption())
-	_ = removeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgRuleId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ForwardingRulesIds(viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgRuleId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ForwardingRulesIds(
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(removeCmd.NS, cloudapiv6.ArgNetworkLoadBalancerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeCmd.AddIpFlag(cloudapiv6.ArgIp, "", nil, "IP of a balanced target VM", core.RequiredFlagOption())
-	removeCmd.AddStringFlag(cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, "", "Port of the balanced target service. Range: 1 to 65535", core.RequiredFlagOption())
-	removeCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Forwarding Rule Target deletion to be executed")
-	removeCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Forwarding Rule Target deletion [seconds]")
+	removeCmd.AddStringFlag(
+		cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, "", "Port of the balanced target service. Range: 1 to 65535",
+		core.RequiredFlagOption(),
+	)
+	removeCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Forwarding Rule Target deletion to be executed",
+	)
+	removeCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds,
+		"Timeout option for Request for Forwarding Rule Target deletion [seconds]",
+	)
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all Forwarding Rule Targets.")
-	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	removeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return nlbRuleTargetCmd
 }
 
 func PreRunNetworkLoadBalancerRuleTarget(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgIp, cloudapiv6.ArgPort)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId,
+		cloudapiv6.ArgIp, cloudapiv6.ArgPort,
+	)
 }
 
 func PreRunNetworkLoadBalancerRuleTargetRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgTargetIp, cloudapiv6.ArgTargetPort},
-		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgAll},
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId,
+			cloudapiv6.ArgTargetIp, cloudapiv6.ArgTargetPort,
+		},
+		[]string{
+			cloudapiv6.ArgDataCenterId, cloudapiv6.ArgNetworkLoadBalancerId, cloudapiv6.ArgRuleId, cloudapiv6.ArgAll,
+		},
 	)
 }
 
@@ -196,7 +311,10 @@ func RunNlbRuleTargetList(c *core.CommandConfig) error {
 		resources.QueryParams{},
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -214,8 +332,10 @@ func RunNlbRuleTargetList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancerRuleTarget, *targets,
-		tabheaders.GetHeadersAllDefault(defaultRuleTargetCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancerRuleTarget, *targets,
+		tabheaders.GetHeadersAllDefault(defaultRuleTargetCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -241,7 +361,10 @@ func RunNlbRuleTargetAdd(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -265,10 +388,15 @@ func RunNlbRuleTargetAdd(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Adding NlbRuleTarget with id: %v to NetworkLoadBalancer with id: %v", ruleId, nlbId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding NlbRuleTarget with id: %v to NetworkLoadBalancer with id: %v", ruleId, nlbId,
+		),
+	)
 
-	_, resp, err = c.CloudApiV6Services.NetworkLoadBalancers().UpdateForwardingRule(dcId, nlbId, ruleId, nlbForwardingRule, queryParams)
+	_, resp, err = c.CloudApiV6Services.NetworkLoadBalancers().UpdateForwardingRule(
+		dcId, nlbId, ruleId, nlbForwardingRule, queryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -279,8 +407,10 @@ func RunNlbRuleTargetAdd(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.NetworkLoadBalancerRuleTarget,
-		targetNew.NetworkLoadBalancerForwardingRuleTarget, tabheaders.GetHeadersAllDefault(defaultRuleTargetCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.NetworkLoadBalancerRuleTarget,
+		targetNew.NetworkLoadBalancerForwardingRuleTarget, tabheaders.GetHeadersAllDefault(defaultRuleTargetCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -305,12 +435,18 @@ func RunNlbRuleTargetRemove(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete forwarding rule target", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete forwarding rule target",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"NlbRuleTarget with id: %v is removing...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"NlbRuleTarget with id: %v is removing...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId)),
+		),
+	)
 
 	frOld, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().GetForwardingRule(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -319,7 +455,10 @@ func RunNlbRuleTargetRemove(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -345,7 +484,10 @@ func RunNlbRuleTargetRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule Target successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule Target successfully deleted"),
+	)
 	return nil
 }
 
@@ -361,11 +503,21 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) error {
 	ruleId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRuleId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NetworkLoadBalancer ID: %v", nlbId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NetworkLoadBalancerForwardingRule ID: %v", ruleId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting NetworkLoadBalancerForwardingRule..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("NetworkLoadBalancer ID: %v", nlbId),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("NetworkLoadBalancerForwardingRule ID: %v", ruleId),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Getting NetworkLoadBalancerForwardingRule..."),
+	)
 
-	forwardingRule, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().GetForwardingRule(dcId, nlbId, ruleId, cloudapiv6.ParentResourceQueryParams)
+	forwardingRule, resp, err := c.CloudApiV6Services.NetworkLoadBalancers().GetForwardingRule(
+		dcId, nlbId, ruleId, cloudapiv6.ParentResourceQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -384,7 +536,9 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) error {
 		return fmt.Errorf("no Forwarding Rule Targets found")
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule Targets to be removed:"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Forwarding Rule Targets to be removed:"),
+	)
 
 	for _, target := range *targets {
 		delIdAndName := ""
@@ -400,11 +554,17 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove all the Forwarding Rule Targets", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove all the Forwarding Rule Targets",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing all the Forwarding Rule Targets..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Removing all the Forwarding Rule Targets..."),
+	)
 
 	targetItems := make([]ionoscloud.NetworkLoadBalancerForwardingRuleTarget, 0)
 	nlbFwRuleProp := &resources.NetworkLoadBalancerForwardingRuleProperties{
@@ -413,9 +573,14 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) error {
 		},
 	}
 
-	_, resp, err = c.CloudApiV6Services.NetworkLoadBalancers().UpdateForwardingRule(dcId, nlbId, ruleId, nlbFwRuleProp, queryParams)
+	_, resp, err = c.CloudApiV6Services.NetworkLoadBalancers().UpdateForwardingRule(
+		dcId, nlbId, ruleId, nlbFwRuleProp, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -425,7 +590,10 @@ func RemoveAllNlbRuleTarget(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule Targets successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(),
+		jsontabwriter.GenerateLogOutput("Network Load Balancer Forwarding Rule Targets successfully deleted"),
+	)
 	return nil
 }
 
@@ -449,14 +617,19 @@ func getRuleTargetInfo(c *core.CommandConfig) resources.NetworkLoadBalancerForwa
 	targetHealth.SetCheckInterval(checkInterval)
 	target.SetHealthCheck(targetHealth.NetworkLoadBalancerForwardingRuleTargetHealthCheck)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for adding the NlbRuleTarget: Ip: %v, Port: %v, Weight: %v, Maintenance: %v, Check: %v, CheckInterval: %v",
-		targetIp, targetPort, weight, maintenance, check, checkInterval))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for adding the NlbRuleTarget: Ip: %v, Port: %v, Weight: %v, Maintenance: %v, Check: %v, CheckInterval: %v",
+			targetIp, targetPort, weight, maintenance, check, checkInterval,
+		),
+	)
 
 	return target
 }
 
-func getRuleTargetsRemove(c *core.CommandConfig, frOld *resources.NetworkLoadBalancerForwardingRule) (*resources.NetworkLoadBalancerForwardingRuleProperties, error) {
+func getRuleTargetsRemove(
+	c *core.CommandConfig, frOld *resources.NetworkLoadBalancerForwardingRule,
+) (*resources.NetworkLoadBalancerForwardingRuleProperties, error) {
 	var (
 		foundIp   = false
 		foundPort = false

--- a/commands/cloudapi-v6/networkloadbalancer_rule_target_test.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_target_test.go
@@ -75,428 +75,540 @@ var (
 func TestPreRunNetworkLoadBalancerRuleTarget(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		err := PreRunNetworkLoadBalancerRuleTarget(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			err := PreRunNetworkLoadBalancerRuleTarget(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerRuleTargetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunNetworkLoadBalancerRuleTarget(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunNetworkLoadBalancerRuleTarget(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
-		err := RunNlbRuleTargetList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
+			err := RunNlbRuleTargetList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetListGetTargetsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, nil)
-		err := RunNlbRuleTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			err := RunNlbRuleTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetListGetPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.NetworkLoadBalancerForwardingRule{}, nil, nil)
-		err := RunNlbRuleTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.NetworkLoadBalancerForwardingRule{}, nil, nil)
+			err := RunNlbRuleTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties, testQueryParamOther).
-			Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
-		err := RunNlbRuleTargetAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties,
+				testQueryParamOther,
+			).
+				Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
+			err := RunNlbRuleTargetAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetAddResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties, testQueryParamOther).Return(&testNlbRuleTargetGetUpdated, &testResponse, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties,
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGetUpdated, &testResponse, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties, testQueryParamOther).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties,
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetAddWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties, testQueryParamOther).Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNlbRuleTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheck), testNlbRuleTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenance), testNlbRuleTargetBoolVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, &testRuleTargetProperties,
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNlbRuleTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
-			&resources.NetworkLoadBalancerForwardingRuleProperties{
-				NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
-					Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				&resources.NetworkLoadBalancerForwardingRuleProperties{
+					NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
+						Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testNlbRuleTargetGet, &testResponse, nil)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGet, &testResponse, nil)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
-			&resources.NetworkLoadBalancerForwardingRuleProperties{
-				NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
-					Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testNlbRuleTargetGetUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				&resources.NetworkLoadBalancerForwardingRuleProperties{
+					NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
+						Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testNlbRuleTargetGet, &testResponse, nil)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGet, &testResponse, nil)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
-			&resources.NetworkLoadBalancerForwardingRuleProperties{
-				NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
-					Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				&resources.NetworkLoadBalancerForwardingRuleProperties{
+					NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
+						Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testNlbRuleTargetGet, nil, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGet, nil, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, testNlbRuleTargetErr)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveIpErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), "x.x.x.x")
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), "x.x.x.x")
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemovePortErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), int32(2))
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), int32(2))
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
-			&resources.NetworkLoadBalancerForwardingRuleProperties{
-				NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
-					Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				&resources.NetworkLoadBalancerForwardingRuleProperties{
+					NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
+						Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testNlbRuleTargetGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbRuleTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
-			&resources.NetworkLoadBalancerForwardingRuleProperties{
-				NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
-					Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbRuleTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbRuleTargetVar, testNlbRuleTargetVar, testNlbRuleTargetVar,
+				&resources.NetworkLoadBalancerForwardingRuleProperties{
+					NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
+						Targets: &[]ionoscloud.NetworkLoadBalancerForwardingRuleTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testNlbRuleTargetGet, nil, nil)
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testNlbRuleTargetGet, nil, nil)
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNlbRuleTargetRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNlbRuleTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testNlbRuleTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testNlbRuleTargetIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNlbRuleTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/networkloadbalancer_rule_test.go
+++ b/commands/cloudapi-v6/networkloadbalancer_rule_test.go
@@ -33,7 +33,8 @@ var (
 					TargetTimeout:  &testNlbForwardingRuleIntVar,
 					Retries:        &testNlbForwardingRuleIntVar,
 				},
-			}},
+			},
+		},
 	}
 	testNlbForwardingRulePropertiesNew = resources.NetworkLoadBalancerForwardingRuleProperties{
 		NetworkLoadBalancerForwardingRuleProperties: ionoscloud.NetworkLoadBalancerForwardingRuleProperties{
@@ -88,574 +89,692 @@ var (
 func TestPreRunNetworkLoadBalancerRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		err := PreRunNetworkLoadBalancerRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			err := PreRunNetworkLoadBalancerRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerRuleListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNetworkLoadBalancerRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalancerRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNetworkLoadBalancerRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalancerRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerForwardingRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
-		err := PreRunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
+			err := PreRunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerForwardingRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerForwardingRuleIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		err := PreRunDcNetworkLoadBalancerForwardingRuleIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			err := PreRunDcNetworkLoadBalancerForwardingRuleIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerForwardingRuleIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNetworkLoadBalancerForwardingRuleIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNetworkLoadBalancerForwardingRuleIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(testNlbForwardingRules, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(testNlbForwardingRules, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(resources.NetworkLoadBalancerForwardingRules{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(resources.NetworkLoadBalancerForwardingRules{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(testNlbForwardingRules, nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(testNlbForwardingRules, nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testNlbForwardingRuleGet, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testNlbForwardingRuleGet, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testNlbForwardingRuleGet, nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().GetForwardingRule(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testNlbForwardingRuleGet, nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
-		).
-			Return(&testNlbForwardingRuleGet, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
+			).
+				Return(&testNlbForwardingRuleGet, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
-		).Return(&testNlbForwardingRuleGet, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
+			).Return(&testNlbForwardingRuleGet, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
-		).Return(&testNlbForwardingRuleGet, nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
+			).Return(&testNlbForwardingRuleGet, nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
-		).Return(&testNlbForwardingRuleGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testNlbForwardingRuleAlgorithm)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().CreateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testInputForwardingRule, testQueryParamOther,
+			).Return(&testNlbForwardingRuleGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerForwardingRuleCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew, testQueryParamOther,
-		).
-			Return(&testNlbForwardingRuleUpdated, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew,
+				testQueryParamOther,
+			).
+				Return(&testNlbForwardingRuleUpdated, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew, testQueryParamOther,
-		).Return(&testNlbForwardingRuleUpdated, nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew,
+				testQueryParamOther,
+			).Return(&testNlbForwardingRuleUpdated, nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew, testQueryParamOther,
-		).Return(&testNlbForwardingRuleUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerIp), testNlbForwardingRuleNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerPort), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgClientTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgConnectionTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetTimeout), testNlbForwardingRuleNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testNlbForwardingRuleNewIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().UpdateForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, &testNlbForwardingRulePropertiesNew,
+				testQueryParamOther,
+			).Return(&testNlbForwardingRuleUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerForwardingRuleUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testNlbForwardingRuleVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(testNlbForwardingRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).
-			Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).
-			Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(testNlbForwardingRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).
+				Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).
+				Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(testNlbForwardingRulesList, nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(testNlbForwardingRulesList, nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(resources.NetworkLoadBalancerForwardingRules{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(resources.NetworkLoadBalancerForwardingRules{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(resources.NetworkLoadBalancerForwardingRules{NetworkLoadBalancerForwardingRules: ionoscloud.NetworkLoadBalancerForwardingRules{Items: &[]ionoscloud.NetworkLoadBalancerForwardingRule{}}}, &testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(
+					resources.NetworkLoadBalancerForwardingRules{NetworkLoadBalancerForwardingRules: ionoscloud.NetworkLoadBalancerForwardingRules{Items: &[]ionoscloud.NetworkLoadBalancerForwardingRule{}}},
+					&testResponse, nil,
+				)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam)).
-			Return(testNlbForwardingRulesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).
-			Return(&testResponse, testNetworkLoadBalancerForwardingRuleErr)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).
-			Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().ListForwardingRules(
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).
+				Return(testNlbForwardingRulesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).
+				Return(&testResponse, testNetworkLoadBalancerForwardingRuleErr)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).
+				Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).Return(nil, testNetworkLoadBalancerForwardingRuleErr)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).Return(nil, testNetworkLoadBalancerForwardingRuleErr)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(testNlbForwardingRuleVar,
-			testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
-		).Return(nil, nil)
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().DeleteForwardingRule(
+				testNlbForwardingRuleVar,
+				testNlbForwardingRuleVar, testNlbForwardingRuleVar, testQueryParamOther,
+			).Return(nil, nil)
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerForwardingRuleDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNlbForwardingRuleVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRuleId), testNlbForwardingRuleVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNetworkLoadBalancerForwardingRuleDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/networkloadbalancer_test.go
+++ b/commands/cloudapi-v6/networkloadbalancer_test.go
@@ -97,510 +97,650 @@ func TestNetworkloadbalancerCmd(t *testing.T) {
 func TestPreRunNetworkLoadBalancerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		err := PreRunNetworkLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			err := PreRunNetworkLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNetworkLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNetworkLoadBalancerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNetworkLoadBalancerList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNetworkLoadBalancerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		err := PreRunDcNetworkLoadBalancerIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			err := PreRunDcNetworkLoadBalancerIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNetworkLoadBalancerIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunDcNetworkLoadBalancerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunDcNetworkLoadBalancerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancersList, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunNetworkLoadBalancerListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancersList, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunNetworkLoadBalancerListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancers, &testResponse, nil)
-		err := RunNetworkLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancers, &testResponse, nil)
+			err := RunNetworkLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.NetworkLoadBalancers{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.NetworkLoadBalancers{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancers, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancers, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTestGet, &testResponse, nil)
-		err := RunNetworkLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTestGet, &testResponse, nil)
+			err := RunNetworkLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTestGet, nil, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTestGet, nil, nil)
-		err := RunNetworkLoadBalancerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTestGet, nil, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTestGet, nil, nil)
+			err := RunNetworkLoadBalancerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTestGet, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTestGet, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTestGet, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Get(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTestGet, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTest, &testResponse, nil)
-		err := RunNetworkLoadBalancerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(
+				testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTest, &testResponse, nil)
+			err := RunNetworkLoadBalancerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTest, &testResponse, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(
+				testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTest, &testResponse, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTest, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(
+				testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTest, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Create(
+				testNetworkLoadBalancerVar, networkloadbalancerTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).
-			Return(&networkloadbalancerNew, &testResponse, nil)
-		err := RunNetworkLoadBalancerUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).
+				Return(&networkloadbalancerNew, &testResponse, nil)
+			err := RunNetworkLoadBalancerUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerNew, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerNew, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&networkloadbalancerNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPrivateIps), testNetworkLoadBalancerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetLan), testNetworkLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgListenerLan), testNetworkLoadBalancerNewIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Update(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, networkloadbalancerProperties,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&networkloadbalancerNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancersList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancersList, nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancersList, nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.NetworkLoadBalancers{}, &testResponse, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.NetworkLoadBalancers{}, &testResponse, nil)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.NetworkLoadBalancers{NetworkLoadBalancers: ionoscloud.NetworkLoadBalancers{Items: &[]ionoscloud.NetworkLoadBalancer{}}}, &testResponse, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.NetworkLoadBalancers{NetworkLoadBalancers: ionoscloud.NetworkLoadBalancers{Items: &[]ionoscloud.NetworkLoadBalancer{}}},
+				&testResponse, nil,
+			)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(networkloadbalancersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNetworkLoadBalancerErr)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().List(
+				testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(networkloadbalancersList, &testResponse, nil)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNetworkLoadBalancerErr)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNetworkLoadBalancerErr)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNetworkLoadBalancerErr)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.NetworkLoadBalancer.EXPECT().Delete(
+				testNetworkLoadBalancerVar, testNetworkLoadBalancerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNetworkLoadBalancerDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNetworkLoadBalancerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNetworkLoadBalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNetworkLoadBalancerId), testNetworkLoadBalancerVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNetworkLoadBalancerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/nic_test.go
+++ b/commands/cloudapi-v6/nic_test.go
@@ -134,457 +134,587 @@ func TestNicCmd(t *testing.T) {
 func TestPreRunNicList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		err := PreRunNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			err := PreRunNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNicListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunNicListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunNicList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunNicList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ns, &testResponse, nil)
-		err := RunNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ns, &testResponse, nil)
+			err := RunNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Nics{}, &testResponse, nil)
-		err := RunNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Nics{}, &testResponse, nil)
+			err := RunNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ns, nil, testNicErr)
-		err := RunNicList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ns, nil, testNicErr)
+			err := RunNicList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Get(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		err := RunNicGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Get(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			err := RunNicGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Get(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, testNicErr)
-		err := RunNicGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Get(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, testNicErr)
+			err := RunNicGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Create(testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		err := RunNicCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Create(
+				testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			err := RunNicCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Create(testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, testNicErr)
-		err := RunNicCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Create(
+				testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, testNicErr)
+			err := RunNicCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Create(testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNicCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIps), ipsNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNicId)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirewallType), testNicVar)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Create(
+				testNicVar, testNicVar, testNicCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNicCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Get(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Update(testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nicNew, &testResponse, nil)
-		err := RunNicUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Get(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Update(
+				testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nicNew, &testResponse, nil)
+			err := RunNicUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Get(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Update(testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nicNew, nil, testNicErr)
-		err := RunNicUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Get(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Update(
+				testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nicNew, nil, testNicErr)
+			err := RunNicUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Get(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Lan.EXPECT().Get(testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&lanNic, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Update(testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&nicNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNicUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testNicNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDhcp), dhcpNewNic)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLanId), lanNewNicId)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Get(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Lan.EXPECT().Get(
+				testNicVar, lanNicIdString, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&lanNic, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Update(
+				testNicVar, testNicVar, testNicVar, nicProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&nicNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNicUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNicDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNicDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nicsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNicDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nicsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNicDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nicsList, nil, testNicErr)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nicsList, nil, testNicErr)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Nics{}, &testResponse, nil)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Nics{}, &testResponse, nil)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Nics{Nics: ionoscloud.Nics{Items: &[]ionoscloud.Nic{}}}, &testResponse, nil)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.Nics{Nics: ionoscloud.Nics{Items: &[]ionoscloud.Nic{}}}, &testResponse, nil,
+			)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().List(testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(nicsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNicErr)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().List(
+				testNicVar, testNicVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(nicsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNicErr)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testNicErr)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testNicErr)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Nic.EXPECT().Delete(testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunNicDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Nic.EXPECT().Delete(
+				testNicVar, testNicVar, testNicVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunNicDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunNicDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunNicDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testNicVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunNicDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 // LoadBalancer Nic
@@ -592,376 +722,484 @@ func TestRunNicDeleteAskForConfirmErr(t *testing.T) {
 func TestPreRunDcNicLoadBalancerIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		err := PreRunDcNicLoadBalancerIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			err := PreRunDcNicLoadBalancerIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunLoadBalancerNicList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		err := PreRunLoadBalancerNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			err := PreRunLoadBalancerNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunLoadBalancerNicListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunLoadBalancerNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunLoadBalancerNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunLoadBalancerNicListFiltersErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunLoadBalancerNicList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunLoadBalancerNicList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcNicLoadBalancerIdsRequiredFlagsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcNicLoadBalancerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcNicLoadBalancerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicAttach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, nil)
-		err := RunLoadBalancerNicAttach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, nil)
+			err := RunLoadBalancerNicAttach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicAttachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, testLoadbalancerErr)
-		err := RunLoadBalancerNicAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, testLoadbalancerErr)
+			err := RunLoadBalancerNicAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicAttachWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLoadBalancerNicAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().AttachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLoadBalancerNicAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(balancedns, nil, nil)
-		err := RunLoadBalancerNicList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(balancedns, nil, nil)
+			err := RunLoadBalancerNicList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(balancedns, nil, testLoadbalancerErr)
-		err := RunLoadBalancerNicList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(balancedns, nil, testLoadbalancerErr)
+			err := RunLoadBalancerNicList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().GetNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, nil)
-		err := RunLoadBalancerNicGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().GetNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, nil)
+			err := RunLoadBalancerNicGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().GetNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Nic{Nic: n}, nil, testLoadbalancerErr)
-		err := RunLoadBalancerNicGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().GetNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Nic{Nic: n}, nil, testLoadbalancerErr)
+			err := RunLoadBalancerNicGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(balancedNicsList, nil, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(balancedNicsList, nil, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(balancedNicsList, nil, testNicErr)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(balancedNicsList, nil, testNicErr)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.BalancedNics{}, nil, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.BalancedNics{}, nil, nil)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.BalancedNics{BalancedNics: ionoscloud.BalancedNics{Items: &[]ionoscloud.Nic{}}}, nil, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.BalancedNics{BalancedNics: ionoscloud.BalancedNics{Items: &[]ionoscloud.Nic{}}}, nil, nil,
+			)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(balancedNicsList, nil, nil)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testNicErr)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().ListNics(
+				testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(balancedNicsList, nil, nil)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testNicErr)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testLoadbalancerErr)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testLoadbalancerErr)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Loadbalancer.EXPECT().DetachNic(
+				testLoadbalancerVar, testLoadbalancerVar, testLoadbalancerVar,
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunLoadBalancerNicDetachAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunLoadBalancerNicDetach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLoadBalancerId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicId), testLoadbalancerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunLoadBalancerNicDetach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/pcc.go
+++ b/commands/cloudapi-v6/pcc.go
@@ -56,134 +56,201 @@ func PccCmd() *core.Command {
 	globalFlags := pccCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultPccCols, tabheaders.ColsMessage(defaultPccCols))
 	_ = viper.BindPFlag(core.GetFlagName(pccCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = pccCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultPccCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = pccCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultPccCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, pccCmd, core.CommandBuilder{
-		Namespace:  "pcc",
-		Resource:   "pcc",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Cross-Connects",
-		LongDesc:   "Use this command to get a list of existing Cross-Connects available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.PccsFiltersUsage(),
-		Example:    listPccsExample,
-		PreCmdRun:  PreRunPccList,
-		CmdRun:     RunPccList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, pccCmd, core.CommandBuilder{
+			Namespace:  "pcc",
+			Resource:   "pcc",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Cross-Connects",
+			LongDesc:   "Use this command to get a list of existing Cross-Connects available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.PccsFiltersUsage(),
+			Example:    listPccsExample,
+			PreCmdRun:  PreRunPccList,
+			CmdRun:     RunPccList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, pccCmd, core.CommandBuilder{
-		Namespace:  "pcc",
-		Resource:   "pcc",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Cross-Connect",
-		LongDesc:   "Use this command to retrieve details about a specific Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
-		Example:    getPccExample,
-		PreCmdRun:  PreRunPccId,
-		CmdRun:     RunPccGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, pccCmd, core.CommandBuilder{
+			Namespace:  "pcc",
+			Resource:   "pcc",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Cross-Connect",
+			LongDesc:   "Use this command to retrieve details about a specific Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
+			Example:    getPccExample,
+			PreCmdRun:  PreRunPccId,
+			CmdRun:     RunPccGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgPccId, cloudapiv6.ArgIdShort, "", cloudapiv6.PccId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, pccCmd, core.CommandBuilder{
-		Namespace:  "pcc",
-		Resource:   "pcc",
-		Verb:       "create",
-		Aliases:    []string{"c"},
-		ShortDesc:  "Create a Cross-Connect",
-		LongDesc:   "Use this command to create a Cross-Connect. You can specify the name and the description for the Cross-Connect.",
-		Example:    createPccExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunPccCreate,
-		InitClient: true,
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed PrivateCrossConnect", "The name for the Cross-Connect")
-	create.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create := core.NewCommand(
+		ctx, pccCmd, core.CommandBuilder{
+			Namespace:  "pcc",
+			Resource:   "pcc",
+			Verb:       "create",
+			Aliases:    []string{"c"},
+			ShortDesc:  "Create a Cross-Connect",
+			LongDesc:   "Use this command to create a Cross-Connect. You can specify the name and the description for the Cross-Connect.",
+			Example:    createPccExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunPccCreate,
+			InitClient: true,
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed PrivateCrossConnect", "The name for the Cross-Connect",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Cross-Connect creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Cross-Connect creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, pccCmd, core.CommandBuilder{
-		Namespace: "pcc",
-		Resource:  "pcc",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Cross-Connect",
-		LongDesc: `Use this command to update details about a specific Cross-Connect. Name and description can be updated.
+	update := core.NewCommand(
+		ctx, pccCmd, core.CommandBuilder{
+			Namespace: "pcc",
+			Resource:  "pcc",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Cross-Connect",
+			LongDesc: `Use this command to update details about a specific Cross-Connect. Name and description can be updated.
 
 Required values to run command:
 
 * Pcc Id`,
-		Example:    updatePccExample,
-		PreCmdRun:  PreRunPccId,
-		CmdRun:     RunPccUpdate,
-		InitClient: true,
-	})
+			Example:    updatePccExample,
+			PreCmdRun:  PreRunPccId,
+			CmdRun:     RunPccUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "The name for the Cross-Connect")
-	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect")
+	update.AddStringFlag(
+		cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "The description for the Cross-Connect",
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgPccId, cloudapiv6.ArgIdShort, "", cloudapiv6.PccId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Cross-Connect update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Cross-Connect update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, pccCmd, core.CommandBuilder{
-		Namespace: "pcc",
-		Resource:  "pcc",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Cross-Connect",
-		LongDesc: `Use this command to delete a Cross-Connect.
+	deleteCmd := core.NewCommand(
+		ctx, pccCmd, core.CommandBuilder{
+			Namespace: "pcc",
+			Resource:  "pcc",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Cross-Connect",
+			LongDesc: `Use this command to delete a Cross-Connect.
 
 Required values to run command:
 
 * Pcc Id`,
-		Example:    deletePccExample,
-		PreCmdRun:  PreRunPccDelete,
-		CmdRun:     RunPccDelete,
-		InitClient: true,
-	})
+			Example:    deletePccExample,
+			PreCmdRun:  PreRunPccDelete,
+			CmdRun:     RunPccDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgPccId, cloudapiv6.ArgIdShort, "", cloudapiv6.PccId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Cross-Connect deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Cross-Connect deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Cross-Connects.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Cross-Connect deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Cross-Connect deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	pccCmd.AddCommand(PeersCmd())
 
@@ -202,7 +269,8 @@ func PreRunPccId(c *core.PreCommandConfig) error {
 }
 
 func PreRunPccDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgPccId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -217,7 +285,10 @@ func RunPccList(c *core.CommandConfig) error {
 
 	pccs, resp, err := c.CloudApiV6Services.Pccs().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -225,8 +296,10 @@ func RunPccList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", allPccJSONPaths, pccs.PrivateCrossConnects,
-		tabheaders.GetHeadersAllDefault(defaultPccCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", allPccJSONPaths, pccs.PrivateCrossConnects,
+		tabheaders.GetHeadersAllDefault(defaultPccCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -243,12 +316,20 @@ func RunPccGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Cross Connect with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Cross Connect with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.Pccs().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.Pccs().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -256,8 +337,10 @@ func RunPccGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allPccJSONPaths, u.PrivateCrossConnect,
-		tabheaders.GetHeadersAllDefault(defaultPccCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", allPccJSONPaths, u.PrivateCrossConnect,
+		tabheaders.GetHeadersAllDefault(defaultPccCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -286,12 +369,18 @@ func RunPccCreate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Cross Connect: Name: %v, Description: %v", name, description))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Cross Connect: Name: %v, Description: %v", name, description,
+		),
+	)
 
 	u, resp, err := c.CloudApiV6Services.Pccs().Create(newUser, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -303,8 +392,10 @@ func RunPccCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allPccJSONPaths, u.PrivateCrossConnect,
-		tabheaders.GetHeadersAllDefault(defaultPccCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", allPccJSONPaths, u.PrivateCrossConnect,
+		tabheaders.GetHeadersAllDefault(defaultPccCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -320,15 +411,26 @@ func RunPccUpdate(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	oldPcc, resp, err := c.CloudApiV6Services.Pccs().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), queryParams)
+	oldPcc, resp, err := c.CloudApiV6Services.Pccs().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), queryParams,
+	)
 	if err != nil {
 		return err
 	}
 
 	newProperties := getPccInfo(oldPcc, c)
-	pccUpd, resp, err := c.CloudApiV6Services.Pccs().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)), *newProperties, queryParams)
+	pccUpd, resp, err := c.CloudApiV6Services.Pccs().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgPccId,
+			),
+		), *newProperties, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -340,8 +442,10 @@ func RunPccUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allPccJSONPaths, pccUpd.PrivateCrossConnect,
-		tabheaders.GetHeadersAllDefault(defaultPccCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", allPccJSONPaths, pccUpd.PrivateCrossConnect,
+		tabheaders.GetHeadersAllDefault(defaultPccCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -367,16 +471,24 @@ func RunPccDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete Cross-Connect", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete Cross-Connect", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Cross Connect with id: %v...", pccId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Cross Connect with id: %v...", pccId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Pccs().Delete(pccId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -390,14 +502,18 @@ func RunPccDelete(c *core.CommandConfig) error {
 	return nil
 }
 
-func getPccInfo(oldUser *resources.PrivateCrossConnect, c *core.CommandConfig) *resources.PrivateCrossConnectProperties {
+func getPccInfo(
+	oldUser *resources.PrivateCrossConnect, c *core.CommandConfig,
+) *resources.PrivateCrossConnectProperties {
 	var namePcc, description string
 
 	if properties, ok := oldUser.GetPropertiesOk(); ok && properties != nil {
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 			namePcc = viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", namePcc))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", namePcc),
+			)
 		} else {
 			if name, ok := properties.GetNameOk(); ok && name != nil {
 				namePcc = *name
@@ -407,7 +523,10 @@ func getPccInfo(oldUser *resources.PrivateCrossConnect, c *core.CommandConfig) *
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDescription)) {
 			description = viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDescription))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description),
+			)
 		} else {
 			if desc, ok := properties.GetDescriptionOk(); ok && desc != nil {
 				description = *desc
@@ -465,11 +584,16 @@ func DeleteAllPccs(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Cross-Connects", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Cross-Connects",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the PrivateCrossConnects..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the PrivateCrossConnects..."),
+	)
 
 	var multiErr error
 	for _, pcc := range *pccsItems {
@@ -478,19 +602,28 @@ func DeleteAllPccs(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting PrivateCrossConnect with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting PrivateCrossConnect with id: %v...", *id,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.Pccs().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
@@ -516,43 +649,60 @@ func PeersCmd() *core.Command {
 		},
 	}
 	globalFlags := peerCmd.GlobalFlags()
-	globalFlags.StringSliceP(constants.ArgCols, "", defaultPccPeersCols,
-		tabheaders.ColsMessage(defaultPccPeersCols))
+	globalFlags.StringSliceP(
+		constants.ArgCols, "", defaultPccPeersCols,
+		tabheaders.ColsMessage(defaultPccPeersCols),
+	)
 	_ = viper.BindPFlag(core.GetFlagName(peerCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = peerCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultPccPeersCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = peerCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultPccPeersCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	listPeers := core.NewCommand(ctx, peerCmd, core.CommandBuilder{
-		Namespace:  "pcc",
-		Resource:   "peers",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "Get a list of Peers from a Cross-Connect",
-		LongDesc:   "Use this command to get a list of Peers from a Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
-		Example:    listPccPeersExample,
-		PreCmdRun:  PreRunPccId,
-		CmdRun:     RunPccPeersList,
-		InitClient: true,
-	})
+	listPeers := core.NewCommand(
+		ctx, peerCmd, core.CommandBuilder{
+			Namespace:  "pcc",
+			Resource:   "peers",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "Get a list of Peers from a Cross-Connect",
+			LongDesc:   "Use this command to get a list of Peers from a Cross-Connect.\n\nRequired values to run command:\n\n* Pcc Id",
+			Example:    listPccPeersExample,
+			PreCmdRun:  PreRunPccId,
+			CmdRun:     RunPccPeersList,
+			InitClient: true,
+		},
+	)
 	listPeers.AddUUIDFlag(cloudapiv6.ArgPccId, "", "", cloudapiv6.PccId, core.RequiredFlagOption())
-	_ = listPeers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgPccId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listPeers.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgPccId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PccsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	return peerCmd
 }
 
 func RunPccPeersList(c *core.CommandConfig) error {
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting Peers from Cross-Connect with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting Peers from Cross-Connect with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)),
+		),
+	)
 
 	u, resp, err := c.CloudApiV6Services.Pccs().GetPeers(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPccId)))
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -568,8 +718,10 @@ func RunPccPeersList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", allPccPeerJSONPaths, peers,
-		tabheaders.GetHeadersAllDefault(defaultPccPeersCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", allPccPeerJSONPaths, peers,
+		tabheaders.GetHeadersAllDefault(defaultPccPeersCols, cols),
+	)
 	if err != nil {
 		return err
 	}

--- a/commands/cloudapi-v6/pcc_test.go
+++ b/commands/cloudapi-v6/pcc_test.go
@@ -95,480 +95,621 @@ func TestPccCmd(t *testing.T) {
 func TestPreRunPccList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunPccList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunPccList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunPccListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunPccList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunPccList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunPccListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunPccList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunPccList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunPccId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		err := PreRunPccId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			err := PreRunPccId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunPccIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunPccId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunPccId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(pccs, &testResponse, nil)
-		err := RunPccList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				pccs, &testResponse, nil,
+			)
+			err := RunPccList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.PrivateCrossConnects{}, &testResponse, nil)
-		err := RunPccList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.PrivateCrossConnects{}, &testResponse, nil,
+			)
+			err := RunPccList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(pccs, nil, testPccErr)
-		err := RunPccList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				pccs, nil, testPccErr,
+			)
+			err := RunPccList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTestGet, &testResponse, nil)
-		err := RunPccGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTestGet, &testResponse, nil)
+			err := RunPccGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTestGet, nil, testPccErr)
-		err := RunPccGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTestGet, nil, testPccErr)
+			err := RunPccGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccPeersList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().GetPeers(testPccVar).Return(&[]resources.Peer{pccPeerTest}, &testResponse, nil)
-		err := RunPccPeersList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().GetPeers(testPccVar).Return(
+				&[]resources.Peer{pccPeerTest}, &testResponse, nil,
+			)
+			err := RunPccPeersList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccPeersListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().GetPeers(testPccVar).Return(&[]resources.Peer{pccPeerTest}, nil, testPccErr)
-		err := RunPccPeersList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().GetPeers(testPccVar).Return(&[]resources.Peer{pccPeerTest}, nil, testPccErr)
+			err := RunPccPeersList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Create(pccTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, &testResponse, nil)
-		err := RunPccCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Create(
+				pccTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, &testResponse, nil)
+			err := RunPccCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Create(pccTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, &testResponse, testPccErr)
-		err := RunPccCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Create(
+				pccTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, &testResponse, testPccErr)
+			err := RunPccCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Create(pccTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, nil, testPccErr)
-		err := RunPccCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Create(
+				pccTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, nil, testPccErr)
+			err := RunPccCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Create(pccTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunPccCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Create(
+				pccTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunPccCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, nil, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Update(testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccNew, &testResponse, nil)
-		err := RunPccUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, nil, nil)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Update(
+				testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccNew, &testResponse, nil)
+			err := RunPccUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccUpdateOldUser(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccNew, nil, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Update(testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccNew, nil, nil)
-		err := RunPccUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccNew, nil, nil)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Update(
+				testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccNew, nil, nil)
+			err := RunPccUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, nil, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Update(testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccNew, nil, testPccErr)
-		err := RunPccUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, nil, nil)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Update(
+				testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccNew, nil, testPccErr)
+			err := RunPccUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, nil, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Update(testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunPccUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, nil, nil)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Update(
+				testPccVar, pccProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunPccUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Get(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&pccTest, nil, testPccErr)
-		err := RunPccUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Get(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&pccTest, nil, testPccErr)
+			err := RunPccUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunPccDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunPccDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(pccsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunPccDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				pccsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunPccDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(pccsList, nil, testPccErr)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				pccsList, nil, testPccErr,
+			)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.PrivateCrossConnects{}, &testResponse, nil)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.PrivateCrossConnects{}, &testResponse, nil,
+			)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.PrivateCrossConnects{PrivateCrossConnects: ionoscloud.PrivateCrossConnects{Items: &[]ionoscloud.PrivateCrossConnect{}}}, &testResponse, nil)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.PrivateCrossConnects{PrivateCrossConnects: ionoscloud.PrivateCrossConnects{Items: &[]ionoscloud.PrivateCrossConnect{}}},
+				&testResponse, nil,
+			)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(pccsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testPccErr)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				pccsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testPccErr)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testPccErr)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testPccErr)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(testPccVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunPccDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Pcc.EXPECT().Delete(
+				testPccVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunPccDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunPccDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunPccDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPccId), testPccVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunPccDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -41,67 +41,96 @@ func UserS3keyCmd() *core.Command {
 	globalFlags := s3keyCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultS3KeyCols, tabheaders.ColsMessage(defaultS3KeyCols))
 	_ = viper.BindPFlag(core.GetFlagName(s3keyCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = s3keyCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultS3KeyCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = s3keyCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultS3KeyCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, s3keyCmd, core.CommandBuilder{
-		Namespace:  "user",
-		Resource:   "s3key",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List User S3Keys",
-		LongDesc:   "Use this command to get a list of S3Keys of a specified User.\n\nRequired values to run command:\n\n* User Id",
-		Example:    listS3KeysExample,
-		PreCmdRun:  PreRunUserId,
-		CmdRun:     RunUserS3KeyList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, s3keyCmd, core.CommandBuilder{
+			Namespace:  "user",
+			Resource:   "s3key",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List User S3Keys",
+			LongDesc:   "Use this command to get a list of S3Keys of a specified User.\n\nRequired values to run command:\n\n* User Id",
+			Example:    listS3KeysExample,
+			PreCmdRun:  PreRunUserId,
+			CmdRun:     RunUserS3KeyList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgUserId, "", "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, s3keyCmd, core.CommandBuilder{
-		Namespace:  "user",
-		Resource:   "s3key",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a User S3Key",
-		LongDesc:   "Use this command to get information about a specified S3Key from a specified User.\n\nRequired values to run command:\n\n* User Id\n* S3Key Id",
-		Example:    getS3KeyExample,
-		PreCmdRun:  PreRunUserKeyIds,
-		CmdRun:     RunUserS3KeyGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, s3keyCmd, core.CommandBuilder{
+			Namespace:  "user",
+			Resource:   "s3key",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a User S3Key",
+			LongDesc:   "Use this command to get information about a specified S3Key from a specified User.\n\nRequired values to run command:\n\n* User Id\n* S3Key Id",
+			Example:    getS3KeyExample,
+			PreCmdRun:  PreRunUserKeyIds,
+			CmdRun:     RunUserS3KeyGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgUserId, "", "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddStringFlag(cloudapiv6.ArgS3KeyId, cloudapiv6.ArgIdShort, "", cloudapiv6.S3KeyId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgS3KeyId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.S3KeyIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgUserId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgS3KeyId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.S3KeyIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgUserId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, s3keyCmd, core.CommandBuilder{
-		Namespace: "user",
-		Resource:  "s3key",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a S3Key for a User",
-		LongDesc: `Use this command to create a S3Key for a particular User.
+	create := core.NewCommand(
+		ctx, s3keyCmd, core.CommandBuilder{
+			Namespace: "user",
+			Resource:  "s3key",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a S3Key for a User",
+			LongDesc: `Use this command to create a S3Key for a particular User.
 
 Note: A maximum of five S3 keys may be created for any given user.
 
@@ -110,29 +139,42 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 Required values to run command:
 
 * User Id`,
-		Example:    createS3KeyExample,
-		PreCmdRun:  PreRunUserId,
-		CmdRun:     RunUserS3KeyCreate,
-		InitClient: true,
-	})
+			Example:    createS3KeyExample,
+			PreCmdRun:  PreRunUserId,
+			CmdRun:     RunUserS3KeyCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgUserId, "", "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for User S3Key creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for User S3Key creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for User S3Key creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for User S3Key creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, s3keyCmd, core.CommandBuilder{
-		Namespace: "user",
-		Resource:  "s3key",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a S3Key",
-		LongDesc: `Use this command to update a specified S3Key from a particular User. This operation allows you to enable or disable a specific S3Key.
+	update := core.NewCommand(
+		ctx, s3keyCmd, core.CommandBuilder{
+			Namespace: "user",
+			Resource:  "s3key",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a S3Key",
+			LongDesc: `Use this command to update a specified S3Key from a particular User. This operation allows you to enable or disable a specific S3Key.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -141,51 +183,102 @@ Required values to run command:
 * User Id
 * S3Key Id
 * S3Key Active`,
-		Example:    updateS3KeyExample,
-		PreCmdRun:  PreRunUserKeyIds,
-		CmdRun:     RunUserS3KeyUpdate,
-		InitClient: true,
-	})
+			Example:    updateS3KeyExample,
+			PreCmdRun:  PreRunUserKeyIds,
+			CmdRun:     RunUserS3KeyUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgUserId, "", "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(cloudapiv6.ArgS3KeyActive, "", false, "Enable or disable an User S3Key. E.g.: --s3key-active=true, --s3key-active=false")
-	update.AddStringFlag(cloudapiv6.ArgS3KeyId, cloudapiv6.ArgIdShort, "", cloudapiv6.S3KeyId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgS3KeyId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.S3KeyIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgUserId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for User S3Key update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for User S3Key update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgS3KeyActive, "", false,
+		"Enable or disable an User S3Key. E.g.: --s3key-active=true, --s3key-active=false",
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgS3KeyId, cloudapiv6.ArgIdShort, "", cloudapiv6.S3KeyId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgS3KeyId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.S3KeyIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgUserId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for User S3Key update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for User S3Key update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, s3keyCmd, core.CommandBuilder{
-		Namespace:  "user",
-		Resource:   "s3key",
-		Verb:       "delete",
-		Aliases:    []string{"d"},
-		ShortDesc:  "Delete a S3Key",
-		LongDesc:   "Use this command to delete a specific S3Key of an User.\n\nRequired values to run command:\n\n* User Id\n* S3Key Id",
-		Example:    deleteS3KeyExample,
-		PreCmdRun:  PreRunUserKeyDelete,
-		CmdRun:     RunUserS3KeyDelete,
-		InitClient: true,
-	})
+	deleteCmd := core.NewCommand(
+		ctx, s3keyCmd, core.CommandBuilder{
+			Namespace:  "user",
+			Resource:   "s3key",
+			Verb:       "delete",
+			Aliases:    []string{"d"},
+			ShortDesc:  "Delete a S3Key",
+			LongDesc:   "Use this command to delete a specific S3Key of an User.\n\nRequired values to run command:\n\n* User Id\n* S3Key Id",
+			Example:    deleteS3KeyExample,
+			PreCmdRun:  PreRunUserKeyDelete,
+			CmdRun:     RunUserS3KeyDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgUserId, "", "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddStringFlag(cloudapiv6.ArgS3KeyId, cloudapiv6.ArgIdShort, "", cloudapiv6.S3KeyId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgS3KeyId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.S3KeyIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgUserId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for User S3Key deletion to be executed")
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddStringFlag(
+		cloudapiv6.ArgS3KeyId, cloudapiv6.ArgIdShort, "", cloudapiv6.S3KeyId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgS3KeyId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.S3KeyIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgUserId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for Request for User S3Key deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the S3Keys of an User.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for User S3Key deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for User S3Key deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return s3keyCmd
 }
@@ -195,7 +288,8 @@ func PreRunUserKeyIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunUserKeyDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgUserId, cloudapiv6.ArgS3KeyId},
 		[]string{cloudapiv6.ArgUserId, cloudapiv6.ArgAll},
 	)
@@ -208,9 +302,14 @@ func RunUserS3KeyList(c *core.CommandConfig) error {
 		return err
 	}
 
-	ss, resp, err := c.CloudApiV6Services.S3Keys().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), listQueryParams)
+	ss, resp, err := c.CloudApiV6Services.S3Keys().List(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -218,8 +317,10 @@ func RunUserS3KeyList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.S3Key, ss.S3Keys,
-		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.S3Key, ss.S3Keys,
+		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -236,14 +337,21 @@ func RunUserS3KeyGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"S3 keys with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3KeyId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"S3 keys with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3KeyId)),
+		),
+	)
 
-	s, resp, err := c.CloudApiV6Services.S3Keys().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)),
+	s, resp, err := c.CloudApiV6Services.S3Keys().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)),
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3KeyId)), queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -251,8 +359,10 @@ func RunUserS3KeyGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.S3Key, s.S3Key,
-		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.S3Key, s.S3Key,
+		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -270,11 +380,17 @@ func RunUserS3KeyCreate(c *core.CommandConfig) error {
 	queryParams := listQueryParams.QueryParams
 	userId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating S3 Key for User with ID: %v", userId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Creating S3 Key for User with ID: %v", userId),
+	)
 
 	s, resp, err := c.CloudApiV6Services.S3Keys().Create(userId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -286,8 +402,10 @@ func RunUserS3KeyCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.S3Key, s.S3Key,
-		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.S3Key, s.S3Key,
+		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -318,12 +436,18 @@ func RunUserS3KeyUpdate(c *core.CommandConfig) error {
 	userId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))
 	keyId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgS3KeyId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Creating S3 Key with ID: %v for User with ID: %v", keyId, userId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Creating S3 Key with ID: %v for User with ID: %v", keyId, userId,
+		),
+	)
 
 	s, resp, err := c.CloudApiV6Services.S3Keys().Update(userId, keyId, newKey, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -335,8 +459,10 @@ func RunUserS3KeyUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.S3Key, s.S3Key,
-		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.S3Key, s.S3Key,
+		tabheaders.GetHeadersAllDefault(defaultS3KeyCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -363,16 +489,24 @@ func RunUserS3KeyDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete s3key", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete s3key", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("User ID: %v", userId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting S3 Key with ID: %v...", s3KeyId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting S3 Key with ID: %v...", s3KeyId),
+	)
 
 	resp, err := c.CloudApiV6Services.S3Keys().Delete(userId, s3KeyId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -419,7 +553,10 @@ func DeleteAllS3keys(c *core.CommandConfig) error {
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the S3Keys", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the S3Keys",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -432,18 +569,27 @@ func DeleteAllS3keys(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Staring deleting S3 keys with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Staring deleting S3 keys with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.S3Keys().Delete(userId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/s3key_test.go
+++ b/commands/cloudapi-v6/s3key_test.go
@@ -74,388 +74,491 @@ var (
 func TestPreRunUserKeyIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		err := PreRunUserKeyIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			err := PreRunUserKeyIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunUserKeyIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunUserKeyIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunUserKeyIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(s3keys, &testResponse, nil)
-		err := RunUserS3KeyList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(s3keys, &testResponse, nil)
+			err := RunUserS3KeyList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(s3keys, nil, testS3keyErr)
-		err := RunUserS3KeyList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(s3keys, nil, testS3keyErr)
+			err := RunUserS3KeyList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Get(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTestGet, &testResponse, nil)
-		err := RunUserS3KeyGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Get(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTestGet, &testResponse, nil)
+			err := RunUserS3KeyGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Get(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTestGet, nil, testS3keyErr)
-		err := RunUserS3KeyGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Get(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTestGet, nil, testS3keyErr)
+			err := RunUserS3KeyGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Create(testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTest, &testResponse, nil)
-		err := RunUserS3KeyCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Create(
+				testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTest, &testResponse, nil)
+			err := RunUserS3KeyCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Create(testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTest, &testResponse, testS3keyErr)
-		err := RunUserS3KeyCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Create(
+				testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTest, &testResponse, testS3keyErr)
+			err := RunUserS3KeyCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Create(testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunUserS3KeyCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Create(
+				testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunUserS3KeyCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Create(testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyTest, nil, testS3keyErr)
-		err := RunUserS3KeyCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Create(
+				testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyTest, nil, testS3keyErr)
+			err := RunUserS3KeyCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Update(testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyNew, &testResponse, nil)
-		err := RunUserS3KeyUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Update(
+				testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyNew, &testResponse, nil)
+			err := RunUserS3KeyUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyUpdateOld(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Update(testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyNew, nil, nil)
-		err := RunUserS3KeyUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Update(
+				testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyNew, nil, nil)
+			err := RunUserS3KeyUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Update(testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunUserS3KeyUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Update(
+				testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunUserS3KeyUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Update(testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&s3keyNew, nil, testS3keyErr)
-		err := RunUserS3KeyUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyActive), testS3keyBoolNewVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Update(
+				testS3keyVar, testS3keyVar, s3keyNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&s3keyNew, nil, testS3keyErr)
+			err := RunUserS3KeyUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserS3KeyDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(s3keysList, &testResponse, nil)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(s3keysList, &testResponse, nil)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserS3KeyDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(s3keysList, nil, testS3keyErr)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(s3keysList, nil, testS3keyErr)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.S3Keys{}, &testResponse, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.S3Keys{}, &testResponse, nil)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.S3Keys{S3Keys: ionoscloud.S3Keys{Items: &[]ionoscloud.S3Key{}}}, &testResponse, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.S3Keys{S3Keys: ionoscloud.S3Keys{Items: &[]ionoscloud.S3Key{}}}, &testResponse, nil,
+			)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().List(testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(s3keysList, &testResponse, nil)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testS3keyErr)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().List(
+				testS3keyVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(s3keysList, &testResponse, nil)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testS3keyErr)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testS3keyErr)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testS3keyErr)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunUserS3KeyDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgS3KeyId), testS3keyVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.S3Key.EXPECT().Delete(
+				testS3keyVar, testS3keyVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunUserS3KeyDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserS3KeyDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunUserS3KeyDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testS3keyVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunUserS3KeyDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -36,8 +36,13 @@ const (
 )
 
 var (
-	defaultServerCols = []string{"ServerId", "Name", "Type", "AvailabilityZone", "Cores", "Ram", "CpuFamily", "VmState", "State"}
-	allServerCols     = []string{"ServerId", "DatacenterId", "Name", "AvailabilityZone", "Cores", "Ram", "CpuFamily", "VmState", "State", "TemplateId", "Type", "BootCdromId", "BootVolumeId"}
+	defaultServerCols = []string{
+		"ServerId", "Name", "Type", "AvailabilityZone", "Cores", "Ram", "CpuFamily", "VmState", "State",
+	}
+	allServerCols = []string{
+		"ServerId", "DatacenterId", "Name", "AvailabilityZone", "Cores", "Ram", "CpuFamily", "VmState", "State",
+		"TemplateId", "Type", "BootCdromId", "BootVolumeId",
+	}
 )
 
 func ServerCmd() *core.Command {
@@ -54,78 +59,121 @@ func ServerCmd() *core.Command {
 	globalFlags := serverCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultServerCols, tabheaders.ColsMessage(allServerCols))
 	_ = viper.BindPFlag(core.GetFlagName(serverCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = serverCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allServerCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = serverCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allServerCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "server",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Servers",
-		LongDesc:   "Use this command to list Servers from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ServersFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listServerExample,
-		PreCmdRun:  PreRunServerList,
-		CmdRun:     RunServerList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "server",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Servers",
+			LongDesc:   "Use this command to list Servers from a specified Virtual Data Center.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.ServersFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listServerExample,
+			PreCmdRun:  PreRunServerList,
+			CmdRun:     RunServerList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "server",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Server",
-		LongDesc:   "Use this command to get information about a specified Server from a Virtual Data Center. You can also wait for Server to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
-		Example:    getServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "server",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Server",
+			LongDesc:   "Use this command to get information about a specified Server from a Virtual Data Center. You can also wait for Server to get in AVAILABLE state using `--wait-for-state` option.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
+			Example:    getServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for specified Server to be in AVAILABLE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for waiting for Server to be in AVAILABLE state [seconds]")
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for specified Server to be in AVAILABLE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for waiting for Server to be in AVAILABLE state [seconds]",
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Server",
-		LongDesc: `Use this command to create an ENTERPRISE, CUBE or VCPU Server in a specified Virtual Data Center.
+	create := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Server",
+			LongDesc: `Use this command to create an ENTERPRISE, CUBE or VCPU Server in a specified Virtual Data Center.
 
 1. For ENTERPRISE Servers:
 
@@ -170,77 +218,157 @@ Required values to create a Server of type VCPU:
 By default, Licence Type for Direct Attached Storage is set to LINUX. You can set it using the ` + "`" + `--licence-type` + "`" + ` option or set an Image Id. For Image Id, it is needed to set a password or SSH keys.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can also wait for Server to be in AVAILABLE state using ` + "`" + `--wait-for-state` + "`" + ` option. It is recommended to use both options together for this command.`,
-		Example:    createServerExample,
-		PreCmdRun:  PreRunServerCreate,
-		CmdRun:     RunServerCreate,
-		InitClient: true,
-	})
+			Example:    createServerExample,
+			PreCmdRun:  PreRunServerCreate,
+			CmdRun:     RunServerCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Server", "Name of the Server")
-	create.AddIntFlag(constants.FlagCores, "", cloudapiv6.DefaultServerCores, "The total number of cores for the Server, e.g. 4. Maximum: depends on contract resource limits", core.RequiredFlagOption())
-	create.AddStringFlag(constants.FlagRam, "", "", "The amount of memory for the Server. Size must be specified in multiples of 256. e.g. --ram 256 or --ram 256MB", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagRam, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"256MB", "512MB", "1024MB", "2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.FlagCpuFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Family for the Server. For CUBE Servers, the CPU Family is INTEL_SKYLAKE")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
-		return completer.DatacenterCPUFamilies(create.Command.Context(), datacenterId), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO", "Availability zone of the Server")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgTemplateId, "", "", "[CUBE Server] The unique Template Id", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTemplateId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TemplatesIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddSetFlag(constants.FlagType, "", serverEnterpriseType, []string{serverEnterpriseType, serverCubeType, serverVCPUType}, "Type usages for the Server")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{serverEnterpriseType, serverCubeType}, cobra.ShellCompDirectiveNoFileComp
-	})
+	create.AddIntFlag(
+		constants.FlagCores, "", cloudapiv6.DefaultServerCores,
+		"The total number of cores for the Server, e.g. 4. Maximum: depends on contract resource limits",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		constants.FlagRam, "", "",
+		"The amount of memory for the Server. Size must be specified in multiples of 256. e.g. --ram 256 or --ram 256MB",
+		core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagRam,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"256MB", "512MB", "1024MB", "2GB", "3GB", "4GB", "5GB", "10GB", "16GB",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.FlagCpuFamily, "", cloudapiv6.DefaultServerCPUFamily,
+		"CPU Family for the Server. For CUBE Servers, the CPU Family is INTEL_SKYLAKE",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			datacenterId := viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))
+			return completer.DatacenterCPUFamilies(
+				create.Command.Context(), datacenterId,
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO", "Availability zone of the Server",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagAvailabilityZone,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgTemplateId, "", "", "[CUBE Server] The unique Template Id", core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTemplateId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TemplatesIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddSetFlag(
+		constants.FlagType, "", serverEnterpriseType, []string{serverEnterpriseType, serverCubeType, serverVCPUType},
+		"Type usages for the Server",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{serverEnterpriseType, serverCubeType}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	// Volume Properties - for DAS Volume associated with Cube Server
-	create.AddStringFlag(cloudapiv6.ArgVolumeName, "N", "Unnamed Direct Attached Storage", "[CUBE Server] Name of the Direct Attached Storage")
+	create.AddStringFlag(
+		cloudapiv6.ArgVolumeName, "N", "Unnamed Direct Attached Storage",
+		"[CUBE Server] Name of the Direct Attached Storage",
+	)
 	create.AddStringFlag(cloudapiv6.ArgBus, "", "VIRTIO", "[CUBE Server] The bus type of the Direct Attached Storage")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBus, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"VIRTIO", "IDE"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddSetFlag(cloudapiv6.ArgLicenceType, "l", "LINUX", constants.EnumLicenceType, "[CUBE Server] Licence Type of the Direct Attached Storage")
-	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "[CUBE Server] The Image Alias to use instead of Image Id for the Direct Attached Storage")
-	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "[CUBE Server] The Image Id or snapshot Id to be used as for the Direct Attached Storage")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			// Completer for HDD images that are in the same location as the datacenter
-			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
-				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
-			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
-				return ionoscloud.ApiImagesGetRequest{}
-			}
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBus,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"VIRTIO", "IDE"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddSetFlag(
+		cloudapiv6.ArgLicenceType, "l", "LINUX", constants.EnumLicenceType,
+		"[CUBE Server] Licence Type of the Direct Attached Storage",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "",
+		"[CUBE Server] The Image Alias to use instead of Image Id for the Direct Attached Storage",
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgImageId, "", "",
+		"[CUBE Server] The Image Id or snapshot Id to be used as for the Direct Attached Storage",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgImageId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					// Completer for HDD images that are in the same location as the datacenter
+					chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+						context.Background(),
+						viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
+					).Execute()
+					if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+						return ionoscloud.ApiImagesGetRequest{}
+					}
 
-			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.ArgPassword, constants.ArgPasswordShort, "", "[CUBE Server] Initial image password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9")
-	create.AddStringSliceFlag(cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, []string{""}, "[CUBE Server] Absolute paths for the SSH Keys of the Direct Attached Storage")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server creation to be executed")
-	create.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for new Server to be in AVAILABLE state")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server creation/for Server to be in AVAILABLE state [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+					return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.ArgPassword, constants.ArgPasswordShort, "",
+		"[CUBE Server] Initial image password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9",
+	)
+	create.AddStringSliceFlag(
+		cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, []string{""},
+		"[CUBE Server] Absolute paths for the SSH Keys of the Direct Attached Storage",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server creation to be executed",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for new Server to be in AVAILABLE state",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server creation/for Server to be in AVAILABLE state [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Server",
-		LongDesc: `Use this command to update a specified Server from a Virtual Data Center.
+	update := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Server",
+			LongDesc: `Use this command to update a specified Server from a Virtual Data Center.
 
 You can set the RAM size in the following ways:
 
@@ -257,66 +385,135 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    updateServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerUpdate,
-		InitClient: true,
-	})
+			Example:    updateServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", "The unique Volume Id for the BootVolume. The Volume needs to be already attached to the Server")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgCdromId, "", "", "The unique Cdrom Id for the BootCdrom. The Cdrom needs to be already attached to the Server")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgCdromId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			// Completer for CDROM images that are in the same location as the datacenter
-			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
-				viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))).Execute()
-			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
-				return ionoscloud.ApiImagesGetRequest{}
-			}
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, "", "",
+		"The unique Volume Id for the BootVolume. The Volume needs to be already attached to the Server",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgCdromId, "", "",
+		"The unique Cdrom Id for the BootCdrom. The Cdrom needs to be already attached to the Server",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgCdromId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					// Completer for CDROM images that are in the same location as the datacenter
+					chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+						context.Background(),
+						viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId)),
+					).Execute()
+					if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+						return ionoscloud.ApiImagesGetRequest{}
+					}
 
-			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "CDROM")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+					return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "CDROM")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Server")
 	update.AddStringFlag(constants.FlagCpuFamily, "", cloudapiv6.DefaultServerCPUFamily, "CPU Family of the Server")
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		datacenterId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))
-		return completer.DatacenterCPUFamilies(update.Command.Context(), datacenterId), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "", "Availability zone of the Server")
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddIntFlag(constants.FlagCores, "", cloudapiv6.DefaultServerCores, "The total number of cores for the Server, e.g. 4. Maximum: depends on contract resource limits")
-	update.AddStringFlag(constants.FlagRam, "", "", "The amount of memory for the Server. Size must be specified in multiples of 256. e.g. --ram 256 or --ram 256MB")
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagRam, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"256MB", "512MB", "1024MB", "2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server update to be executed")
-	update.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for the updated Server to be in AVAILABLE state")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server update/for Server to be in AVAILABLE state [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagCpuFamily, func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			datacenterId := viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))
+			return completer.DatacenterCPUFamilies(
+				update.Command.Context(), datacenterId,
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "", "Availability zone of the Server",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagAvailabilityZone,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"AUTO", "ZONE_1", "ZONE_2"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddIntFlag(
+		constants.FlagCores, "", cloudapiv6.DefaultServerCores,
+		"The total number of cores for the Server, e.g. 4. Maximum: depends on contract resource limits",
+	)
+	update.AddStringFlag(
+		constants.FlagRam, "", "",
+		"The amount of memory for the Server. Size must be specified in multiples of 256. e.g. --ram 256 or --ram 256MB",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagRam,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"256MB", "512MB", "1024MB", "2GB", "3GB", "4GB", "5GB", "10GB", "16GB",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server update to be executed",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for the updated Server to be in AVAILABLE state",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server update/for Server to be in AVAILABLE state [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Server",
-		LongDesc: `Use this command to delete a specified Server from a Virtual Data Center.
+	deleteCmd := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Server",
+			LongDesc: `Use this command to delete a specified Server from a Virtual Data Center.
 
 NOTE: This will not automatically remove the storage Volumes attached to a Server.
 
@@ -326,33 +523,60 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    deleteServerExample,
-		PreCmdRun:  PreRunDcServerDelete,
-		CmdRun:     RunServerDelete,
-		InitClient: true,
-	})
+			Example:    deleteServerExample,
+			PreCmdRun:  PreRunDcServerDelete,
+			CmdRun:     RunServerDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Servers form a virtual Datacenter.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Servers form a virtual Datacenter.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Suspend Command
 	*/
-	suspend := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "suspend",
-		ShortDesc: "Suspend a Cube Server",
-		LongDesc: `Use this command to suspend a Cube Server. The operation can only be applied to Cube Servers. Note: The virtual machine will not be deleted.
+	suspend := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "suspend",
+			ShortDesc: "Suspend a Cube Server",
+			LongDesc: `Use this command to suspend a Cube Server. The operation can only be applied to Cube Servers. Note: The virtual machine will not be deleted.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -360,38 +584,59 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    suspendServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerSuspend,
-		InitClient: true,
-	})
+			Example:    suspendServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerSuspend,
+			InitClient: true,
+		},
+	)
+	suspend.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	suspend.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = suspend.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	suspend.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = suspend.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIdsCustom(viper.GetString(core.GetFlagName(suspend.NS, cloudapiv6.ArgDataCenterId)),
-			resources.ListQueryParams{
-				Filters: &map[string][]string{
-					"type": {serverCubeType},
+	_ = suspend.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	suspend.AddUUIDFlag(
+		cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption(),
+	)
+	_ = suspend.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIdsCustom(
+				viper.GetString(core.GetFlagName(suspend.NS, cloudapiv6.ArgDataCenterId)),
+				resources.ListQueryParams{
+					Filters: &map[string][]string{
+						"type": {serverCubeType},
+					},
 				},
-			}), cobra.ShellCompDirectiveNoFileComp
-	})
-	suspend.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server suspend to be executed")
-	suspend.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server suspend [seconds]")
-	suspend.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	suspend.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server suspend to be executed",
+	)
+	suspend.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server suspend [seconds]",
+	)
+	suspend.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Start Command
 	*/
-	start := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "start",
-		Aliases:   []string{"on"},
-		ShortDesc: "Start a Server",
-		LongDesc: `Use this command to start a Server from a Virtual Data Center. If the Server's public IP was deallocated then a new IP will be assigned.
+	start := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "start",
+			Aliases:   []string{"on"},
+			ShortDesc: "Start a Server",
+			LongDesc: `Use this command to start a Server from a Virtual Data Center. If the Server's public IP was deallocated then a new IP will be assigned.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -399,33 +644,56 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    startServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerStart,
-		InitClient: true,
-	})
+			Example:    startServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerStart,
+			InitClient: true,
+		},
+	)
+	start.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	start.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = start.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = start.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	start.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = start.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(start.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	start.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server start to be executed")
-	start.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server start [seconds]")
-	start.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = start.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						start.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	start.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server start to be executed",
+	)
+	start.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server start [seconds]",
+	)
+	start.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Stop Command
 	*/
-	stop := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "stop",
-		Aliases:   []string{"off"},
-		ShortDesc: "Stop a Server",
-		LongDesc: `Use this command to stop a Server from a Virtual Data Center. The machine will be forcefully powered off, billing will cease, and the public IP, if one is allocated, will be deallocated.
+	stop := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "stop",
+			Aliases:   []string{"off"},
+			ShortDesc: "Stop a Server",
+			LongDesc: `Use this command to stop a Server from a Virtual Data Center. The machine will be forcefully powered off, billing will cease, and the public IP, if one is allocated, will be deallocated.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -433,33 +701,56 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    stopServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerStop,
-		InitClient: true,
-	})
+			Example:    stopServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerStop,
+			InitClient: true,
+		},
+	)
+	stop.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	stop.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = stop.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = stop.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	stop.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = stop.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(stop.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	stop.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server stop to be executed")
-	stop.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server stop [seconds]")
-	stop.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = stop.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						stop.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	stop.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server stop to be executed",
+	)
+	stop.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server stop [seconds]",
+	)
+	stop.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Reboot Command
 	*/
-	reboot := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "reboot",
-		Aliases:   []string{"r"},
-		ShortDesc: "Force a hard reboot of a Server",
-		LongDesc: `Use this command to force a hard reboot of the Server. Do not use this method if you want to gracefully reboot the machine. This is the equivalent of powering off the machine and turning it back on.
+	reboot := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "reboot",
+			Aliases:   []string{"r"},
+			ShortDesc: "Force a hard reboot of a Server",
+			LongDesc: `Use this command to force a hard reboot of the Server. Do not use this method if you want to gracefully reboot the machine. This is the equivalent of powering off the machine and turning it back on.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -467,33 +758,58 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    rebootServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerReboot,
-		InitClient: true,
-	})
+			Example:    rebootServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerReboot,
+			InitClient: true,
+		},
+	)
+	reboot.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	reboot.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = reboot.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	reboot.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = reboot.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(reboot.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	reboot.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server reboot to be executed")
-	reboot.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server reboot [seconds]")
-	reboot.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = reboot.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	reboot.AddUUIDFlag(
+		cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption(),
+	)
+	_ = reboot.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						reboot.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	reboot.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server reboot to be executed",
+	)
+	reboot.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server reboot [seconds]",
+	)
+	reboot.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Resume Command
 	*/
-	resume := core.NewCommand(ctx, serverCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "server",
-		Verb:      "resume",
-		Aliases:   []string{"res"},
-		ShortDesc: "Resume a Cube Server",
-		LongDesc: `Use this command to resume a Cube Server. The operation can only be applied to suspended Cube Servers.
+	resume := core.NewCommand(
+		ctx, serverCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "server",
+			Verb:      "resume",
+			Aliases:   []string{"res"},
+			ShortDesc: "Resume a Cube Server",
+			LongDesc: `Use this command to resume a Cube Server. The operation can only be applied to suspended Cube Servers.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -501,27 +817,47 @@ Required values to run command:
 
 * Data Center Id
 * Server Id`,
-		Example:    resumeServerExample,
-		PreCmdRun:  PreRunDcServerIds,
-		CmdRun:     RunServerResume,
-		InitClient: true,
-	})
+			Example:    resumeServerExample,
+			PreCmdRun:  PreRunDcServerIds,
+			CmdRun:     RunServerResume,
+			InitClient: true,
+		},
+	)
+	resume.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	resume.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = resume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	resume.AddUUIDFlag(cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = resume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIdsCustom(viper.GetString(core.GetFlagName(resume.NS, cloudapiv6.ArgDataCenterId)),
-			resources.ListQueryParams{
-				Filters: &map[string][]string{
-					"type": {serverCubeType},
+	_ = resume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	resume.AddUUIDFlag(
+		cloudapiv6.ArgServerId, cloudapiv6.ArgIdShort, "", cloudapiv6.ServerId, core.RequiredFlagOption(),
+	)
+	_ = resume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIdsCustom(
+				viper.GetString(core.GetFlagName(resume.NS, cloudapiv6.ArgDataCenterId)),
+				resources.ListQueryParams{
+					Filters: &map[string][]string{
+						"type": {serverCubeType},
+					},
 				},
-			}), cobra.ShellCompDirectiveNoFileComp
-	})
-	resume.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Server resume to be executed")
-	resume.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Server resume [seconds]")
-	resume.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	resume.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Server resume to be executed",
+	)
+	resume.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Server resume [seconds]",
+	)
+	resume.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	serverCmd.AddCommand(ServerTokenCmd())
 	serverCmd.AddCommand(ServerConsoleCmd())
@@ -532,7 +868,8 @@ Required values to run command:
 }
 
 func PreRunServerList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -557,36 +894,47 @@ func PreRunServerCreate(c *core.PreCommandConfig) error {
 	}
 
 	// If either image ID or alias is set, we'll need to modify the required flags.
-	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) || viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)) {
+	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, cloudapiv6.ArgImageAlias,
+		),
+	) {
 		imageRequiredFlags := make([][]string, 0)
 
 		// If image-alias is set, it's a public image. Otherwise, we need to check.
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)) {
 			// Directly append public image flags.
 			for _, baseFlagSet := range baseRequiredFlags {
-				imageRequiredFlags = append(imageRequiredFlags,
+				imageRequiredFlags = append(
+					imageRequiredFlags,
 					append(baseFlagSet, cloudapiv6.ArgImageAlias, cloudapiv6.ArgPassword),
 					append(baseFlagSet, cloudapiv6.ArgImageAlias, cloudapiv6.ArgSshKeyPaths),
 				)
 			}
 		} else if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) {
 			// is image public or private?
-			img, _, err := client.Must().CloudClient.ImagesApi.ImagesFindById(context.Background(),
-				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId))).Execute()
+			img, _, err := client.Must().CloudClient.ImagesApi.ImagesFindById(
+				context.Background(),
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)),
+			).Execute()
 			if err != nil {
-				return fmt.Errorf("failed getting image %s: %w", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)), err)
+				return fmt.Errorf(
+					"failed getting image %s: %w", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)), err,
+				)
 			}
 
 			for _, baseFlagSet := range baseRequiredFlags {
 				if *img.Properties.Public {
 					// For public images, password or SSH key is required.
-					imageRequiredFlags = append(imageRequiredFlags,
+					imageRequiredFlags = append(
+						imageRequiredFlags,
 						append(baseFlagSet, cloudapiv6.ArgImageId, cloudapiv6.ArgPassword),
 						append(baseFlagSet, cloudapiv6.ArgImageId, cloudapiv6.ArgSshKeyPaths),
 					)
 				} else {
 					// For private images, no additional flags beyond image ID are required.
-					imageRequiredFlags = append(imageRequiredFlags,
+					imageRequiredFlags = append(
+						imageRequiredFlags,
 						append(baseFlagSet, cloudapiv6.ArgImageId),
 					)
 				}
@@ -607,7 +955,8 @@ func PreRunDcServerIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcServerDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -677,13 +1026,18 @@ func RunServerListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allServers, allServersConverted,
-		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allServers, allServersConverted,
+		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -717,9 +1071,18 @@ func RunServerList(c *core.CommandConfig) error {
 		}
 	}
 
-	servers, resp, err := c.CloudApiV6Services.Servers().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), listQueryParams)
+	servers, resp, err := c.CloudApiV6Services.Servers().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -727,8 +1090,10 @@ func RunServerList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Server, servers.Servers,
-		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Server, servers.Servers,
+		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -745,10 +1110,15 @@ func RunServerGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Server with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Server with id: %v is getting... ", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
+		),
+	)
 
-	if err := waitfor.WaitForState(c, waiter.ServerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.ServerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
+	); err != nil {
 		return err
 	}
 	svr, resp, err := c.CloudApiV6Services.Servers().Get(
@@ -757,7 +1127,10 @@ func RunServerGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -765,8 +1138,10 @@ func RunServerGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Server, svr.Server,
-		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Server, svr.Server,
+		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -797,16 +1172,27 @@ func RunServerCreate(c *core.CommandConfig) error {
 		}
 
 		// Attach Storage
-		input.SetEntities(ionoscloud.ServerEntities{
-			Volumes: &ionoscloud.AttachedVolumes{
-				Items: &[]ionoscloud.Volume{volumeDAS.Volume},
+		input.SetEntities(
+			ionoscloud.ServerEntities{
+				Volumes: &ionoscloud.AttachedVolumes{
+					Items: &[]ionoscloud.Volume{volumeDAS.Volume},
+				},
 			},
-		})
+		)
 	}
 
-	svr, resp, err := c.CloudApiV6Services.Servers().Create(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), *input, queryParams)
+	svr, resp, err := c.CloudApiV6Services.Servers().Create(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), *input, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -822,8 +1208,10 @@ func RunServerCreate(c *core.CommandConfig) error {
 				return err
 			}
 
-			if svr, _, err = c.CloudApiV6Services.Servers().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
-				*id, queryParams); err != nil {
+			if svr, _, err = c.CloudApiV6Services.Servers().Get(
+				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+				*id, queryParams,
+			); err != nil {
 				return err
 			}
 		} else {
@@ -833,8 +1221,10 @@ func RunServerCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Server, svr.Server,
-		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Server, svr.Server,
+		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -856,9 +1246,13 @@ func RunServerUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Updating Server with ID: %v in Datacenter with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating Server with ID: %v in Datacenter with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 
 	svr, resp, err := c.CloudApiV6Services.Servers().Update(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -867,7 +1261,10 @@ func RunServerUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -878,20 +1275,26 @@ func RunServerUpdate(c *core.CommandConfig) error {
 	}
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgWaitForState)) {
-		if err = waitfor.WaitForState(c, waiter.ServerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))); err != nil {
+		if err = waitfor.WaitForState(
+			c, waiter.ServerStateInterrogator, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)),
+		); err != nil {
 			return err
 		}
 
-		if svr, _, err = c.CloudApiV6Services.Servers().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)), queryParams); err != nil {
+		if svr, _, err = c.CloudApiV6Services.Servers().Get(
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId)), queryParams,
+		); err != nil {
 			return err
 		}
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Server, svr.Server,
-		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Server, svr.Server,
+		tabheaders.GetHeaders(allServerCols, defaultServerCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -918,16 +1321,24 @@ func RunServerDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Server with id: %v from datacenter with id: %v... ", serverId, dcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Server with id: %v from datacenter with id: %v... ", serverId, dcId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Servers().Delete(dcId, serverId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -948,7 +1359,9 @@ func RunServerStart(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "start server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "start server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -960,7 +1373,10 @@ func RunServerStart(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -982,7 +1398,9 @@ func RunServerStop(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "stop server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "stop server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -994,7 +1412,10 @@ func RunServerStop(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1016,7 +1437,9 @@ func RunServerSuspend(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "suspend cube server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "suspend cube server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1028,7 +1451,10 @@ func RunServerSuspend(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1050,7 +1476,9 @@ func RunServerReboot(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "reboot server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "reboot server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1062,7 +1490,10 @@ func RunServerReboot(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1084,7 +1515,9 @@ func RunServerResume(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "resume cube server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "resume cube server", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1096,7 +1529,10 @@ func RunServerResume(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1117,46 +1553,65 @@ func getUpdateServerInfo(c *core.CommandConfig) (*resources.ServerProperties, er
 		name := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))
 		input.SetName(name)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property name set: %v ", name))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property name set: %v ", name),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagCpuFamily)) {
 		cpuFamily := viper.GetString(core.GetFlagName(c.NS, constants.FlagCpuFamily))
 		input.SetCpuFamily(cpuFamily)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CpuFamily set: %v ", cpuFamily))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property CpuFamily set: %v ", cpuFamily),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagAvailabilityZone)) {
 		availabilityZone := viper.GetString(core.GetFlagName(c.NS, constants.FlagAvailabilityZone))
 		input.SetAvailabilityZone(availabilityZone)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AvailabilityZone set: %v ", availabilityZone))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property AvailabilityZone set: %v ", availabilityZone),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagCores)) {
 		cores := viper.GetInt32(core.GetFlagName(c.NS, constants.FlagCores))
 		input.SetCores(cores)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v ", cores))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v ", cores),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId)) {
 		volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
-		input.SetBootVolume(ionoscloud.ResourceReference{
-			Id: &volumeId,
-		})
+		input.SetBootVolume(
+			ionoscloud.ResourceReference{
+				Id: &volumeId,
+			},
+		)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property BootVolume set: %v ", volumeId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property BootVolume set: %v ", volumeId),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId)) {
 		cdromId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgCdromId))
-		input.SetBootCdrom(ionoscloud.ResourceReference{
-			Id: &cdromId,
-		})
+		input.SetBootCdrom(
+			ionoscloud.ResourceReference{
+				Id: &cdromId,
+			},
+		)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property BootCdrom set: %v ", cdromId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property BootCdrom set: %v ", cdromId),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagRam)) {
@@ -1169,7 +1624,9 @@ func getUpdateServerInfo(c *core.CommandConfig) (*resources.ServerProperties, er
 		}
 		input.SetRam(int32(size))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB ", int32(size)))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB ", int32(size)),
+		)
 	}
 
 	return &resources.ServerProperties{
@@ -1188,8 +1645,13 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 	input.SetAvailabilityZone(availabilityZone)
 	input.SetName(name)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Type set: %v", serverType))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property AvailabilityZone set: %v", availabilityZone))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Type set: %v", serverType),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Property AvailabilityZone set: %v", availabilityZone),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Name set: %v", name))
 
 	// CUBE Server Properties
@@ -1215,7 +1677,10 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 			templateUuid := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTemplateId))
 			input.SetTemplateUuid(templateUuid)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property TemplateUuid set: %v", templateUuid))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property TemplateUuid set: %v", templateUuid),
+			)
 		}
 	}
 
@@ -1230,7 +1695,9 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 			cores := viper.GetInt32(core.GetFlagName(c.NS, constants.FlagCores))
 			input.SetCores(cores)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v", cores))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v", cores),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagRam)) {
@@ -1244,7 +1711,10 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 
 			input.SetRam(int32(size))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB", int32(size)))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB", int32(size)),
+			)
 		}
 	}
 
@@ -1262,7 +1732,9 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 			cores := viper.GetInt32(core.GetFlagName(c.NS, constants.FlagCores))
 			input.SetCores(cores)
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v", cores))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Cores set: %v", cores),
+			)
 		}
 		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagRam)) {
 			size, err := utils2.ConvertSize(
@@ -1275,7 +1747,10 @@ func getNewServer(c *core.CommandConfig) (*resources.Server, error) {
 
 			input.SetRam(int32(size))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB", int32(size)))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Ram set: %vMB", int32(size)),
+			)
 		}
 	}
 
@@ -1314,7 +1789,9 @@ func getNewDAS(c *core.CommandConfig) (*resources.Volume, error) {
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSshKeyPaths)) {
 		sshKeysPaths := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgSshKeyPaths))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SSH Key Paths: %v", sshKeysPaths))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SSH Key Paths: %v", sshKeysPaths),
+		)
 
 		sshKeys, err := getSshKeysFromPaths(sshKeysPaths)
 		if err != nil {
@@ -1376,7 +1853,10 @@ func DeleteAllServers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Servers", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Servers",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1389,19 +1869,28 @@ func DeleteAllServers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Server with id: %v from datacenter with id: %v... ", *id, dcId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Server with id: %v from datacenter with id: %v... ", *id, dcId,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.Servers().Delete(dcId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/server_test.go
+++ b/commands/cloudapi-v6/server_test.go
@@ -166,1107 +166,1362 @@ func TestServerCmd(t *testing.T) {
 func TestPreRunServerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		err := PreRunServerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			err := PreRunServerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunServerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunServerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunServerList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunServerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		err := PreRunDcServerIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			err := PreRunDcServerIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerIdsRequiredFlagErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testServerVar)
+			err := PreRunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCreateImageAlias(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testServerVar})
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testServerVar})
+			err := PreRunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCreateCube(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		err := PreRunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+			err := PreRunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerCreateCubeErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunServerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunServerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ss, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunServerListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ss, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunServerListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ss, &testResponse, nil)
-		err := RunServerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ss, &testResponse, nil)
+			err := RunServerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Servers{}, &testResponse, nil)
-		err := RunServerList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Servers{}, &testResponse, nil)
+			err := RunServerList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ss, nil, testServerErr)
-		err := RunServerList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ss, nil, testServerErr)
+			err := RunServerList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, &testResponse, nil)
-		err := RunServerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, &testResponse, nil)
+			err := RunServerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerGetWait(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
-		err := RunServerGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, nil)
+			err := RunServerGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerGetWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, testServerErr)
-		err := RunServerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, testServerErr)
+			err := RunServerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, testServerErr)
-		err := RunServerGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, testServerErr)
+			err := RunServerGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), strconv.Itoa(int(ram)))
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, &testResponse, nil)
-		err := RunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), strconv.Itoa(int(ram)))
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, &testResponse, nil)
+			err := RunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateCube(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		sentServer := serverCubeCreate
-		sentServer.Properties.CpuFamily = nil
-		expectedServer := s
-		expectedServer.Properties.CpuFamily = nil
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
-		err := RunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			sentServer := serverCubeCreate
+			sentServer.Properties.CpuFamily = nil
+			expectedServer := s
+			expectedServer.Properties.CpuFamily = nil
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: expectedServer}, nil, nil)
+			err := RunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateCubeExplicitCpuFamily(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), "AMD_OPTERON")
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		sentServer := serverCubeCreate
-		sentServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
-		expectedServer := s
-		expectedServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
-		err := RunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), "AMD_OPTERON")
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testLicenceType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			sentServer := serverCubeCreate
+			sentServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
+			expectedServer := s
+			expectedServer.Properties.CpuFamily = pointer.From("AMD_OPTERON")
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: expectedServer}, nil, nil)
+			err := RunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateCubeImgAlias(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		sentServer := serverCubeCreateImg
-		sentServer.Properties.CpuFamily = nil
-		expectedServer := s
-		s.Properties.CpuFamily = nil
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: expectedServer}, nil, nil)
-		err := RunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			sentServer := serverCubeCreateImg
+			sentServer.Properties.CpuFamily = nil
+			expectedServer := s
+			s.Properties.CpuFamily = nil
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, sentServer, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: expectedServer}, nil, nil)
+			err := RunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateCubeImgSshErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testServerVar})
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		err := RunServerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerCubeType)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTemplateId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testServerVar})
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			err := RunServerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateWaitState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, nil)
-		err := RunServerCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, nil)
+			err := RunServerCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, nil, testServerErr)
-		err := RunServerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, nil, testServerErr)
+			err := RunServerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Create(testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Server{Server: s}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testServerEnterpriseType)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), cores)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ram)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Create(
+				testServerVar, serverCreate, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Server{Server: s}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, &testResponse, nil)
-		err := RunServerUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, &testResponse, nil)
+			err := RunServerUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdateWaitStateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, testServerErr)
-		err := RunServerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, testServerErr)
+			err := RunServerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdateWaitState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Get(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, nil)
-		err := RunServerUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Get(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, nil)
+			err := RunServerUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, nil, testServerErr)
-		err := RunServerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, nil, testServerErr)
+			err := RunServerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, &testResponse, testServerErr)
-		err := RunServerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, &testResponse, testServerErr)
+			err := RunServerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Update(testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&serverNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCores), coresNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagRam), ramNew)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagCpuFamily), testServerNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCdromId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Update(
+				testServerVar, testServerVar, serverProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&serverNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ssList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ssList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ssList, nil, testServerErr)
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ssList, nil, testServerErr)
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Servers{}, &testResponse, nil)
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Servers{}, &testResponse, nil)
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().List(testServerVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(ssList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testServerErr)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().List(
+				testServerVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(ssList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testServerErr)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Delete(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunServerDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Delete(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunServerDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerSuspend(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Suspend(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerSuspend(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Suspend(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerSuspend(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerSuspendErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Suspend(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerSuspend(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Suspend(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerSuspend(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerSuspendWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Suspend(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerSuspend(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Suspend(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerSuspend(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerSuspendAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerSuspend(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerSuspend(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStart(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Start(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerStart(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Start(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerStart(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerStartErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Start(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerStart(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Start(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerStart(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStartWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Start(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerStart(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Start(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerStart(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStartAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerStart(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerStart(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStop(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Stop(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerStop(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Stop(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerStop(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerStopErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Stop(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerStop(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Stop(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerStop(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStopWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Stop(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerStop(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Stop(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerStop(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerStopAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerStop(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerStop(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerReboot(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		rm.CloudApiV6Mocks.Server.EXPECT().Reboot(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		err := RunServerReboot(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			rm.CloudApiV6Mocks.Server.EXPECT().Reboot(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			err := RunServerReboot(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerRebootErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Reboot(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerReboot(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Reboot(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerReboot(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerRebootWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Reboot(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerReboot(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Reboot(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerReboot(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerRebootAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerReboot(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerReboot(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerResume(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Resume(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunServerResume(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Resume(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunServerResume(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerResumeErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().Resume(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testServerErr)
-		err := RunServerResume(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().Resume(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testServerErr)
+			err := RunServerResume(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerResumeWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().Resume(testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerResume(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().Resume(
+				testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerResume(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerResumeAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunServerResume(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunServerResume(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/share.go
+++ b/commands/cloudapi-v6/share.go
@@ -43,102 +43,153 @@ func ShareCmd() *core.Command {
 	globalFlags := shareCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultGroupShareCols, tabheaders.ColsMessage(allGroupShareCols))
 	_ = viper.BindPFlag(core.GetFlagName(shareCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = shareCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allGroupShareCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = shareCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allGroupShareCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, shareCmd, core.CommandBuilder{
-		Namespace:  "share",
-		Resource:   "share",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Resources Shares through a Group",
-		LongDesc:   "Use this command to get a full list of all the Resources that are shared through a specified Group.\n\nRequired values to run command:\n\n* Group Id",
-		Example:    listSharesExample,
-		PreCmdRun:  PreRunShareList,
-		CmdRun:     RunShareList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
+	list := core.NewCommand(
+		ctx, shareCmd, core.CommandBuilder{
+			Namespace:  "share",
+			Resource:   "share",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Resources Shares through a Group",
+			LongDesc:   "Use this command to get a full list of all the Resources that are shared through a specified Group.\n\nRequired values to run command:\n\n* Group Id",
+			Example:    listSharesExample,
+			PreCmdRun:  PreRunShareList,
+			CmdRun:     RunShareList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, shareCmd, core.CommandBuilder{
-		Namespace:  "share",
-		Resource:   "share",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Resource Share from a Group",
-		LongDesc:   "Use this command to retrieve the details of a specific Shared Resource available to a specified Group.\n\nRequired values to run command:\n\n* Group Id\n* Resource Id",
-		Example:    getShareExample,
-		PreCmdRun:  PreRunGroupResourceIds,
-		CmdRun:     RunShareGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, shareCmd, core.CommandBuilder{
+			Namespace:  "share",
+			Resource:   "share",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Resource Share from a Group",
+			LongDesc:   "Use this command to retrieve the details of a specific Shared Resource available to a specified Group.\n\nRequired values to run command:\n\n* Group Id\n* Resource Id",
+			Example:    getShareExample,
+			PreCmdRun:  PreRunGroupResourceIds,
+			CmdRun:     RunShareGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupResourcesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgResourceId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupResourcesIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgGroupId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, shareCmd, core.CommandBuilder{
-		Namespace: "share",
-		Resource:  "share",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Resource Share for a Group",
-		LongDesc: `Use this command to create a specific Resource Share to a Group and optionally allow the setting of permissions for that Resource. As an example, you might use this to grant permissions to use an Image or Snapshot to a specific Group.
+	create := core.NewCommand(
+		ctx, shareCmd, core.CommandBuilder{
+			Namespace: "share",
+			Resource:  "share",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Resource Share for a Group",
+			LongDesc: `Use this command to create a specific Resource Share to a Group and optionally allow the setting of permissions for that Resource. As an example, you might use this to grant permissions to use an Image or Snapshot to a specific Group.
 
 Required values to run a command:
 
 * Group Id
 * Resource Id`,
-		Example:    createShareExample,
-		PreCmdRun:  PreRunGroupResourceIds,
-		CmdRun:     RunShareCreate,
-		InitClient: true,
-	})
+			Example:    createShareExample,
+			PreCmdRun:  PreRunGroupResourceIds,
+			CmdRun:     RunShareCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ResourcesIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(cloudapiv6.ArgEditPrivilege, "", false, "Set the group's permission to edit privileges on resource")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgResourceId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ResourcesIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgEditPrivilege, "", false, "Set the group's permission to edit privileges on resource",
+	)
 	create.AddBoolFlag(cloudapiv6.ArgSharePrivilege, "", false, "Set the group's permission to share resource")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Resource share to executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Resource to be shared through a Group [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Resource share to executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Resource to be shared through a Group [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, shareCmd, core.CommandBuilder{
-		Namespace: "share",
-		Resource:  "share",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Resource Share from a Group",
-		LongDesc: `Use this command to update the permissions that a Group has for a specific Resource Share.
+	update := core.NewCommand(
+		ctx, shareCmd, core.CommandBuilder{
+			Namespace: "share",
+			Resource:  "share",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Resource Share from a Group",
+			LongDesc: `Use this command to update the permissions that a Group has for a specific Resource Share.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -146,57 +197,109 @@ Required values to run command:
 
 * Group Id
 * Resource Id`,
-		Example:    updateShareExample,
-		PreCmdRun:  PreRunGroupResourceIds,
-		CmdRun:     RunShareUpdate,
-		InitClient: true,
-	})
+			Example:    updateShareExample,
+			PreCmdRun:  PreRunGroupResourceIds,
+			CmdRun:     RunShareUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupResourcesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(cloudapiv6.ArgEditPrivilege, "", false, "Update the group's permission to edit privileges on resource")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgResourceId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupResourcesIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgGroupId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgEditPrivilege, "", false, "Update the group's permission to edit privileges on resource",
+	)
 	update.AddBoolFlag(cloudapiv6.ArgSharePrivilege, "", false, "Update the group's permission to share resource")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Resource Share update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Resource Share update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Resource Share update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Resource Share update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, shareCmd, core.CommandBuilder{
-		Namespace: "share",
-		Resource:  "share",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Resource Share from a Group",
-		LongDesc: `This command deletes a Resource Share from a specified Group.
+	deleteCmd := core.NewCommand(
+		ctx, shareCmd, core.CommandBuilder{
+			Namespace: "share",
+			Resource:  "share",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Resource Share from a Group",
+			LongDesc: `This command deletes a Resource Share from a specified Group.
 
 Required values to run command:
 
 * Resource Id
 * Group Id`,
-		Example:    deleteShareExample,
-		PreCmdRun:  PreRunGroupResourceDelete,
-		CmdRun:     RunShareDelete,
-		InitClient: true,
-	})
+			Example:    deleteShareExample,
+			PreCmdRun:  PreRunGroupResourceDelete,
+			CmdRun:     RunShareDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgResourceId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupResourcesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Resource Share deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Resources Share from a specified Group.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Resource Share deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgResourceId, cloudapiv6.ArgIdShort, "", cloudapiv6.ResourceId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgResourceId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupResourcesIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgGroupId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Resource Share deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Resources Share from a specified Group.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Resource Share deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return shareCmd
 }
@@ -206,7 +309,8 @@ func PreRunGroupResourceIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunGroupResourceDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgGroupId, cloudapiv6.ArgResourceId},
 		[]string{cloudapiv6.ArgGroupId, cloudapiv6.ArgAll},
 	)
@@ -260,13 +364,18 @@ func RunShareListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allShares, allSharesConverted,
-		tabheaders.GetHeaders(allGroupShareCols, defaultGroupShareCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allShares, allSharesConverted,
+		tabheaders.GetHeaders(allGroupShareCols, defaultGroupShareCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -286,9 +395,18 @@ func RunShareList(c *core.CommandConfig) error {
 		return err
 	}
 
-	shares, resp, err := c.CloudApiV6Services.Groups().ListShares(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), listQueryParams)
+	shares, resp, err := c.CloudApiV6Services.Groups().ListShares(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgGroupId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -296,8 +414,10 @@ func RunShareList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Share, shares.GroupShares,
-		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Share, shares.GroupShares,
+		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -308,7 +428,8 @@ func RunShareList(c *core.CommandConfig) error {
 }
 
 func PreRunShareList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgGroupId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -330,9 +451,13 @@ func RunShareGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Share with Resource ID: %v from Group with ID: %v...",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting Share with Resource ID: %v from Group with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
+		),
+	)
 
 	s, resp, err := c.CloudApiV6Services.Groups().GetShare(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
@@ -340,7 +465,10 @@ func RunShareGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -348,8 +476,10 @@ func RunShareGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Share, s.GroupShare,
-		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Share, s.GroupShare,
+		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -378,11 +508,19 @@ func RunShareCreate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Share: EditPrivilege: %v, SharePrivilege: %v", editPrivilege, sharePrivilege))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding Share for Resource ID: %v from Group with ID: %v...",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Share: EditPrivilege: %v, SharePrivilege: %v", editPrivilege,
+			sharePrivilege,
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Adding Share for Resource ID: %v from Group with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
+		),
+	)
 
 	shareAdded, resp, err := c.CloudApiV6Services.Groups().AddShare(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
@@ -391,7 +529,10 @@ func RunShareCreate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -403,8 +544,10 @@ func RunShareCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Share, shareAdded.GroupShare,
-		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Share, shareAdded.GroupShare,
+		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -421,8 +564,10 @@ func RunShareUpdate(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	s, _, err := c.CloudApiV6Services.Groups().GetShare(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)), queryParams)
+	s, _, err := c.CloudApiV6Services.Groups().GetShare(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)), queryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -434,9 +579,13 @@ func RunShareUpdate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating Share for Resource ID: %v from Group with ID: %v...",
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating Share for Resource ID: %v from Group with ID: %v...",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResourceId)),
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
+		),
+	)
 
 	shareUpdated, resp, err := c.CloudApiV6Services.Groups().UpdateShare(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)),
@@ -445,7 +594,10 @@ func RunShareUpdate(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -457,8 +609,10 @@ func RunShareUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Share, shareUpdated.GroupShare,
-		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Share, shareUpdated.GroupShare,
+		tabheaders.GetHeadersAllDefault(defaultGroupShareCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -486,16 +640,25 @@ func RunShareDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete share from group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete share from group",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Starting deleting Share with Resource ID: %v from Group with ID: %v...", shareId, groupId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Starting deleting Share with Resource ID: %v from Group with ID: %v...", shareId, groupId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Groups().RemoveShare(groupId, shareId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -516,7 +679,10 @@ func getShareUpdateInfo(oldShare *resources.GroupShare, c *core.CommandConfig) *
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgEditPrivilege)) {
 			editPrivilege = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgEditPrivilege))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property EditPrivilege set: %v", editPrivilege))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property EditPrivilege set: %v", editPrivilege),
+			)
 		} else {
 			if e, ok := properties.GetEditPrivilegeOk(); ok && e != nil {
 				editPrivilege = *e
@@ -526,7 +692,10 @@ func getShareUpdateInfo(oldShare *resources.GroupShare, c *core.CommandConfig) *
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSharePrivilege)) {
 			sharePrivilege = viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgSharePrivilege))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SharePrivilege set: %v", sharePrivilege))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property SharePrivilege set: %v", sharePrivilege),
+			)
 		} else {
 			if e, ok := properties.GetSharePrivilegeOk(); ok && e != nil {
 				sharePrivilege = *e
@@ -554,7 +723,9 @@ func DeleteAllShares(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Group ID: %v", groupId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Group Shares..."))
 
-	groupShares, resp, err := c.CloudApiV6Services.Groups().ListShares(groupId, cloudapiv6.ParentResourceListQueryParams)
+	groupShares, resp, err := c.CloudApiV6Services.Groups().ListShares(
+		groupId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -576,7 +747,10 @@ func DeleteAllShares(c *core.CommandConfig) error {
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the GroupShares", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the GroupShares",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -589,19 +763,28 @@ func DeleteAllShares(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Starting deleting Share with Resource ID: %v from Group with ID: %v...", *id, groupId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Starting deleting Share with Resource ID: %v from Group with ID: %v...", *id, groupId,
+			),
+		)
 
 		resp, err = c.CloudApiV6Services.Groups().RemoveShare(groupId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/share_test.go
+++ b/commands/cloudapi-v6/share_test.go
@@ -90,432 +90,556 @@ func TestShareCmd(t *testing.T) {
 func TestPreRunGroupResourceIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		err := PreRunGroupResourceIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			err := PreRunGroupResourceIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunShareIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunGroupResourceIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunGroupResourceIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(groupsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(sharesList, &testResponse, nil).Times(len(getGroups(groupsList)))
-		err := RunShareListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				groupsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(sharesList, &testResponse, nil).Times(len(getGroups(groupsList)))
+			err := RunShareListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 func TestRunShareList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(shares, &testResponse, nil)
-		err := RunShareList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(shares, &testResponse, nil)
+			err := RunShareList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(shares, nil, testShareErr)
-		err := RunShareList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(shares, nil, testShareErr)
+			err := RunShareList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTestGet, &testResponse, nil)
-		err := RunShareGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTestGet, &testResponse, nil)
+			err := RunShareGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTestGet, nil, testShareErr)
-		err := RunShareGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTestGet, nil, testShareErr)
+			err := RunShareGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddShare(testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, &testResponse, nil)
-		err := RunShareCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddShare(
+				testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, &testResponse, nil)
+			err := RunShareCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddShare(testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, &testResponse, testShareErr)
-		err := RunShareCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddShare(
+				testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, &testResponse, testShareErr)
+			err := RunShareCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddShare(testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, testShareErr)
-		err := RunShareCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddShare(
+				testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, testShareErr)
+			err := RunShareCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddShare(testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunShareCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddShare(
+				testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunShareCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareNew, &testResponse, nil)
-		err := RunShareUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(
+				testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareNew, &testResponse, nil)
+			err := RunShareUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareUpdateOldShare(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, nil)
-		err := RunShareUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(
+				testShareVar, testShareVar, shareTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, nil)
+			err := RunShareUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareNew, nil, testShareErr)
-		err := RunShareUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(
+				testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareNew, nil, testShareErr)
+			err := RunShareUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunShareUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().UpdateShare(
+				testShareVar, testShareVar, shareNew, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunShareUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().GetShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&shareTest, nil, testShareErr)
-		err := RunShareUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEditPrivilege), testShareBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSharePrivilege), testShareBoolNewVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().GetShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&shareTest, nil, testShareErr)
+			err := RunShareUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunShareDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunShareDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(sharesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunShareDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(sharesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunShareDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(sharesList, nil, testShareErr)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(sharesList, nil, testShareErr)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.GroupShares{}, &testResponse, nil)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.GroupShares{}, &testResponse, nil)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.GroupShares{GroupShares: ionoscloud.GroupShares{Items: &[]ionoscloud.GroupShare{}}}, &testResponse, nil)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.GroupShares{GroupShares: ionoscloud.GroupShares{Items: &[]ionoscloud.GroupShare{}}},
+				&testResponse, nil,
+			)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListShares(testShareVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(sharesList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testShareErr)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListShares(
+				testShareVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(sharesList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testShareErr)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testShareErr)
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testShareErr)
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunShareDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveShare(
+				testShareVar, testShareVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunShareDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunShareDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunShareDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testShareVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResourceId), testShareVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunShareDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/snapshot.go
+++ b/commands/cloudapi-v6/snapshot.go
@@ -40,67 +40,94 @@ func SnapshotCmd() *core.Command {
 	globalFlags := snapshotCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultSnapshotCols, tabheaders.ColsMessage(defaultSnapshotCols))
 	_ = viper.BindPFlag(core.GetFlagName(snapshotCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = snapshotCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultSnapshotCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = snapshotCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultSnapshotCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace:  "snapshot",
-		Resource:   "snapshot",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Snapshots",
-		LongDesc:   "Use this command to get a list of Snapshots.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.SnapshotsFiltersUsage(),
-		Example:    listSnapshotsExample,
-		PreCmdRun:  PreRunSnapshotList,
-		CmdRun:     RunSnapshotList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace:  "snapshot",
+			Resource:   "snapshot",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Snapshots",
+			LongDesc:   "Use this command to get a list of Snapshots.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.SnapshotsFiltersUsage(),
+			Example:    listSnapshotsExample,
+			PreCmdRun:  PreRunSnapshotList,
+			CmdRun:     RunSnapshotList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace:  "snapshot",
-		Resource:   "snapshot",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Snapshot",
-		LongDesc:   "Use this command to get information about a specified Snapshot.\n\nRequired values to run command:\n\n* Snapshot Id",
-		Example:    getSnapshotExample,
-		PreCmdRun:  PreRunSnapshotId,
-		CmdRun:     RunSnapshotGet,
-		InitClient: true,
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	get := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace:  "snapshot",
+			Resource:   "snapshot",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Snapshot",
+			LongDesc:   "Use this command to get information about a specified Snapshot.\n\nRequired values to run command:\n\n* Snapshot Id",
+			Example:    getSnapshotExample,
+			PreCmdRun:  PreRunSnapshotId,
+			CmdRun:     RunSnapshotGet,
+			InitClient: true,
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace: "snapshot",
-		Resource:  "snapshot",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Snapshot of a Volume within the Virtual Data Center",
-		LongDesc: `Use this command to create a Snapshot. Creation of Snapshots is performed from the perspective of the storage Volume. The name, description and licence type of the Snapshot can be set.
+	create := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace: "snapshot",
+			Resource:  "snapshot",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Snapshot of a Volume within the Virtual Data Center",
+			LongDesc: `Use this command to create a Snapshot. Creation of Snapshots is performed from the perspective of the storage Volume. The name, description and licence type of the Snapshot can be set.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -108,124 +135,240 @@ Required values to run command:
 
 * Data Center Id
 * Volume Id`,
-		Example:    createSnapshotExample,
-		PreCmdRun:  PreRunDcVolumeIds,
-		CmdRun:     RunSnapshotCreate,
-		InitClient: true,
-	})
+			Example:    createSnapshotExample,
+			PreCmdRun:  PreRunDcVolumeIds,
+			CmdRun:     RunSnapshotCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Snapshot", "Name of the Snapshot")
 	create.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Snapshot")
 	create.AddSetFlag(cloudapiv6.ArgLicenceType, "", "LINUX", constants.EnumLicenceType, "Licence Type of the Snapshot")
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(cloudapiv6.ArgSecAuthProtection, "", false, "Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgSecAuthProtection, "", false,
+		"Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Snapshot creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Snapshot creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace: "snapshot",
-		Resource:  "snapshot",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Snapshot",
-		LongDesc: `Use this command to update a specified Snapshot.
+	update := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace: "snapshot",
+			Resource:  "snapshot",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Snapshot",
+			LongDesc: `Use this command to update a specified Snapshot.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
 Required values to run command:
 
 * Snapshot Id`,
-		Example:    updateSnapshotExample,
-		PreCmdRun:  PreRunSnapshotId,
-		CmdRun:     RunSnapshotUpdate,
-		InitClient: true,
-	})
+			Example:    updateSnapshotExample,
+			PreCmdRun:  PreRunSnapshotId,
+			CmdRun:     RunSnapshotUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Snapshot")
 	update.AddStringFlag(cloudapiv6.ArgDescription, cloudapiv6.ArgDescriptionShort, "", "Description of the Snapshot")
 	update.AddSetFlag(cloudapiv6.ArgLicenceType, "", "", constants.EnumLicenceType, "Licence Type of the Snapshot")
-	update.AddUUIDFlag(cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", false, "This volume is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgCpuHotUnplug, "", false, "This volume is capable of CPU hot unplug (no reboot required). E.g.: --cpu-hot-unplug=true, --cpu-hot-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", false, "This volume is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgRamHotUnplug, "", false, "This volume is capable of memory hot unplug (no reboot required). E.g.: --ram-hot-unplug=true, --ram-hot-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", false, "This volume is capable of NIC hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "This volume is capable of NIC hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", false, "This volume is capable of VirtIO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "This volume is capable of VirtIO drive hot unplug (no reboot required). E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscScsiHotPlug, "", false, "This volume is capable of SCSI drive hot plug (no reboot required). E.g.: --disc-scsi-plug=true, --disc-scsi-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscScsiHotUnplug, "", false, "This volume is capable of SCSI drive hot unplug (no reboot required). E.g.: --disc-scsi-unplug=true, --disc-scsi-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgSecAuthProtection, "", false, "Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot creation to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot creation [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCpuHotPlug, "", false,
+		"This volume is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCpuHotUnplug, "", false,
+		"This volume is capable of CPU hot unplug (no reboot required). E.g.: --cpu-hot-unplug=true, --cpu-hot-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgRamHotPlug, "", false,
+		"This volume is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgRamHotUnplug, "", false,
+		"This volume is capable of memory hot unplug (no reboot required). E.g.: --ram-hot-unplug=true, --ram-hot-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgNicHotPlug, "", false,
+		"This volume is capable of NIC hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgNicHotUnplug, "", false,
+		"This volume is capable of NIC hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotPlug, "", false,
+		"This volume is capable of VirtIO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotUnplug, "", false,
+		"This volume is capable of VirtIO drive hot unplug (no reboot required). E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscScsiHotPlug, "", false,
+		"This volume is capable of SCSI drive hot plug (no reboot required). E.g.: --disc-scsi-plug=true, --disc-scsi-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscScsiHotUnplug, "", false,
+		"This volume is capable of SCSI drive hot unplug (no reboot required). E.g.: --disc-scsi-unplug=true, --disc-scsi-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgSecAuthProtection, "", false,
+		"Enable secure authentication protection. E.g.: --sec-auth-protection=true, --sec-auth-protection=false",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Snapshot creation to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Snapshot creation [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Restore Command
 	*/
-	restore := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace:  "snapshot",
-		Resource:   "snapshot",
-		Verb:       "restore",
-		Aliases:    []string{"r"},
-		ShortDesc:  "Restore a Snapshot onto a Volume",
-		LongDesc:   "Use this command to restore a Snapshot onto a Volume. A Snapshot is created as just another image that can be used to create new Volumes or to restore an existing Volume.\n\nRequired values to run command:\n\n* Datacenter Id\n* Volume Id\n* Snapshot Id",
-		Example:    restoreSnapshotExample,
-		PreCmdRun:  PreRunSnapshotIdDcIdVolumeId,
-		CmdRun:     RunSnapshotRestore,
-		InitClient: true,
-	})
-	restore.AddUUIDFlag(cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption())
-	_ = restore.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	restore := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace:  "snapshot",
+			Resource:   "snapshot",
+			Verb:       "restore",
+			Aliases:    []string{"r"},
+			ShortDesc:  "Restore a Snapshot onto a Volume",
+			LongDesc:   "Use this command to restore a Snapshot onto a Volume. A Snapshot is created as just another image that can be used to create new Volumes or to restore an existing Volume.\n\nRequired values to run command:\n\n* Datacenter Id\n* Volume Id\n* Snapshot Id",
+			Example:    restoreSnapshotExample,
+			PreCmdRun:  PreRunSnapshotIdDcIdVolumeId,
+			CmdRun:     RunSnapshotRestore,
+			InitClient: true,
+		},
+	)
+	restore.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	restore.AddUUIDFlag(
+		cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption(),
+	)
+	_ = restore.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	restore.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = restore.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = restore.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	restore.AddUUIDFlag(cloudapiv6.ArgVolumeId, "", "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = restore.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(restore.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	restore.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot restore to be executed")
-	restore.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot restore [seconds]")
-	restore.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = restore.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						restore.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	restore.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Snapshot restore to be executed",
+	)
+	restore.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Snapshot restore [seconds]",
+	)
+	restore.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, snapshotCmd, core.CommandBuilder{
-		Namespace:  "snapshot",
-		Resource:   "snapshot",
-		Verb:       "delete",
-		Aliases:    []string{"d"},
-		ShortDesc:  "Delete a Snapshot",
-		LongDesc:   "Use this command to delete the specified Snapshot.\n\nRequired values to run command:\n\n* Snapshot Id",
-		Example:    deleteSnapshotExample,
-		PreCmdRun:  PreRunSnapshotDelete,
-		CmdRun:     RunSnapshotDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSnapshotId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Snapshot deletion to be executed")
+	deleteCmd := core.NewCommand(
+		ctx, snapshotCmd, core.CommandBuilder{
+			Namespace:  "snapshot",
+			Resource:   "snapshot",
+			Verb:       "delete",
+			Aliases:    []string{"d"},
+			ShortDesc:  "Delete a Snapshot",
+			LongDesc:   "Use this command to delete the specified Snapshot.\n\nRequired values to run command:\n\n* Snapshot Id",
+			Example:    deleteSnapshotExample,
+			PreCmdRun:  PreRunSnapshotDelete,
+			CmdRun:     RunSnapshotDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgSnapshotId, cloudapiv6.ArgIdShort, "", cloudapiv6.SnapshotId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSnapshotId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.SnapshotIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Snapshot deletion to be executed",
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Snapshots.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Snapshot deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Snapshot deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return snapshotCmd
 }
@@ -242,14 +385,17 @@ func PreRunSnapshotId(c *core.PreCommandConfig) error {
 }
 
 func PreRunSnapshotDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgSnapshotId},
 		[]string{cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunSnapshotIdDcIdVolumeId(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgVolumeId, cloudapiv6.ArgSnapshotId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgVolumeId, cloudapiv6.ArgSnapshotId,
+	)
 }
 
 func RunSnapshotList(c *core.CommandConfig) error {
@@ -261,7 +407,10 @@ func RunSnapshotList(c *core.CommandConfig) error {
 
 	ss, resp, err := c.CloudApiV6Services.Snapshots().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -269,8 +418,10 @@ func RunSnapshotList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Snapshot, ss.Snapshots,
-		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Snapshot, ss.Snapshots,
+		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -287,12 +438,24 @@ func RunSnapshotGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Snapshot with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Snapshot with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
+		),
+	)
 
-	s, resp, err := c.CloudApiV6Services.Snapshots().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)), queryParams)
+	s, resp, err := c.CloudApiV6Services.Snapshots().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgSnapshotId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -300,8 +463,10 @@ func RunSnapshotGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Snapshot, s.Snapshot,
-		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Snapshot, s.Snapshot,
+		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -324,13 +489,22 @@ func RunSnapshotCreate(c *core.CommandConfig) error {
 	licenseType := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType))
 	secAuthProtection := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgSecAuthProtection))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Snapshot: DatacenterId: %v, VolumeId: %v, Name: %v, Description: %v, "+
-			"LicenseType: %v, SecAuthProtection: %v", dcId, volumeId, name, description, licenseType, secAuthProtection))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Snapshot: DatacenterId: %v, VolumeId: %v, Name: %v, Description: %v, "+
+				"LicenseType: %v, SecAuthProtection: %v", dcId, volumeId, name, description, licenseType,
+			secAuthProtection,
+		),
+	)
 
-	s, resp, err := c.CloudApiV6Services.Snapshots().Create(dcId, volumeId, name, description, licenseType, secAuthProtection, queryParams)
+	s, resp, err := c.CloudApiV6Services.Snapshots().Create(
+		dcId, volumeId, name, description, licenseType, secAuthProtection, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -342,8 +516,10 @@ func RunSnapshotCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Snapshot, s.Snapshot,
-		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Snapshot, s.Snapshot,
+		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -360,13 +536,21 @@ func RunSnapshotUpdate(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Updating Snapshot with id: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating Snapshot with id: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
+		),
+	)
 
-	s, resp, err := c.CloudApiV6Services.Snapshots().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
-		getSnapshotPropertiesSet(c), queryParams)
+	s, resp, err := c.CloudApiV6Services.Snapshots().Update(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
+		getSnapshotPropertiesSet(c), queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -378,8 +562,10 @@ func RunSnapshotUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Snapshot, s.Snapshot,
-		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Snapshot, s.Snapshot,
+		tabheaders.GetHeadersAllDefault(defaultSnapshotCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -395,12 +581,17 @@ func RunSnapshotRestore(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "restore snapshot", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "restore snapshot", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Snapshot with id: %v is restoring...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Snapshot with id: %v is restoring...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSnapshotId)),
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Snapshots().Restore(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -409,7 +600,10 @@ func RunSnapshotRestore(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -440,15 +634,23 @@ func RunSnapshotDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete snapshot", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete snapshot", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Snapshot with id: %v...", snapshotId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Snapshot with id: %v...", snapshotId),
+	)
 
 	resp, err := c.CloudApiV6Services.Snapshots().Delete(snapshotId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -476,91 +678,130 @@ func getSnapshotPropertiesSet(c *core.CommandConfig) resources.SnapshotPropertie
 		description := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDescription))
 		input.SetDescription(description)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Description set: %v", description),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType)) {
 		licenceType := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType))
 		input.SetLicenceType(licenceType)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property LicenceType set: %v", licenceType))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property LicenceType set: %v", licenceType),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotPlug)) {
 		cpuHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotPlug))
 		input.SetCpuHotPlug(cpuHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotUnplug)) {
 		cpuHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotUnplug))
 		input.SetCpuHotUnplug(cpuHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CpuHotUnplug set: %v", cpuHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property CpuHotUnplug set: %v", cpuHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug)) {
 		ramHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug))
 		input.SetRamHotPlug(ramHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotUnplug)) {
 		ramHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotUnplug))
 		input.SetRamHotUnplug(ramHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property RamHotUnplug set: %v", ramHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property RamHotUnplug set: %v", ramHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug)) {
 		nicHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug))
 		input.SetNicHotPlug(nicHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug)) {
 		nicHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug))
 		input.SetNicHotUnplug(nicHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property nicHotUnplug set: %v", nicHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property nicHotUnplug set: %v", nicHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug)) {
 		discVirtioHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug))
 		input.SetDiscVirtioHotPlug(discVirtioHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug)) {
 		discVirtioHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug))
 		input.SetDiscVirtioHotUnplug(discVirtioHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscScsiHotPlug)) {
 		discScsiHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscScsiHotPlug))
 		input.SetDiscScsiHotPlug(discScsiHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscScsiHotPlug set: %v", discScsiHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscScsiHotPlug set: %v", discScsiHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscScsiHotUnplug)) {
 		discScsiHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscScsiHotUnplug))
 		input.SetDiscScsiHotUnplug(discScsiHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscScsiHotUnplug set: %v", discScsiHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscScsiHotUnplug set: %v", discScsiHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSecAuthProtection)) {
 		secAuthProtection := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgSecAuthProtection))
 		input.SetSecAuthProtection(secAuthProtection)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property SecAuthProtection set: %v", secAuthProtection))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property SecAuthProtection set: %v", secAuthProtection),
+		)
 	}
 
 	return input
@@ -607,7 +848,10 @@ func DeleteAllSnapshots(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Snapshots", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Snapshots",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -620,18 +864,27 @@ func DeleteAllSnapshots(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Snapshot with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Snapshot with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Snapshots().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/snapshot_test.go
+++ b/commands/cloudapi-v6/snapshot_test.go
@@ -93,486 +93,600 @@ func TestSnapshotCmd(t *testing.T) {
 func TestPreRunSnapshotList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunSnapshotList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunSnapshotList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunSnapshotListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunSnapshotList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunSnapshotList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunSnapshotListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunSnapshotList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunSnapshotList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunSnapshotId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		err := PreRunSnapshotId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			err := PreRunSnapshotId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunSnapshotIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunSnapshotId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunSnapshotId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunSnapshotIdDcIdVolumeId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		err := PreRunSnapshotIdDcIdVolumeId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			err := PreRunSnapshotIdDcIdVolumeId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshots, &testResponse, nil)
-		err := RunSnapshotList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshots, &testResponse, nil,
+			)
+			err := RunSnapshotList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Snapshots{}, &testResponse, nil)
-		err := RunSnapshotList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Snapshots{}, &testResponse, nil,
+			)
+			err := RunSnapshotList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshots, nil, testSnapshotErr)
-		err := RunSnapshotList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshots, nil, testSnapshotErr,
+			)
+			err := RunSnapshotList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotListSort(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshots, nil, nil)
-		err := RunSnapshotList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshots, nil, nil,
+			)
+			err := RunSnapshotList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Get(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&snapshotTest, &testResponse, nil)
-		err := RunSnapshotGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Get(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&snapshotTest, &testResponse, nil)
+			err := RunSnapshotGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Get(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&snapshotTest, nil, testSnapshotErr)
-		err := RunSnapshotGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Get(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&snapshotTest, nil, testSnapshotErr)
+			err := RunSnapshotGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Create(testSnapshotVar, testSnapshotVar, testSnapshotVar, testSnapshotVar,
-			testSnapshotVar, false, testQueryParamOther).Return(&snapshotTest, &testResponse, nil)
-		err := RunSnapshotCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Create(
+				testSnapshotVar, testSnapshotVar, testSnapshotVar, testSnapshotVar,
+				testSnapshotVar, false, testQueryParamOther,
+			).Return(&snapshotTest, &testResponse, nil)
+			err := RunSnapshotCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Create(testSnapshotVar, testSnapshotVar, testSnapshotVar, testSnapshotVar,
-			testSnapshotVar, false, testQueryParamOther).Return(&snapshotTest, &testResponse, testSnapshotErr)
-		err := RunSnapshotCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Create(
+				testSnapshotVar, testSnapshotVar, testSnapshotVar, testSnapshotVar,
+				testSnapshotVar, false, testQueryParamOther,
+			).Return(&snapshotTest, &testResponse, testSnapshotErr)
+			err := RunSnapshotCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Update(testSnapshotVar, snapshotProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&snapshotNew, &testResponse, nil)
-		err := RunSnapshotUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Update(
+				testSnapshotVar, snapshotProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&snapshotNew, &testResponse, nil)
+			err := RunSnapshotUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotPlug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotUnplug), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), testSnapshotBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Update(testSnapshotVar, snapshotProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&snapshotNew, nil, testSnapshotErr)
-		err := RunSnapshotUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDescription), testSnapshotNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testSnapshotNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotPlug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscScsiHotUnplug), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSecAuthProtection), testSnapshotBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Update(
+				testSnapshotVar, snapshotProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&snapshotNew, nil, testSnapshotErr)
+			err := RunSnapshotUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotRestore(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunSnapshotRestore(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(
+				testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunSnapshotRestore(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotRestoreErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testSnapshotErr)
-		err := RunSnapshotRestore(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(
+				testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testSnapshotErr)
+			err := RunSnapshotRestore(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotRestoreAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		err := RunSnapshotRestore(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Restore(
+				testSnapshotVar, testSnapshotVar, testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			err := RunSnapshotRestore(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunSnapshotDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshotsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshotsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunSnapshotDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshotsList, nil, testSnapshotErr)
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshotsList, nil, testSnapshotErr,
+			)
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Snapshots{}, &testResponse, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Snapshots{}, &testResponse, nil,
+			)
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Snapshots{Snapshots: ionoscloud.Snapshots{Items: &[]ionoscloud.Snapshot{}}}, &testResponse, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Snapshots{Snapshots: ionoscloud.Snapshots{Items: &[]ionoscloud.Snapshot{}}}, &testResponse,
+				nil,
+			)
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(snapshotsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testSnapshotErr)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				snapshotsList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testSnapshotErr)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testSnapshotErr)
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testSnapshotErr)
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunSnapshotDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Snapshot.EXPECT().Delete(
+				testSnapshotVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunSnapshotDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunSnapshotDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunSnapshotDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSnapshotId), testSnapshotVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunSnapshotDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/targetgroup.go
+++ b/commands/cloudapi-v6/targetgroup.go
@@ -24,9 +24,13 @@ import (
 )
 
 var (
-	defaultTargetGroupCols = []string{"TargetGroupId", "Name", "Algorithm", "Protocol", "CheckTimeout", "CheckInterval", "State"}
-	allTargetGroupCols     = []string{"TargetGroupId", "Name", "Algorithm", "Protocol", "CheckTimeout", "CheckInterval", "Retries",
-		"Path", "Method", "MatchType", "Response", "Regex", "Negate", "State"}
+	defaultTargetGroupCols = []string{
+		"TargetGroupId", "Name", "Algorithm", "Protocol", "CheckTimeout", "CheckInterval", "State",
+	}
+	allTargetGroupCols = []string{
+		"TargetGroupId", "Name", "Algorithm", "Protocol", "CheckTimeout", "CheckInterval", "Retries",
+		"Path", "Method", "MatchType", "Response", "Regex", "Negate", "State",
+	}
 )
 
 func TargetGroupCmd() *core.Command {
@@ -42,179 +46,318 @@ func TargetGroupCmd() *core.Command {
 	}
 	globalFlags := targetGroupCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultTargetGroupCols, tabheaders.ColsMessage(allTargetGroupCols))
-	_ = viper.BindPFlag(core.GetFlagName(targetGroupCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = targetGroupCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allTargetGroupCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = viper.BindPFlag(
+		core.GetFlagName(targetGroupCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols),
+	)
+	_ = targetGroupCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allTargetGroupCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, targetGroupCmd, core.CommandBuilder{
-		Namespace:  "targetgroup",
-		Resource:   "targetgroup",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Target Groups",
-		LongDesc:   "Use this command to get a list of Target Groups.",
-		Example:    listTargetGroupExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunTargetGroupList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, targetGroupCmd, core.CommandBuilder{
+			Namespace:  "targetgroup",
+			Resource:   "targetgroup",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Target Groups",
+			LongDesc:   "Use this command to get a list of Target Groups.",
+			Example:    listTargetGroupExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunTargetGroupList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, targetGroupCmd, core.CommandBuilder{
-		Namespace:  "targetgroup",
-		Resource:   "targetgroup",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Target Group",
-		LongDesc:   "Use this command to get information about a specified Target Group.\n\nRequired values to run command:\n\n* Target Group Id",
-		Example:    getTargetGroupExample,
-		PreCmdRun:  PreRunTargetGroupId,
-		CmdRun:     RunTargetGroupGet,
-		InitClient: true,
-	})
-	get.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	get := core.NewCommand(
+		ctx, targetGroupCmd, core.CommandBuilder{
+			Namespace:  "targetgroup",
+			Resource:   "targetgroup",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Target Group",
+			LongDesc:   "Use this command to get information about a specified Target Group.\n\nRequired values to run command:\n\n* Target Group Id",
+			Example:    getTargetGroupExample,
+			PreCmdRun:  PreRunTargetGroupId,
+			CmdRun:     RunTargetGroupGet,
+			InitClient: true,
+		},
+	)
+	get.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, targetGroupCmd, core.CommandBuilder{
-		Namespace: "targetgroup",
-		Resource:  "targetgroup",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Target Group",
-		LongDesc: `Use this command to create a Target Group.
+	create := core.NewCommand(
+		ctx, targetGroupCmd, core.CommandBuilder{
+			Namespace: "targetgroup",
+			Resource:  "targetgroup",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Target Group",
+			LongDesc: `Use this command to create a Target Group.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` or ` + "`" + `-w` + "`" + ` option.`,
-		Example:    createTargetGroupExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunTargetGroupCreate,
-		InitClient: true,
-	})
-	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Target Group", "The name of the target group.")
+			Example:    createTargetGroupExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunTargetGroupCreate,
+			InitClient: true,
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Target Group", "The name of the target group.",
+	)
 	create.AddStringFlag(cloudapiv6.ArgAlgorithm, "", "ROUND_ROBIN", "Balancing algorithm.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAlgorithm, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ROUND_ROBIN", "LEAST_CONNECTION", "RANDOM", "SOURCE_IP"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAlgorithm,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"ROUND_ROBIN", "LEAST_CONNECTION", "RANDOM", "SOURCE_IP",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, "HTTP", "Balancing protocol")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddIntFlag(cloudapiv6.ArgCheckTimeout, "", 2000, "[Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established.")
-	create.AddIntFlag(cloudapiv6.ArgCheckInterval, "", 2000, "[Health Check] The interval in milliseconds between consecutive health checks; default is 2000.")
-	create.AddIntFlag(cloudapiv6.ArgRetries, "", 3, "[Health Check] The maximum number of attempts to reconnect to a target after a connection failure. Valid range is 0 to 65535, and default is three reconnection attempts.")
-	create.AddStringFlag(cloudapiv6.ArgPath, "", "/.", "[HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /.")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgCheckTimeout, "", 2000,
+		"[Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established.",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgCheckInterval, "", 2000,
+		"[Health Check] The interval in milliseconds between consecutive health checks; default is 2000.",
+	)
+	create.AddIntFlag(
+		cloudapiv6.ArgRetries, "", 3,
+		"[Health Check] The maximum number of attempts to reconnect to a target after a connection failure. Valid range is 0 to 65535, and default is three reconnection attempts.",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgPath, "", "/.",
+		"[HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /.",
+	)
 	create.AddStringFlag(cloudapiv6.ArgMethod, "", "GET", "[HTTP Health Check] The method for the HTTP health check.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgMethod, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HEAD", "PUT", "POST", "GET", "TRACE", "PATCH", "OPTIONS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgMatchType, "", "STATUS_CODE", "[HTTP Health Check] Match Type for the HTTP health check.")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgMatchType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"STATUS_CODE", "RESPONSE_BODY"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(cloudapiv6.ArgResponse, "", "200", "[HTTP Health Check] The response returned by the request, depending on the match type.")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgMethod,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"HEAD", "PUT", "POST", "GET", "TRACE", "PATCH", "OPTIONS",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgMatchType, "", "STATUS_CODE", "[HTTP Health Check] Match Type for the HTTP health check.",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgMatchType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"STATUS_CODE", "RESPONSE_BODY"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgResponse, "", "200",
+		"[HTTP Health Check] The response returned by the request, depending on the match type.",
+	)
 	create.AddBoolFlag(cloudapiv6.ArgRegex, "", false, "[HTTP Health Check] Regex for the HTTP health check.")
 	create.AddBoolFlag(cloudapiv6.ArgNegate, "", false, "[HTTP Health Check] Negate for the HTTP health check.")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Target Group creation to be executed.")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Target Group creation [seconds].")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Target Group creation to be executed.",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Target Group creation [seconds].",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, targetGroupCmd, core.CommandBuilder{
-		Namespace: "targetgroup",
-		Resource:  "targetgroup",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Target Group",
-		LongDesc: `Use this command to update a specified Target Group.
+	update := core.NewCommand(
+		ctx, targetGroupCmd, core.CommandBuilder{
+			Namespace: "targetgroup",
+			Resource:  "targetgroup",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Target Group",
+			LongDesc: `Use this command to update a specified Target Group.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` or ` + "`" + `-w` + "`" + ` option.
 
 Required values to run command:
 
 * Target Group Id`,
-		Example:    updateTargetGroupExample,
-		PreCmdRun:  PreRunTargetGroupId,
-		CmdRun:     RunTargetGroupUpdate,
-		InitClient: true,
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Updated Target Group", "The name of the target group.")
+			Example:    updateTargetGroupExample,
+			PreCmdRun:  PreRunTargetGroupId,
+			CmdRun:     RunTargetGroupUpdate,
+			InitClient: true,
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Updated Target Group", "The name of the target group.",
+	)
 	update.AddStringFlag(cloudapiv6.ArgAlgorithm, "", "ROUND_ROBIN", "Balancing algorithm.")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgAlgorithm, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ROUND_ROBIN", "LEAST_CONNECTION", "RANDOM", "SOURCE_IP"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgAlgorithm,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"ROUND_ROBIN", "LEAST_CONNECTION", "RANDOM", "SOURCE_IP",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgProtocol, cloudapiv6.ArgProtocolShort, "HTTP", "Balancing protocol")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgProtocol, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddIntFlag(cloudapiv6.ArgCheckTimeout, "", 2000, "[Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established.")
-	update.AddIntFlag(cloudapiv6.ArgCheckInterval, "", 2000, "[Health Check] The interval in milliseconds between consecutive health checks; default is 2000.")
-	update.AddIntFlag(cloudapiv6.ArgRetries, "", 3, "[Health Check] The maximum number of attempts to reconnect to a target after a connection failure. Valid range is 0 to 65535, and default is three reconnection attempts.")
-	update.AddStringFlag(cloudapiv6.ArgPath, "", "/.", "[HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /.")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgProtocol,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HTTP"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgCheckTimeout, "", 2000,
+		"[Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established.",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgCheckInterval, "", 2000,
+		"[Health Check] The interval in milliseconds between consecutive health checks; default is 2000.",
+	)
+	update.AddIntFlag(
+		cloudapiv6.ArgRetries, "", 3,
+		"[Health Check] The maximum number of attempts to reconnect to a target after a connection failure. Valid range is 0 to 65535, and default is three reconnection attempts.",
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgPath, "", "/.",
+		"[HTTP Health Check] The path (destination URL) for the HTTP health check request; the default is /.",
+	)
 	update.AddStringFlag(cloudapiv6.ArgMethod, "", "GET", "[HTTP Health Check] The method for the HTTP health check.")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgMethod, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HEAD", "PUT", "POST", "GET", "TRACE", "PATCH", "OPTIONS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgMatchType, "", "STATUS_CODE", "[HTTP Health Check] Match Type for the HTTP health check.")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgMethod, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"STATUS_CODE", "RESPONSE_BODY"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(cloudapiv6.ArgResponse, "", "200", "[HTTP Health Check] The response returned by the request, depending on the match type.")
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgMethod,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"HEAD", "PUT", "POST", "GET", "TRACE", "PATCH", "OPTIONS",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgMatchType, "", "STATUS_CODE", "[HTTP Health Check] Match Type for the HTTP health check.",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgMethod,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"STATUS_CODE", "RESPONSE_BODY"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		cloudapiv6.ArgResponse, "", "200",
+		"[HTTP Health Check] The response returned by the request, depending on the match type.",
+	)
 	update.AddBoolFlag(cloudapiv6.ArgRegex, "", false, "[HTTP Health Check] Regex for the HTTP health check.")
 	update.AddBoolFlag(cloudapiv6.ArgNegate, "", false, "[HTTP Health Check] Negate for the HTTP health check.")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Target Group update to be executed.")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Target Group update [seconds].")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Target Group update to be executed.",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Target Group update [seconds].",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, targetGroupCmd, core.CommandBuilder{
-		Namespace:  "targetgroup",
-		Resource:   "targetgroup",
-		Verb:       "delete",
-		Aliases:    []string{"d"},
-		ShortDesc:  "Delete a Target Group",
-		LongDesc:   "Use this command to delete the specified Target Group.\n\nRequired values to run command:\n\n* Target Group Id",
-		Example:    deleteTargetGroupExample,
-		PreCmdRun:  PreRunTargetGroupDelete,
-		CmdRun:     RunTargetGroupDelete,
-		InitClient: true,
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	deleteCmd := core.NewCommand(
+		ctx, targetGroupCmd, core.CommandBuilder{
+			Namespace:  "targetgroup",
+			Resource:   "targetgroup",
+			Verb:       "delete",
+			Aliases:    []string{"d"},
+			ShortDesc:  "Delete a Target Group",
+			LongDesc:   "Use this command to delete the specified Target Group.\n\nRequired values to run command:\n\n* Target Group Id",
+			Example:    deleteTargetGroupExample,
+			PreCmdRun:  PreRunTargetGroupDelete,
+			CmdRun:     RunTargetGroupDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Target Groups")
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Target Group deletion to be executed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Target Group deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Target Group deletion to be executed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Target Group deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	targetGroupCmd.AddCommand(TargetGroupTargetCmd())
 
@@ -226,7 +369,8 @@ func PreRunTargetGroupId(c *core.PreCommandConfig) error {
 }
 
 func PreRunTargetGroupDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgTargetGroupId},
 		[]string{cloudapiv6.ArgAll},
 	)
@@ -242,7 +386,10 @@ func RunTargetGroupList(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting TargetGroups"))
 	ss, resp, err := c.CloudApiV6Services.TargetGroups().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -250,8 +397,10 @@ func RunTargetGroupList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.TargetGroup, ss.TargetGroups,
-		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.TargetGroup, ss.TargetGroups,
+		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -268,13 +417,25 @@ func RunTargetGroupGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting TargetGroup"))
 
-	s, resp, err := c.CloudApiV6Services.TargetGroups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), queryParams)
+	s, resp, err := c.CloudApiV6Services.TargetGroups().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -282,8 +443,10 @@ func RunTargetGroupGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.TargetGroup, s.TargetGroup,
-		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.TargetGroup, s.TargetGroup,
+		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -304,7 +467,10 @@ func RunTargetGroupCreate(c *core.CommandConfig) error {
 
 	s, resp, err := c.CloudApiV6Services.TargetGroups().Create(getTargetGroupNew(c), queryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -316,8 +482,10 @@ func RunTargetGroupCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.TargetGroup, s.TargetGroup,
-		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.TargetGroup, s.TargetGroup,
+		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -334,13 +502,25 @@ func RunTargetGroupUpdate(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating TargetGroup"))
 
-	s, resp, err := c.CloudApiV6Services.TargetGroups().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), getTargetGroupPropertiesSet(c), queryParams)
+	s, resp, err := c.CloudApiV6Services.TargetGroups().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), getTargetGroupPropertiesSet(c), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -352,8 +532,10 @@ func RunTargetGroupUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.TargetGroup, s.TargetGroup,
-		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.TargetGroup, s.TargetGroup,
+		tabheaders.GetHeaders(allTargetGroupCols, defaultTargetGroupCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -372,8 +554,11 @@ func RunTargetGroupDelete(c *core.CommandConfig) error {
 	var resp *resources.Response
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+			),
+		)
 		err = DeleteAllTargetGroup(c)
 		if err != nil {
 			return err
@@ -381,18 +566,32 @@ func RunTargetGroupDelete(c *core.CommandConfig) error {
 
 		return nil
 	}
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete target group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete target group", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting TargetGroup"))
 
-	resp, err = c.CloudApiV6Services.TargetGroups().Delete(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), queryParams)
+	resp, err = c.CloudApiV6Services.TargetGroups().Delete(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -446,11 +645,16 @@ func DeleteAllTargetGroup(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Target Groups", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Target Groups",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Target Groups..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Target Groups..."),
+	)
 
 	var multiErr error
 	for _, tg := range *targetGroupItems {
@@ -459,18 +663,27 @@ func DeleteAllTargetGroup(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Target Group with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Target Group with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.TargetGroups().Delete(*id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
@@ -489,31 +702,51 @@ func getTargetGroupNew(c *core.CommandConfig) resources.TargetGroup {
 	input := resources.TargetGroupProperties{}
 	// Set Required Properties
 	input.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+		),
+	)
 
 	input.SetAlgorithm(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Algorithm set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Algorithm set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)),
+		),
+	)
 
 	input.SetProtocol(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)),
+		),
+	)
 
 	inputHealthCheck := resources.TargetGroupHealthCheck{}
 
 	// Set Properties for Health Check for Target Group
 	inputHealthCheck.SetCheckTimeout(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property CheckTimeout for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property CheckTimeout for HealthCheck set: %v",
+			viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)),
+		),
+	)
 
 	inputHealthCheck.SetCheckInterval(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property CheckInterval for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property CheckInterval for HealthCheck set: %v",
+			viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval)),
+		),
+	)
 
 	inputHealthCheck.SetRetries(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Retries for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Retries for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries)),
+		),
+	)
 
 	// Set Health Check for Target Group
 	input.SetHealthCheck(inputHealthCheck.TargetGroupHealthCheck)
@@ -522,28 +755,48 @@ func getTargetGroupNew(c *core.CommandConfig) resources.TargetGroup {
 	inputHttpHealthCheck := resources.TargetGroupHttpHealthCheck{}
 	// Set Properties for Http Health Check for Target Group
 	inputHttpHealthCheck.SetPath(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Path for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Path for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath)),
+		),
+	)
 
 	inputHttpHealthCheck.SetMethod(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Method for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Method for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)),
+		),
+	)
 
 	inputHttpHealthCheck.SetMatchType(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property MatchType for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property MatchType for HttpHealthCheck set: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)),
+		),
+	)
 
 	inputHttpHealthCheck.SetResponse(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Response for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Response for HttpHealthCheck set: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)),
+		),
+	)
 
 	inputHttpHealthCheck.SetRegex(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Regex for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRegex))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Regex for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)),
+		),
+	)
 
 	inputHttpHealthCheck.SetNegate(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Negate for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Negate for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)),
+		),
+	)
 
 	// Set Http Health Check for Target Group
 	input.SetHttpHealthCheck(inputHttpHealthCheck.TargetGroupHttpHealthCheck)
@@ -562,22 +815,31 @@ func getTargetGroupPropertiesSet(c *core.CommandConfig) *resources.TargetGroupPr
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgName)) {
 		input.SetName(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Name set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgName)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)) {
 		input.SetAlgorithm(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Algorithm set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Algorithm set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgAlgorithm)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)) {
 		input.SetProtocol(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Property Protocol set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgProtocol)),
+			),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)) ||
@@ -589,66 +851,114 @@ func getTargetGroupPropertiesSet(c *core.CommandConfig) *resources.TargetGroupPr
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)) {
 			inputHealthCheck.SetCheckTimeout(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property CheckTimeout for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property CheckTimeout for HealthCheck set: %v",
+					viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckTimeout)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval)) {
 			inputHealthCheck.SetCheckInterval(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property CheckInterval for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property CheckInterval for HealthCheck set: %v",
+					viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgCheckInterval)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRetries)) {
 			inputHealthCheck.SetRetries(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Retries for HealthCheck set: %v", viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Retries for HealthCheck set: %v",
+					viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgRetries)),
+				),
+			)
 		}
 
 		input.SetHealthCheck(inputHealthCheck.TargetGroupHealthCheck)
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating HealthCheck"))
 	}
 
-	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPath)) || viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)) ||
-		viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)) || viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)) ||
-		viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)) || viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)) {
+	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPath)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, cloudapiv6.ArgMethod,
+		),
+	) ||
+		viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, cloudapiv6.ArgRegex,
+		),
+	) ||
+		viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, cloudapiv6.ArgMatchType,
+		),
+	) {
 		inputHttpHealthCheck := resources.TargetGroupHttpHealthCheck{}
 
 		// Set new values for Health Check Properties
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPath)) {
 			inputHttpHealthCheck.SetPath(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Path for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Path for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPath)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)) {
 			inputHttpHealthCheck.SetMethod(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Method for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Method for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMethod)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)) {
 			inputHttpHealthCheck.SetResponse(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Response for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Response for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgResponse)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)) {
 			inputHttpHealthCheck.SetMatchType(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property MatchType for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property MatchType for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMatchType)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)) {
 			inputHttpHealthCheck.SetRegex(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Regex for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRegex))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Regex for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgRegex)),
+				),
+			)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)) {
 			inputHttpHealthCheck.SetNegate(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-				"Property Negate for HttpHealthCheck set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate))))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"Property Negate for HttpHealthCheck set: %v",
+					viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgNegate)),
+				),
+			)
 		}
 
 		input.SetHttpHealthCheck(inputHttpHealthCheck.TargetGroupHttpHealthCheck)

--- a/commands/cloudapi-v6/targetgroup_target.go
+++ b/commands/cloudapi-v6/targetgroup_target.go
@@ -25,7 +25,9 @@ import (
 )
 
 var (
-	defaultTargetGroupTargetCols = []string{"TargetIp", "TargetPort", "Weight", "HealthCheckEnabled", "MaintenanceEnabled"}
+	defaultTargetGroupTargetCols = []string{
+		"TargetIp", "TargetPort", "Weight", "HealthCheckEnabled", "MaintenanceEnabled",
+	}
 )
 
 func TargetGroupTargetCmd() *core.Command {
@@ -43,37 +45,50 @@ func TargetGroupTargetCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, targetGroupTargetCmd, core.CommandBuilder{
-		Namespace:  "targetgroup",
-		Resource:   "target",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Target Groups Targets",
-		LongDesc:   "Use this command to get a list of Target Groups Targets.",
-		Example:    listTargetGroupTargetExample,
-		PreCmdRun:  PreRunTargetGroupId,
-		CmdRun:     RunTargetGroupTargetList,
-		InitClient: true,
-	})
-	list.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	list := core.NewCommand(
+		ctx, targetGroupTargetCmd, core.CommandBuilder{
+			Namespace:  "targetgroup",
+			Resource:   "target",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Target Groups Targets",
+			LongDesc:   "Use this command to get a list of Target Groups Targets.",
+			Example:    listTargetGroupTargetExample,
+			PreCmdRun:  PreRunTargetGroupId,
+			CmdRun:     RunTargetGroupTargetList,
+			InitClient: true,
+		},
+	)
+	list.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols),
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Add Command
 	*/
-	add := core.NewCommand(ctx, targetGroupTargetCmd, core.CommandBuilder{
-		Namespace: "targetgroup",
-		Resource:  "target",
-		Verb:      "add",
-		Aliases:   []string{"a"},
-		ShortDesc: "Add a Target to a Target Group",
-		LongDesc: `Use this command to add a Target to a Target Group. You will need to provide the IP, the port and the weight. Weight parameter is used to adjust the target VM's weight relative to other target VMs. All target VMs will receive a load proportional to their weight relative to the sum of all weights, so the higher the weight, the higher the load. The default weight is 1, and the maximal value is 256. A value of 0 means the target VM will not participate in load-balancing but will still accept persistent connections. If this parameter is used to distribute the load according to target VM's capacity, it is recommended to start with values which can both grow and shrink, for instance between 10 and 100 to leave enough room above and below for later adjustments.
+	add := core.NewCommand(
+		ctx, targetGroupTargetCmd, core.CommandBuilder{
+			Namespace: "targetgroup",
+			Resource:  "target",
+			Verb:      "add",
+			Aliases:   []string{"a"},
+			ShortDesc: "Add a Target to a Target Group",
+			LongDesc: `Use this command to add a Target to a Target Group. You will need to provide the IP, the port and the weight. Weight parameter is used to adjust the target VM's weight relative to other target VMs. All target VMs will receive a load proportional to their weight relative to the sum of all weights, so the higher the weight, the higher the load. The default weight is 1, and the maximal value is 256. A value of 0 means the target VM will not participate in load-balancing but will still accept persistent connections. If this parameter is used to distribute the load according to target VM's capacity, it is recommended to start with values which can both grow and shrink, for instance between 10 and 100 to leave enough room above and below for later adjustments.
 
 Health Check can also be set. The ` + "`" + `--check` + "`" + ` option specifies whether the target VM's health is checked. If turned off, a target VM is always considered available. If turned on, the target VM is available when accepting periodic TCP connections, to ensure that it is really able to serve requests. The address and port to send the tests to are those of the target VM. The health check only consists of a connection attempt.
 
@@ -84,55 +99,106 @@ Required values to run command:
 * Target Group Id
 * Target Ip
 * Target Port`,
-		Example:    addTargetGroupTargetExample,
-		PreCmdRun:  PreRunTargetGroupIdTargetIpPort,
-		CmdRun:     RunTargetGroupTargetAdd,
-		InitClient: true,
-	})
-	add.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = add.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+			Example:    addTargetGroupTargetExample,
+			PreCmdRun:  PreRunTargetGroupIdTargetIpPort,
+			CmdRun:     RunTargetGroupTargetAdd,
+			InitClient: true,
+		},
+	)
+	add.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	add.AddIpFlag(cloudapiv6.ArgIp, "", nil, "The IP of the balanced target VM.", core.RequiredFlagOption())
-	add.AddIntFlag(cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, 8080, "The port of the balanced target service; valid range is 1 to 65535.", core.RequiredFlagOption())
-	add.AddIntFlag(cloudapiv6.ArgWeight, cloudapiv6.ArgWeightShort, 1, "Traffic is distributed in proportion to target weight, relative to the combined weight of all targets. A target with higher weight receives a greater share of traffic. Valid range is 0 to 256 and default is 1; targets with weight of 0 do not participate in load balancing but still accept persistent connections. It is best use values in the middle of the range to leave room for later adjustments.")
-	add.AddBoolFlag(cloudapiv6.ArgHealthCheckEnabled, "", true, "Makes the target available only if it accepts periodic health check TCP connection attempts; when turned off, the target is considered always available. The health check only consists of a connection attempt to the address and port of the target. Default is True.")
-	add.AddBoolFlag(cloudapiv6.ArgMaintenanceEnabled, cloudapiv6.ArgMaintenanceShort, false, "Maintenance mode prevents the target from receiving balanced traffic.")
-	add.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Target Group Target addition to be executed")
-	add.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Target Group Target addition [seconds]")
-	add.AddStringSliceFlag(constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols))
-	_ = add.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	add.AddIntFlag(
+		cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, 8080,
+		"The port of the balanced target service; valid range is 1 to 65535.", core.RequiredFlagOption(),
+	)
+	add.AddIntFlag(
+		cloudapiv6.ArgWeight, cloudapiv6.ArgWeightShort, 1,
+		"Traffic is distributed in proportion to target weight, relative to the combined weight of all targets. A target with higher weight receives a greater share of traffic. Valid range is 0 to 256 and default is 1; targets with weight of 0 do not participate in load balancing but still accept persistent connections. It is best use values in the middle of the range to leave room for later adjustments.",
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgHealthCheckEnabled, "", true,
+		"Makes the target available only if it accepts periodic health check TCP connection attempts; when turned off, the target is considered always available. The health check only consists of a connection attempt to the address and port of the target. Default is True.",
+	)
+	add.AddBoolFlag(
+		cloudapiv6.ArgMaintenanceEnabled, cloudapiv6.ArgMaintenanceShort, false,
+		"Maintenance mode prevents the target from receiving balanced traffic.",
+	)
+	add.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Target Group Target addition to be executed",
+	)
+	add.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Target Group Target addition [seconds]",
+	)
+	add.AddStringSliceFlag(
+		constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols),
+	)
+	_ = add.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Remove Command
 	*/
-	remove := core.NewCommand(ctx, targetGroupTargetCmd, core.CommandBuilder{
-		Namespace:  "targetgroup",
-		Resource:   "target",
-		Verb:       "remove",
-		Aliases:    []string{"r"},
-		ShortDesc:  "Remove a Target from a Target Group",
-		LongDesc:   "Use this command to delete the specified Target from Target Group.\n\nRequired values to run command:\n\n* Target Group Id\n* Target Ip\n* Target Port",
-		Example:    removeTargetGroupTargetExample,
-		PreCmdRun:  PreRunTargetGroupTargetRemove,
-		CmdRun:     RunTargetGroupTargetRemove,
-		InitClient: true,
-	})
-	remove.AddUUIDFlag(cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption())
-	_ = remove.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgTargetGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	remove := core.NewCommand(
+		ctx, targetGroupTargetCmd, core.CommandBuilder{
+			Namespace:  "targetgroup",
+			Resource:   "target",
+			Verb:       "remove",
+			Aliases:    []string{"r"},
+			ShortDesc:  "Remove a Target from a Target Group",
+			LongDesc:   "Use this command to delete the specified Target from Target Group.\n\nRequired values to run command:\n\n* Target Group Id\n* Target Ip\n* Target Port",
+			Example:    removeTargetGroupTargetExample,
+			PreCmdRun:  PreRunTargetGroupTargetRemove,
+			CmdRun:     RunTargetGroupTargetRemove,
+			InitClient: true,
+		},
+	)
+	remove.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	remove.AddUUIDFlag(
+		cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIdShort, "", cloudapiv6.TargetGroupId, core.RequiredFlagOption(),
+	)
+	_ = remove.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgTargetGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TargetGroupIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	remove.AddIpFlag(cloudapiv6.ArgIp, "", nil, "IP of a balanced target VM", core.RequiredFlagOption())
-	remove.AddIntFlag(cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, 8080, "Port of the balanced target service. (range: 1 to 65535)", core.RequiredFlagOption())
+	remove.AddIntFlag(
+		cloudapiv6.ArgPort, cloudapiv6.ArgPortShort, 8080, "Port of the balanced target service. (range: 1 to 65535)",
+		core.RequiredFlagOption(),
+	)
 	remove.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Target Group Targets")
-	remove.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Target Group Target deletion to be executed")
-	remove.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Target Group Target deletion [seconds]")
-	remove.AddStringSliceFlag(constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols))
-	_ = remove.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	remove.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Target Group Target deletion to be executed",
+	)
+	remove.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Target Group Target deletion [seconds]",
+	)
+	remove.AddStringSliceFlag(
+		constants.ArgCols, "", defaultTargetGroupTargetCols, tabheaders.ColsMessage(defaultTargetGroupTargetCols),
+	)
+	_ = remove.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultTargetGroupTargetCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	return targetGroupTargetCmd
 }
@@ -142,20 +208,35 @@ func PreRunTargetGroupIdTargetIpPort(c *core.PreCommandConfig) error {
 }
 
 func PreRunTargetGroupTargetRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgIp, cloudapiv6.ArgPort},
 		[]string{cloudapiv6.ArgTargetGroupId, cloudapiv6.ArgAll},
 	)
 }
 
 func RunTargetGroupTargetList(c *core.CommandConfig) error {
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Targets from TargetGroup"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Targets from TargetGroup"),
+	)
 
-	targetGroups, resp, err := c.CloudApiV6Services.TargetGroups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), resources.QueryParams{})
+	targetGroups, resp, err := c.CloudApiV6Services.TargetGroups().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), resources.QueryParams{},
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -165,8 +246,10 @@ func RunTargetGroupTargetList(c *core.CommandConfig) error {
 		if targets, ok := properties.GetTargetsOk(); ok && targets != nil {
 			cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-			out, err := jsontabwriter.GenerateOutput("", jsonpaths.TargetGroupTarget, *targets,
-				tabheaders.GetHeadersAllDefault(defaultTargetGroupTargetCols, cols))
+			out, err := jsontabwriter.GenerateOutput(
+				"", jsonpaths.TargetGroupTarget, *targets,
+				tabheaders.GetHeadersAllDefault(defaultTargetGroupTargetCols, cols),
+			)
 			if err != nil {
 				return err
 			}
@@ -191,17 +274,28 @@ func RunTargetGroupTargetAdd(c *core.CommandConfig) error {
 	var targetItems []ionoscloud.TargetGroupTarget
 
 	// Get existing Targets from the specified Target Group
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting TargetGroup"))
 
-	targetGroupOld, resp, err := c.CloudApiV6Services.TargetGroups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), queryParams)
+	targetGroupOld, resp, err := c.CloudApiV6Services.TargetGroups().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), queryParams,
+	)
 	if err != nil {
 		return err
 	}
 
 	if properties, ok := targetGroupOld.GetPropertiesOk(); ok && properties != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Targets from TargetGroup"))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Targets from TargetGroup"),
+		)
 
 		if targets, ok := properties.GetTargetsOk(); ok && targets != nil {
 			targetItems = *targets
@@ -211,14 +305,20 @@ func RunTargetGroupTargetAdd(c *core.CommandConfig) error {
 	targetNew := getTargetGroupTargetInfo(c)
 
 	// Add new Target to the existing Targets in a Target Group
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding new Target to existing Targets"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Adding new Target to existing Targets"),
+	)
 
 	targetItems = append(targetItems, targetNew.TargetGroupTarget)
 
 	// Update Target Group with the new Targets
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating TargetGroup with the new Targets"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Updating TargetGroup with the new Targets"),
+	)
 
-	_, resp, err = c.CloudApiV6Services.TargetGroups().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+	_, resp, err = c.CloudApiV6Services.TargetGroups().Update(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
 		&resources.TargetGroupProperties{
 			TargetGroupProperties: ionoscloud.TargetGroupProperties{
 				Targets: &targetItems,
@@ -227,7 +327,10 @@ func RunTargetGroupTargetAdd(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -239,8 +342,10 @@ func RunTargetGroupTargetAdd(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.TargetGroupTarget, targetNew.TargetGroupTarget,
-		tabheaders.GetHeadersAllDefault(defaultTargetGroupTargetCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.TargetGroupTarget, targetNew.TargetGroupTarget,
+		tabheaders.GetHeadersAllDefault(defaultTargetGroupTargetCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -259,8 +364,11 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 	var resp *resources.Response
 
 	if viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAll)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+			),
+		)
 
 		resp, err = RemoveAllTargetGroupTarget(c)
 		if err != nil {
@@ -270,14 +378,26 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 		return nil
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Target IP: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Target Port: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPort))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.TargetGroupId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Target IP: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Target Port: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPort)),
+		),
+	)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove target from target group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove target from target group",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -286,7 +406,13 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 	// Get existing Targets from the specified Target Group
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting TargetGroup"))
 
-	targetGroupOld, _, err := c.CloudApiV6Services.TargetGroups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), queryParams)
+	targetGroupOld, _, err := c.CloudApiV6Services.TargetGroups().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), queryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -294,7 +420,10 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 	if propertiesOk, ok := targetGroupOld.GetPropertiesOk(); ok && propertiesOk != nil {
 		if itemsOk, ok := propertiesOk.GetTargetsOk(); ok && itemsOk != nil {
 			// Remove specified Target from Target Group
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Removing Target from existing Targets"))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Removing Target from existing Targets"),
+			)
 
 			newTargets, err := getTargetGroupTargetsRemove(c, itemsOk)
 			if err != nil {
@@ -307,11 +436,23 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 	}
 
 	// Update Target Group with the new Targets
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updating TargetGroup with the new Targets"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Updating TargetGroup with the new Targets"),
+	)
 
-	_, resp, err = c.CloudApiV6Services.TargetGroups().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), &propertiesUpdated, queryParams)
+	_, resp, err = c.CloudApiV6Services.TargetGroups().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), &propertiesUpdated, queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -321,14 +462,22 @@ func RunTargetGroupTargetRemove(c *core.CommandConfig) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Target Group Target successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Target Group Target successfully deleted"),
+	)
 	return nil
 }
 
 func RemoveAllTargetGroupTarget(c *core.CommandConfig) (*resources.Response, error) {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Target Group Targets to be deleted:"))
 
-	applicationLoadBalancerRules, resp, err := c.CloudApiV6Services.TargetGroups().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgTargetGroupId)), cloudapiv6.ParentResourceQueryParams)
+	applicationLoadBalancerRules, resp, err := c.CloudApiV6Services.TargetGroups().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgTargetGroupId,
+			),
+		), cloudapiv6.ParentResourceQueryParams,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -345,16 +494,24 @@ func RemoveAllTargetGroupTarget(c *core.CommandConfig) (*resources.Response, err
 			}
 
 			if typeOk, ok := httpRuleOk.GetPortOk(); ok && typeOk != nil {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Target Port: %v", strconv.Itoa(int(*typeOk))))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Target Port: %v", strconv.Itoa(int(*typeOk))),
+				)
 			}
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Targets from Target Group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Targets from Target Group",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return nil, fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Target Group Targets..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all the Target Group Targets..."),
+	)
 
 	propertiesOk.SetTargets([]ionoscloud.TargetGroupTarget{})
 
@@ -364,8 +521,13 @@ func RemoveAllTargetGroupTarget(c *core.CommandConfig) (*resources.Response, err
 		resources.QueryParams{},
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Request Id: %v", request.GetId(resp)),
+		)
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return nil, err
@@ -375,7 +537,9 @@ func RemoveAllTargetGroupTarget(c *core.CommandConfig) (*resources.Response, err
 		return nil, err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Target Group Targets successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Target Group Targets successfully deleted"),
+	)
 	return resp, err
 }
 
@@ -383,29 +547,48 @@ func getTargetGroupTargetInfo(c *core.CommandConfig) resources.TargetGroupTarget
 	target := resources.TargetGroupTarget{}
 
 	target.SetIp(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Ip for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Ip for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgIp)),
+		),
+	)
 
 	target.SetPort(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgPort)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Port for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPort))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Port for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPort)),
+		),
+	)
 
 	target.SetWeight(viper.GetInt32(core.GetFlagName(c.NS, cloudapiv6.ArgWeight)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property Weight for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgWeight))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property Weight for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgWeight)),
+		),
+	)
 
 	target.SetMaintenanceEnabled(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgMaintenanceEnabled)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property MaintenanceEnabled for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMaintenanceEnabled))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property MaintenanceEnabled for Target set: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgMaintenanceEnabled)),
+		),
+	)
 
 	target.SetHealthCheckEnabled(viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgHealthCheckEnabled)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Property HealthCheckEnabled for Target set: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgHealthCheckEnabled))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Property HealthCheckEnabled for Target set: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgHealthCheckEnabled)),
+		),
+	)
 
 	return target
 }
 
-func getTargetGroupTargetsRemove(c *core.CommandConfig, targetsOld *[]ionoscloud.TargetGroupTarget) (*[]ionoscloud.TargetGroupTarget, error) {
+func getTargetGroupTargetsRemove(
+	c *core.CommandConfig, targetsOld *[]ionoscloud.TargetGroupTarget,
+) (*[]ionoscloud.TargetGroupTarget, error) {
 	var (
 		foundIp   = false
 		foundPort = false

--- a/commands/cloudapi-v6/targetgroup_target_test.go
+++ b/commands/cloudapi-v6/targetgroup_target_test.go
@@ -61,445 +61,552 @@ func TestTargetGroupTargetCmd(t *testing.T) {
 func TestPreRunTargetGroupIdTargetIpPort(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		err := PreRunTargetGroupIdTargetIpPort(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			err := PreRunTargetGroupIdTargetIpPort(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupIdTargetIpPortErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunTargetGroupIdTargetIpPort(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunTargetGroupIdTargetIpPort(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupTargetRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		err := PreRunTargetGroupTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			err := PreRunTargetGroupTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupTargetRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		err := PreRunTargetGroupTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			err := PreRunTargetGroupTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupTargetRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		err := PreRunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			err := PreRunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		err := RunTargetGroupTargetList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			err := RunTargetGroupTargetList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetListResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
-		err := RunTargetGroupTargetList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
+			err := RunTargetGroupTargetList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetListGetTargetsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, nil)
-		err := RunTargetGroupTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			err := RunTargetGroupTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetListGetPropertiesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.TargetGroup{}, nil, nil)
-		err := RunTargetGroupTargetList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.TargetGroup{}, nil, nil)
+			err := RunTargetGroupTargetList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		err := RunTargetGroupTargetAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther,
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			err := RunTargetGroupTargetAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetAddResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
-		err := RunTargetGroupTargetAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther,
+			).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
+			err := RunTargetGroupTargetAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther,
+			).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetAddGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetAddWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunTargetGroupTargetAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgWeight), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMaintenanceEnabled), testTargetGroupTargetBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgHealthCheckEnabled), testTargetGroupTargetBoolVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar, &testTargetGroupTargetProperties, testQueryParamOther,
+			).Return(&testTargetGroupTargetGetUpdated, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunTargetGroupTargetAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar,
-			&resources.TargetGroupProperties{
-				TargetGroupProperties: ionoscloud.TargetGroupProperties{
-					Targets: &[]ionoscloud.TargetGroupTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar,
+				&resources.TargetGroupProperties{
+					TargetGroupProperties: ionoscloud.TargetGroupProperties{
+						Targets: &[]ionoscloud.TargetGroupTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testTargetGroupTargetGet, nil, nil)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar,
-			&resources.TargetGroupProperties{
-				TargetGroupProperties: ionoscloud.TargetGroupProperties{
-					Targets: &[]ionoscloud.TargetGroupTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar,
+				&resources.TargetGroupProperties{
+					TargetGroupProperties: ionoscloud.TargetGroupProperties{
+						Targets: &[]ionoscloud.TargetGroupTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testTargetGroupTargetGet, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testTargetGroupTargetGet, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, testTargetGroupTargetErr)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveIpErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), "x.x.x.x")
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), "x.x.x.x")
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemovePortErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), int32(2))
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), int32(2))
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar,
-			&resources.TargetGroupProperties{
-				TargetGroupProperties: ionoscloud.TargetGroupProperties{
-					Targets: &[]ionoscloud.TargetGroupTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar,
+				&resources.TargetGroupProperties{
+					TargetGroupProperties: ionoscloud.TargetGroupProperties{
+						Targets: &[]ionoscloud.TargetGroupTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testTargetGroupTargetGet, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testTargetGroupTargetGet, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar,
-			&resources.TargetGroupProperties{
-				TargetGroupProperties: ionoscloud.TargetGroupProperties{
-					Targets: &[]ionoscloud.TargetGroupTarget{},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar,
+				&resources.TargetGroupProperties{
+					TargetGroupProperties: ionoscloud.TargetGroupProperties{
+						Targets: &[]ionoscloud.TargetGroupTarget{},
+					},
 				},
-			},
-			testQueryParamOther,
-		).Return(&testTargetGroupTargetGet, nil, nil)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+				testQueryParamOther,
+			).Return(&testTargetGroupTargetGet, nil, nil)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGetUpdated, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupTargetVar, gomock.AssignableToTypeOf(&testTargetGroupTargetProperties), gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testTargetGroupTargetGet, &testResponse, nil)
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGetUpdated, nil, nil)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupTargetVar, gomock.AssignableToTypeOf(&testTargetGroupTargetProperties),
+				gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testTargetGroupTargetGet, &testResponse, nil)
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupTargetRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunTargetGroupTargetRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgIp), testTargetGroupTargetVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPort), testTargetGroupTargetIntVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunTargetGroupTargetRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/targetgroup_test.go
+++ b/commands/cloudapi-v6/targetgroup_test.go
@@ -123,388 +123,477 @@ func TestTargetGroupCmd(t *testing.T) {
 func TestPreRunTargetGroupId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		err := PreRunTargetGroupId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			err := PreRunTargetGroupId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunTargetGroupId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunTargetGroupId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		err := PreRunTargetGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			err := PreRunTargetGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunTargetGroupDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		err := PreRunTargetGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			err := PreRunTargetGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, nil)
-		err := RunTargetGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, nil,
+			)
+			err := RunTargetGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, nil)
-		err := RunTargetGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, nil,
+			)
+			err := RunTargetGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupListResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, &testResponse, nil)
-		err := RunTargetGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, &testResponse, nil,
+			)
+			err := RunTargetGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, testTargetGroupErr)
-		err := RunTargetGroupList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, testTargetGroupErr,
+			)
+			err := RunTargetGroupList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupListSort(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testTargetGroupVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, nil)
-		err := RunTargetGroupList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testTargetGroupVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, nil,
+			)
+			err := RunTargetGroupList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&targetGroupTestGet, nil, nil)
-		err := RunTargetGroupGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&targetGroupTestGet, nil, nil)
+			err := RunTargetGroupGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupGetResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&targetGroupTestGet, &testResponse, nil)
-		err := RunTargetGroupGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&targetGroupTestGet, &testResponse, nil)
+			err := RunTargetGroupGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&targetGroupTestGet, nil, testTargetGroupErr)
-		err := RunTargetGroupGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Get(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&targetGroupTestGet, nil, testTargetGroupErr)
+			err := RunTargetGroupGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupRetries)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Create(targetGroupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&targetGroupTestGet, nil, nil)
-		err := RunTargetGroupCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupRetries)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Create(
+				targetGroupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&targetGroupTestGet, nil, nil)
+			err := RunTargetGroupCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupCreateResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupRetries)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Create(targetGroupTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&targetGroupTestGet, &testResponse, nil)
-		err := RunTargetGroupCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupRetries)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Create(
+				targetGroupTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&targetGroupTestGet, &testResponse, nil)
+			err := RunTargetGroupCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupNewTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupNewTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupNewRetries)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupVar, &targetGroupNewProperties, testQueryParamOther).Return(&targetGroupNew, nil, nil)
-		err := RunTargetGroupUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupNewTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupNewTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupNewRetries)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupVar, &targetGroupNewProperties, testQueryParamOther,
+			).Return(&targetGroupNew, nil, nil)
+			err := RunTargetGroupUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupNewTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupNewTimeout)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupNewRetries)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(testTargetGroupVar, &targetGroupNewProperties, testQueryParamOther).Return(&targetGroupNew, nil, testTargetGroupErr)
-		err := RunTargetGroupUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAlgorithm), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgProtocol), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckTimeout), testTargetGroupNewTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCheckInterval), testTargetGroupNewTimeout)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRetries), testTargetGroupNewRetries)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPath), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMatchType), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgResponse), testTargetGroupNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRegex), testTargetGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNegate), testTargetGroupBoolNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Update(
+				testTargetGroupVar, &targetGroupNewProperties, testQueryParamOther,
+			).Return(&targetGroupNew, nil, testTargetGroupErr)
+			err := RunTargetGroupUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunTargetGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunTargetGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunTargetGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, nil,
+			)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunTargetGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, nil)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testTargetGroupTargetErr)
-		err := RunTargetGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, nil,
+			)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testTargetGroupTargetErr)
+			err := RunTargetGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(targetGroups, nil, testTargetGroupTargetErr)
-		err := RunTargetGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				targetGroups, nil, testTargetGroupTargetErr,
+			)
+			err := RunTargetGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testTargetGroupErr)
-		err := RunTargetGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testTargetGroupErr)
+			err := RunTargetGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunTargetGroupDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.TargetGroup.EXPECT().Delete(
+				testTargetGroupVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunTargetGroupDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunTargetGroupDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunTargetGroupDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgTargetGroupId), testTargetGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunTargetGroupDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/user.go
+++ b/commands/cloudapi-v6/user.go
@@ -24,7 +24,10 @@ import (
 )
 
 var (
-	defaultUserCols = []string{"UserId", "Firstname", "Lastname", "Email", "S3CanonicalUserId", "Administrator", "ForceSecAuth", "SecAuthActive", "Active"}
+	defaultUserCols = []string{
+		"UserId", "Firstname", "Lastname", "Email", "S3CanonicalUserId", "Administrator", "ForceSecAuth",
+		"SecAuthActive", "Active",
+	}
 )
 
 func UserCmd() *core.Command {
@@ -42,64 +45,89 @@ func UserCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, userCmd, core.CommandBuilder{
-		Namespace:  "user",
-		Resource:   "user",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Users",
-		LongDesc:   "Use this command to get a list of existing Users available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.UsersFiltersUsage(),
-		Example:    listUserExample,
-		PreCmdRun:  PreRunUserList,
-		CmdRun:     RunUserList,
-		InitClient: true,
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	list := core.NewCommand(
+		ctx, userCmd, core.CommandBuilder{
+			Namespace:  "user",
+			Resource:   "user",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Users",
+			LongDesc:   "Use this command to get a list of existing Users available on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.UsersFiltersUsage(),
+			Example:    listUserExample,
+			PreCmdRun:  PreRunUserList,
+			CmdRun:     RunUserList,
+			InitClient: true,
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultUserCols, tabheaders.ColsMessage(defaultUserCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, userCmd, core.CommandBuilder{
-		Namespace:  "user",
-		Resource:   "user",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a User",
-		LongDesc:   "Use this command to retrieve details about a specific User.\n\nRequired values to run command:\n\n* User Id",
-		Example:    getUserExample,
-		PreCmdRun:  PreRunUserId,
-		CmdRun:     RunUserGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, userCmd, core.CommandBuilder{
+			Namespace:  "user",
+			Resource:   "user",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a User",
+			LongDesc:   "Use this command to retrieve details about a specific User.\n\nRequired values to run command:\n\n* User Id",
+			Example:    getUserExample,
+			PreCmdRun:  PreRunUserId,
+			CmdRun:     RunUserGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, userCmd, core.CommandBuilder{
-		Namespace: "user",
-		Resource:  "user",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a User under a particular contract",
-		LongDesc: `Use this command to create a User under a particular contract. You need to specify the firstname, lastname, email and password for the new User.
+	create := core.NewCommand(
+		ctx, userCmd, core.CommandBuilder{
+			Namespace: "user",
+			Resource:  "user",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a User under a particular contract",
+			LongDesc: `Use this command to create a User under a particular contract. You need to specify the firstname, lastname, email and password for the new User.
 
 Required values to run a command:
 
@@ -107,75 +135,110 @@ Required values to run a command:
 * Last Name
 * Email
 * Password`,
-		Example:    createUserExample,
-		PreCmdRun:  PreRunUserNameEmailPwd,
-		CmdRun:     RunUserCreate,
-		InitClient: true,
-	})
+			Example:    createUserExample,
+			PreCmdRun:  PreRunUserNameEmailPwd,
+			CmdRun:     RunUserCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgFirstName, "", "", "The first name for the User", core.RequiredFlagOption())
 	create.AddStringFlag(cloudapiv6.ArgLastName, "", "", "The last name for the User", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The email for the User", core.RequiredFlagOption())
-	create.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "The password for the User (must be at least 5 characters long)", core.RequiredFlagOption())
+	create.AddStringFlag(
+		cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The email for the User", core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "",
+		"The password for the User (must be at least 5 characters long)", core.RequiredFlagOption(),
+	)
 	create.AddBoolFlag(cloudapiv6.ArgAdmin, "", false, "Assigns the User to have administrative rights")
-	create.AddBoolFlag(cloudapiv6.ArgForceSecAuth, "", false, "Indicates if secure (two-factor) authentication should be forced for the User")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddBoolFlag(
+		cloudapiv6.ArgForceSecAuth, "", false,
+		"Indicates if secure (two-factor) authentication should be forced for the User",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, userCmd, core.CommandBuilder{
-		Namespace: "user",
-		Resource:  "user",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a User",
-		LongDesc: `Use this command to update details about a specific User including their privileges.
+	update := core.NewCommand(
+		ctx, userCmd, core.CommandBuilder{
+			Namespace: "user",
+			Resource:  "user",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a User",
+			LongDesc: `Use this command to update details about a specific User including their privileges.
 
 Required values to run command:
 
 * User Id`,
-		Example:    updateUserExample,
-		PreCmdRun:  PreRunUserId,
-		CmdRun:     RunUserUpdate,
-		InitClient: true,
-	})
+			Example:    updateUserExample,
+			PreCmdRun:  PreRunUserId,
+			CmdRun:     RunUserUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgFirstName, "", "", "The first name for the User")
 	update.AddStringFlag(cloudapiv6.ArgLastName, "", "", "The last name for the User")
 	update.AddStringFlag(cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The email for the User")
-	update.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "The password for the User (must be at least 5 characters long)")
-	update.AddBoolFlag(cloudapiv6.ArgAdmin, "", false, "Assigns the User to have administrative rights. E.g.: --admin=true, --admin=false")
-	update.AddBoolFlag(cloudapiv6.ArgForceSecAuth, "", false, "Indicates if secure (two-factor) authentication should be forced for the User. E.g.: --force-secure-auth=true, --force-secure-auth=false")
+	update.AddStringFlag(
+		cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "",
+		"The password for the User (must be at least 5 characters long)",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgAdmin, "", false,
+		"Assigns the User to have administrative rights. E.g.: --admin=true, --admin=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgForceSecAuth, "", false,
+		"Indicates if secure (two-factor) authentication should be forced for the User. E.g.: --force-secure-auth=true, --force-secure-auth=false",
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, userCmd, core.CommandBuilder{
-		Namespace: "user",
-		Resource:  "user",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Blacklists the User, disabling them",
-		LongDesc: `This command blacklists the User, disabling them. The User is not completely purged, therefore if you anticipate needing to create a User with the same name in the future, we suggest renaming the User before you delete it.
+	deleteCmd := core.NewCommand(
+		ctx, userCmd, core.CommandBuilder{
+			Namespace: "user",
+			Resource:  "user",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Blacklists the User, disabling them",
+			LongDesc: `This command blacklists the User, disabling them. The User is not completely purged, therefore if you anticipate needing to create a User with the same name in the future, we suggest renaming the User before you delete it.
 
 Required values to run command:
 
 * User Id`,
-		Example:    deleteUserExample,
-		PreCmdRun:  PreRunUserDelete,
-		CmdRun:     RunUserDelete,
-		InitClient: true,
-	})
+			Example:    deleteUserExample,
+			PreCmdRun:  PreRunUserDelete,
+			CmdRun:     RunUserDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Users.")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	userCmd.AddCommand(UserS3keyCmd())
 
@@ -194,14 +257,17 @@ func PreRunUserId(c *core.PreCommandConfig) error {
 }
 
 func PreRunUserDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgUserId},
 		[]string{cloudapiv6.ArgAll},
 	)
 }
 
 func PreRunUserNameEmailPwd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgFirstName, cloudapiv6.ArgLastName, cloudapiv6.ArgEmail, cloudapiv6.ArgPassword)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgFirstName, cloudapiv6.ArgLastName, cloudapiv6.ArgEmail, cloudapiv6.ArgPassword,
+	)
 }
 
 func RunUserList(c *core.CommandConfig) error {
@@ -213,7 +279,10 @@ func RunUserList(c *core.CommandConfig) error {
 
 	users, resp, err := c.CloudApiV6Services.Users().List(listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -221,8 +290,10 @@ func RunUserList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.User, users.Users,
-		tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.User, users.Users,
+		tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -240,12 +311,20 @@ func RunUserGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"User with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"User with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)),
+		),
+	)
 
-	u, resp, err := c.CloudApiV6Services.Users().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), queryParams)
+	u, resp, err := c.CloudApiV6Services.Users().Get(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), queryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -253,7 +332,9 @@ func RunUserGet(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.User, u.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.User, u.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -290,14 +371,20 @@ func RunUserCreate(c *core.CommandConfig) error {
 		},
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the user: Firstname: %v, Lastname: %v, Email: %v, ForceSecAuth: %v, Administrator: %v",
-		firstname, lastname, email, secureAuth, admin))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the user: Firstname: %v, Lastname: %v, Email: %v, ForceSecAuth: %v, Administrator: %v",
+			firstname, lastname, email, secureAuth, admin,
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Creating User..."))
 
 	u, resp, err := c.CloudApiV6Services.Users().Create(newUser, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -305,7 +392,9 @@ func RunUserCreate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.User, u.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.User, u.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -322,19 +411,37 @@ func RunUserUpdate(c *core.CommandConfig) error {
 	}
 
 	queryParams := listQueryParams.QueryParams
-	oldUser, resp, err := c.CloudApiV6Services.Users().Get(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), queryParams)
+	oldUser, resp, err := c.CloudApiV6Services.Users().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgUserId,
+			),
+		), queryParams,
+	)
 	if err != nil {
 		return err
 	}
 
 	newUser := getUserInfo(oldUser, c)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Updating User with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Updating User with ID: %v...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)),
+		),
+	)
 
-	userUpd, resp, err := c.CloudApiV6Services.Users().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId)), *newUser, queryParams)
+	userUpd, resp, err := c.CloudApiV6Services.Users().Update(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgUserId,
+			),
+		), *newUser, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -342,7 +449,9 @@ func RunUserUpdate(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.User, userUpd.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.User, userUpd.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -369,15 +478,23 @@ func RunUserDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete user", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete user", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting User with id: %v...", userId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting User with id: %v...", userId),
+	)
 
 	resp, err := c.CloudApiV6Services.Users().Delete(userId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -396,7 +513,10 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgFirstName)) {
 			firstName := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgFirstName))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property FirstName set: %v", firstName))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property FirstName set: %v", firstName),
+			)
 
 			userPropertiesPut.SetFirstname(firstName)
 		} else {
@@ -408,7 +528,10 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgLastName)) {
 			lastName := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLastName))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property LastName set: %v", lastName))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property LastName set: %v", lastName),
+			)
 
 			userPropertiesPut.SetLastname(lastName)
 		} else {
@@ -420,7 +543,9 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgEmail)) {
 			email := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgEmail))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Email set: %v", email))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Email set: %v", email),
+			)
 
 			userPropertiesPut.SetEmail(email)
 		} else {
@@ -432,7 +557,10 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPassword)) {
 			password := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgPassword))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Password set: %v", password))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Password set: %v", password),
+			)
 
 			userPropertiesPut.SetPassword(password)
 		}
@@ -440,7 +568,10 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgForceSecAuth)) {
 			forceSecureAuth := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgForceSecAuth))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ForceSecAuth set: %v", forceSecureAuth))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property ForceSecAuth set: %v", forceSecureAuth),
+			)
 
 			userPropertiesPut.SetForceSecAuth(forceSecureAuth)
 		} else {
@@ -452,7 +583,10 @@ func getUserInfo(oldUser *resources.User, c *core.CommandConfig) *resources.User
 		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgAdmin)) {
 			admin := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgAdmin))
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Administrator set: %v", admin))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Property Administrator set: %v", admin),
+			)
 
 			userPropertiesPut.SetAdministrator(admin)
 		} else {
@@ -514,7 +648,9 @@ func DeleteAllUsers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Users", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Users", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -527,7 +663,10 @@ func DeleteAllUsers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting User with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting User with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Users().Delete(*id, queryParams)
 		if err != nil {
@@ -535,7 +674,10 @@ func DeleteAllUsers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
@@ -566,92 +708,143 @@ func GroupUserCmd() *core.Command {
 	/*
 		List Users Command
 	*/
-	listUsers := core.NewCommand(ctx, groupUserCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "user",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Users from a Group",
-		LongDesc:   "Use this command to get a list of Users from a specific Group.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.UsersFiltersUsage(),
-		Example:    listGroupUsersExample,
-		PreCmdRun:  PreRunGroupId,
-		CmdRun:     RunGroupUserList,
-		InitClient: true,
-	})
+	listUsers := core.NewCommand(
+		ctx, groupUserCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "user",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Users from a Group",
+			LongDesc:   "Use this command to get a list of Users from a specific Group.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.UsersFiltersUsage(),
+			Example:    listGroupUsersExample,
+			PreCmdRun:  PreRunGroupId,
+			CmdRun:     RunGroupUserList,
+			InitClient: true,
+		},
+	)
 	listUsers.AddStringSliceFlag(constants.ArgCols, "", defaultUserCols, tabheaders.ColsMessage(defaultUserCols))
-	_ = listUsers.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listUsers.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	listUsers.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = listUsers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	listUsers.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	listUsers.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = listUsers.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listUsers.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	listUsers.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	listUsers.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = listUsers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	listUsers.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = listUsers.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listUsers.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listUsers.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = listUsers.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Add User Command
 	*/
-	addUser := core.NewCommand(ctx, groupUserCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "user",
-		Verb:       "add",
-		Aliases:    []string{"a"},
-		ShortDesc:  "Add User to a Group",
-		LongDesc:   "Use this command to add an existing User to a specific Group.\n\nRequired values to run command:\n\n* Group Id\n* User Id",
-		Example:    addGroupUserExample,
-		PreCmdRun:  PreRunGroupUserIds,
-		CmdRun:     RunGroupUserAdd,
-		InitClient: true,
-	})
+	addUser := core.NewCommand(
+		ctx, groupUserCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "user",
+			Verb:       "add",
+			Aliases:    []string{"a"},
+			ShortDesc:  "Add User to a Group",
+			LongDesc:   "Use this command to add an existing User to a specific Group.\n\nRequired values to run command:\n\n* Group Id\n* User Id",
+			Example:    addGroupUserExample,
+			PreCmdRun:  PreRunGroupUserIds,
+			CmdRun:     RunGroupUserAdd,
+			InitClient: true,
+		},
+	)
 	addUser.AddStringSliceFlag(constants.ArgCols, "", defaultUserCols, tabheaders.ColsMessage(defaultUserCols))
-	_ = addUser.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addUser.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addUser.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = addUser.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addUser.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	addUser.AddUUIDFlag(cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = addUser.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = addUser.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.UsersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Remove User Command
 	*/
-	removeUser := core.NewCommand(ctx, groupUserCmd, core.CommandBuilder{
-		Namespace:  "group",
-		Resource:   "user",
-		Verb:       "remove",
-		Aliases:    []string{"r"},
-		ShortDesc:  "Remove User from a Group",
-		LongDesc:   "Use this command to remove a User from a Group.\n\nRequired values to run command:\n\n* Group Id\n* User Id",
-		Example:    removeGroupUserExample,
-		PreCmdRun:  PreRunGroupUserRemove,
-		CmdRun:     RunGroupUserRemove,
-		InitClient: true,
-	})
+	removeUser := core.NewCommand(
+		ctx, groupUserCmd, core.CommandBuilder{
+			Namespace:  "group",
+			Resource:   "user",
+			Verb:       "remove",
+			Aliases:    []string{"r"},
+			ShortDesc:  "Remove User from a Group",
+			LongDesc:   "Use this command to remove a User from a Group.\n\nRequired values to run command:\n\n* Group Id\n* User Id",
+			Example:    removeGroupUserExample,
+			PreCmdRun:  PreRunGroupUserRemove,
+			CmdRun:     RunGroupUserRemove,
+			InitClient: true,
+		},
+	)
+	removeUser.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	removeUser.AddStringSliceFlag(constants.ArgCols, "", defaultUserCols, tabheaders.ColsMessage(defaultUserCols))
-	_ = removeUser.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeUser.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return defaultUserCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeUser.AddUUIDFlag(cloudapiv6.ArgGroupId, "", "", cloudapiv6.GroupId, core.RequiredFlagOption())
-	_ = removeUser.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgGroupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	removeUser.AddUUIDFlag(cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption())
-	_ = removeUser.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgUserId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.GroupUsersIds(viper.GetString(core.GetFlagName(removeUser.NS, cloudapiv6.ArgGroupId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = removeUser.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgGroupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	removeUser.AddUUIDFlag(
+		cloudapiv6.ArgUserId, cloudapiv6.ArgIdShort, "", cloudapiv6.UserId, core.RequiredFlagOption(),
+	)
+	_ = removeUser.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgUserId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.GroupUsersIds(
+				viper.GetString(
+					core.GetFlagName(
+						removeUser.NS, cloudapiv6.ArgGroupId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	removeUser.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all Users from a group.")
 
 	return groupUserCmd
@@ -664,9 +857,18 @@ func RunGroupUserList(c *core.CommandConfig) error {
 		return err
 	}
 
-	users, resp, err := c.CloudApiV6Services.Groups().ListUsers(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId)), listQueryParams)
+	users, resp, err := c.CloudApiV6Services.Groups().ListUsers(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgGroupId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -674,8 +876,10 @@ func RunGroupUserList(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.User, users.GroupMembers,
-		tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.User, users.GroupMembers,
+		tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -686,7 +890,8 @@ func RunGroupUserList(c *core.CommandConfig) error {
 }
 
 func PreRunGroupUserRemove(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgGroupId, cloudapiv6.ArgUserId},
 		[]string{cloudapiv6.ArgGroupId, cloudapiv6.ArgAll},
 	)
@@ -702,7 +907,10 @@ func RunGroupUserAdd(c *core.CommandConfig) error {
 	id := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))
 	groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("User with id: %v is adding to group with id: %v...", id, groupId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("User with id: %v is adding to group with id: %v...", id, groupId),
+	)
 
 	u := resources.User{
 		User: ionoscloud.User{
@@ -712,7 +920,10 @@ func RunGroupUserAdd(c *core.CommandConfig) error {
 
 	userAdded, resp, err := c.CloudApiV6Services.Groups().AddUser(groupId, u, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -720,7 +931,9 @@ func RunGroupUserAdd(c *core.CommandConfig) error {
 
 	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.User, userAdded.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.User, userAdded.User, tabheaders.GetHeadersAllDefault(defaultUserCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -745,19 +958,28 @@ func RunGroupUserRemove(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove user from group", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove user from group",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	userId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserId))
 	groupId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgGroupId))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"User with id: %v is adding to group with id: %v...", userId, groupId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"User with id: %v is adding to group with id: %v...", userId, groupId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Groups().RemoveUser(groupId, userId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -816,7 +1038,9 @@ func RemoveAllUsers(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "remove all the Users", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "remove all the Users", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -829,18 +1053,27 @@ func RemoveAllUsers(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting removing User with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting removing User with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Groups().RemoveUser(groupId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			return err

--- a/commands/cloudapi-v6/user_test.go
+++ b/commands/cloudapi-v6/user_test.go
@@ -113,444 +113,562 @@ func TestUserCmd(t *testing.T) {
 func TestPreRunUserList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunUserList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunUserList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunUserListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("firstname=%s", testQueryParamVar)})
-		err := PreRunUserList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("firstname=%s", testQueryParamVar)},
+			)
+			err := PreRunUserList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunUserListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunUserList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunUserList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunUserId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		err := PreRunUserId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			err := PreRunUserId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunUserIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunUserId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunUserId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunUserNameEmailPwd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
-		err := PreRunUserNameEmailPwd(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
+			err := PreRunUserNameEmailPwd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunUserNameEmailPwdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		err := PreRunUserNameEmailPwd(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			err := PreRunUserNameEmailPwd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(users, &testResponse, nil)
-		err := RunUserList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				users, &testResponse, nil,
+			)
+			err := RunUserList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Users{}, &testResponse, nil)
-		err := RunUserList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Users{}, &testResponse, nil,
+			)
+			err := RunUserList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(users, nil, testUserErr)
-		err := RunUserList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				users, nil, testUserErr,
+			)
+			err := RunUserList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, &testResponse, nil)
-		err := RunUserGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, &testResponse, nil)
+			err := RunUserGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, testUserErr)
-		err := RunUserGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, testUserErr)
+			err := RunUserGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Create(userTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, &testResponse, nil)
-		err := RunUserCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Create(
+				userTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, &testResponse, nil)
+			err := RunUserCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserCreateResponseErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Create(userTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, &testResponse, testUserErr)
-		err := RunUserCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Create(
+				userTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, &testResponse, testUserErr)
+			err := RunUserCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Create(userTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, testUserErr)
-		err := RunUserCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgPassword), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Create(
+				userTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, testUserErr)
+			err := RunUserCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgForceSecAuth), testUserBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAdmin), testUserBoolVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Update(testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userNew, &testResponse, nil)
-		err := RunUserUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgForceSecAuth), testUserBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAdmin), testUserBoolVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, nil)
+			rm.CloudApiV6Mocks.User.EXPECT().Update(
+				testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userNew, &testResponse, nil)
+			err := RunUserUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserUpdateOldUser(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userNew, nil, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Update(testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userNew, nil, nil)
-		err := RunUserUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userNew, nil, nil)
+			rm.CloudApiV6Mocks.User.EXPECT().Update(
+				testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userNew, nil, nil)
+			err := RunUserUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Update(testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userNew, nil, testUserErr)
-		err := RunUserUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, nil)
+			rm.CloudApiV6Mocks.User.EXPECT().Update(
+				testUserVar, userNewPut, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userNew, nil, testUserErr)
+			err := RunUserUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserUpdateGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Get(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, testUserErr)
-		err := RunUserUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFirstName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLastName), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testUserNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testUserNewVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Get(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, testUserErr)
+			err := RunUserUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(usersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				usersList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(usersList, nil, testUserErr)
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				usersList, nil, testUserErr,
+			)
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Users{}, &testResponse, nil)
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Users{}, &testResponse, nil,
+			)
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Users{Users: ionoscloud.Users{Items: &[]ionoscloud.User{}}}, &testResponse, nil)
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				resources.Users{Users: ionoscloud.Users{Items: &[]ionoscloud.User{}}}, &testResponse, nil,
+			)
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(usersList, &testResponse, nil)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testUserErr)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.User.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				usersList, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testUserErr)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testUserErr)
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testUserErr)
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.User.EXPECT().Delete(testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunUserDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.User.EXPECT().Delete(
+				testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunUserDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunUserDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunUserDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunUserDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 // Group Users Test
@@ -571,234 +689,298 @@ var (
 func TestRunGroupUserList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(groupUsersTest, &testResponse, nil)
-		err := RunGroupUserList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(groupUsersTest, &testResponse, nil)
+			err := RunGroupUserList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(groupUsersTest, nil, testGroupErr)
-		err := RunGroupUserList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(groupUsersTest, nil, testGroupErr)
+			err := RunGroupUserList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserAdd(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddUser(testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, &testResponse, nil)
-		err := RunGroupUserAdd(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddUser(
+				testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, &testResponse, nil)
+			err := RunGroupUserAdd(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserAddErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddUser(testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, nil, testUserErr)
-		err := RunGroupUserAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddUser(
+				testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, nil, testUserErr)
+			err := RunGroupUserAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserAddResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().AddUser(testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&userTestGet, &testResponse, testUserErr)
-		err := RunGroupUserAdd(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().AddUser(
+				testGroupVar, groupUserTest, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&userTestGet, &testResponse, testUserErr)
+			err := RunGroupUserAdd(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemove(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupUserRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(groupUsersTestList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(groupUsersTestList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupUserRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(groupUsersTestList, nil, testUserErr)
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(groupUsersTestList, nil, testUserErr)
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.GroupMembers{}, &testResponse, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.GroupMembers{}, &testResponse, nil)
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.GroupMembers{GroupMembers: ionoscloud.GroupMembers{Items: &[]ionoscloud.User{}}}, &testResponse, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.GroupMembers{GroupMembers: ionoscloud.GroupMembers{Items: &[]ionoscloud.User{}}},
+				&testResponse, nil,
+			)
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(testGroupVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(groupUsersTestList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testUserErr)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Group.EXPECT().ListUsers(
+				testGroupVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(groupUsersTestList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testUserErr)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testUserErr)
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testUserErr)
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunGroupUserRemove(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiV6Mocks.Group.EXPECT().RemoveUser(
+				testGroupVar, testUserVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunGroupUserRemove(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunGroupUserRemoveAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunGroupUserRemove(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserId), testUserVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgGroupId), testGroupVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunGroupUserRemove(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -31,8 +31,10 @@ import (
 
 var (
 	defaultVolumeCols = []string{"VolumeId", "Name", "Size", "Type", "LicenceType", "State", "Image"}
-	allVolumeCols     = []string{"VolumeId", "Name", "Size", "Type", "LicenceType", "State", "Image", "Bus", "AvailabilityZone", "BackupunitId",
-		"DeviceNumber", "UserData", "BootServerId", "DatacenterId"}
+	allVolumeCols     = []string{
+		"VolumeId", "Name", "Size", "Type", "LicenceType", "State", "Image", "Bus", "AvailabilityZone", "BackupunitId",
+		"DeviceNumber", "UserData", "BootServerId", "DatacenterId",
+	}
 )
 
 func VolumeCmd() *core.Command {
@@ -49,76 +51,113 @@ func VolumeCmd() *core.Command {
 	globalFlags := volumeCmd.GlobalFlags()
 	globalFlags.StringSliceP(constants.ArgCols, "", defaultVolumeCols, tabheaders.ColsMessage(allVolumeCols))
 	_ = viper.BindPFlag(core.GetFlagName(volumeCmd.Name(), constants.ArgCols), globalFlags.Lookup(constants.ArgCols))
-	_ = volumeCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = volumeCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, volumeCmd, core.CommandBuilder{
-		Namespace:  "volume",
-		Resource:   "volume",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List Volumes",
-		LongDesc:   "Use this command to list all Volumes from a Data Center on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.VolumesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
-		Example:    listVolumeExample,
-		PreCmdRun:  PreRunVolumeList,
-		CmdRun:     RunVolumeList,
-		InitClient: true,
-	})
+	list := core.NewCommand(
+		ctx, volumeCmd, core.CommandBuilder{
+			Namespace:  "volume",
+			Resource:   "volume",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List Volumes",
+			LongDesc:   "Use this command to list all Volumes from a Data Center on your account.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.VolumesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id",
+			Example:    listVolumeExample,
+			PreCmdRun:  PreRunVolumeList,
+			CmdRun:     RunVolumeList,
+			InitClient: true,
+		},
+	)
 	list.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	list.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	list.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	list.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	list.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = list.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	list.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = list.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	list.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, cloudapiv6.ArgListAllDescription)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, volumeCmd, core.CommandBuilder{
-		Namespace:  "volume",
-		Resource:   "volume",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a Volume",
-		LongDesc:   "Use this command to retrieve information about a Volume using its ID.\n\nRequired values to run command:\n\n* Data Center Id\n* Volume Id",
-		Example:    getVolumeExample,
-		PreCmdRun:  PreRunDcVolumeIds,
-		CmdRun:     RunVolumeGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, volumeCmd, core.CommandBuilder{
+			Namespace:  "volume",
+			Resource:   "volume",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a Volume",
+			LongDesc:   "Use this command to retrieve information about a Volume using its ID.\n\nRequired values to run command:\n\n* Data Center Id\n* Volume Id",
+			Example:    getVolumeExample,
+			PreCmdRun:  PreRunDcVolumeIds,
+			CmdRun:     RunVolumeGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	get.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+	_ = get.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						get.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, volumeCmd, core.CommandBuilder{
-		Namespace: "volume",
-		Resource:  "volume",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a Volume",
-		LongDesc: `Use this command to create a Volume on your account, within a Data Center. This will NOT attach the Volume to a Server. Please see the Servers commands for details on how to attach storage Volumes. You can specify the name, size, type, licence type, availability zone, image and other properties for the object.
+	create := core.NewCommand(
+		ctx, volumeCmd, core.CommandBuilder{
+			Namespace: "volume",
+			Resource:  "volume",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a Volume",
+			LongDesc: `Use this command to create a Volume on your account, within a Data Center. This will NOT attach the Volume to a Server. Please see the Servers commands for details on how to attach storage Volumes. You can specify the name, size, type, licence type, availability zone, image and other properties for the object.
 
 NNote: The Licence Type has a default value, but if Image ID or Image Alias is supplied, then Licence Type will be automatically set. The Image Password or SSH Keys attributes can be defined when creating a Volume that uses an Image ID or Image Alias of an IONOS public Image. You may wish to set a valid value for Image Password even when using SSH Keys so that it is possible to authenticate with a password when using the remote console feature of the DCD.
 
@@ -127,75 +166,151 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 Required values to run command:
 
 * Data Center Id`,
-		Example:    createVolumeExample,
-		PreCmdRun:  PreRunVolumeCreate,
-		CmdRun:     RunVolumeCreate,
-		InitClient: true,
-	})
+			Example:    createVolumeExample,
+			PreCmdRun:  PreRunVolumeCreate,
+			CmdRun:     RunVolumeCreate,
+			InitClient: true,
+		},
+	)
 	create.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "Unnamed Volume", "Name of the Volume")
-	create.AddStringFlag(cloudapiv6.ArgSize, cloudapiv6.ArgSizeShort, strconv.Itoa(cloudapiv6.DefaultVolumeSize), "The size of the Volume in GB. e.g.: --size 10 or --size 10GB. The maximum Volume size is determined by your contract limit")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSize, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	create.AddStringFlag(
+		cloudapiv6.ArgSize, cloudapiv6.ArgSizeShort, strconv.Itoa(cloudapiv6.DefaultVolumeSize),
+		"The size of the Volume in GB. e.g.: --size 10 or --size 10GB. The maximum Volume size is determined by your contract limit",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSize,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(cloudapiv6.ArgBus, "", "VIRTIO", "The bus type of the Volume")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBus, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"VIRTIO", "IDE"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBus,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"VIRTIO", "IDE"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddSetFlag(cloudapiv6.ArgLicenceType, "", "LINUX", constants.EnumLicenceType, "Licence Type of the Volume")
 	create.AddStringFlag(constants.FlagType, "", "HDD", "Type of the Volume")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLicenceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HDD", "SSD", "SSD Standard", "SSD Premium"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO", "Availability zone of the Volume. Storage zone can only be selected prior provisioning")
-	_ = create.Command.RegisterFlagCompletionFunc(constants.FlagAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"AUTO", "ZONE_1", "ZONE_2", "ZONE_3"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgBackupUnitId, "", "", "The unique Id of the Backup Unit that User has access to. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "The Image Id or Snapshot Id to be used as template for the new Volume. A password or SSH Key need to be set")
-	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
-			// Completer for HDD images that are in the same location as the datacenter
-			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
-				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
-			if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
-				return ionoscloud.ApiImagesGetRequest{}
-			}
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgLicenceType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HDD", "SSD", "SSD Standard", "SSD Premium"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO",
+		"Availability zone of the Volume. Storage zone can only be selected prior provisioning",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.FlagAvailabilityZone,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"AUTO", "ZONE_1", "ZONE_2", "ZONE_3"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgBackupUnitId, "", "",
+		"The unique Id of the Backup Unit that User has access to. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgBackupUnitId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddUUIDFlag(
+		cloudapiv6.ArgImageId, "", "",
+		"The Image Id or Snapshot Id to be used as template for the new Volume. A password or SSH Key need to be set",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgImageId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ImageIds(
+				func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+					// Completer for HDD images that are in the same location as the datacenter
+					chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(
+						context.Background(),
+						viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId)),
+					).Execute()
+					if err != nil || chosenDc.Properties == nil || chosenDc.Properties.Location == nil {
+						return ionoscloud.ApiImagesGetRequest{}
+					}
 
-			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+					return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
-	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "The Image Alias to set instead of Image Id. A password or SSH Key need to be set")
-	create.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "Initial password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9")
-	create.AddStringFlag(cloudapiv6.ArgUserData, "", "", "The cloud-init configuration for the Volume as base64 encoded string. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property")
-	create.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", false, "It is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false")
-	create.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", false, "It is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false")
-	create.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", false, "It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false")
-	create.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false")
-	create.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", false, "It is capable of Virt-IO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false")
-	create.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "It is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false")
-	create.AddStringFlag(cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, "", "Absolute paths of the SSH Keys for the Volume")
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Volume creation to be executed")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Volume creation [seconds]")
-	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
+	create.AddStringFlag(
+		cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "",
+		"The Image Alias to set instead of Image Id. A password or SSH Key need to be set",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "",
+		"Initial password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgUserData, "", "",
+		"The cloud-init configuration for the Volume as base64 encoded string. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgCpuHotPlug, "", false,
+		"It is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgRamHotPlug, "", false,
+		"It is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgNicHotPlug, "", false,
+		"It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgNicHotUnplug, "", false,
+		"It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotPlug, "", false,
+		"It is capable of Virt-IO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false",
+	)
+	create.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotUnplug, "", false,
+		"It is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false",
+	)
+	create.AddStringFlag(
+		cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, "", "Absolute paths of the SSH Keys for the Volume",
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Volume creation to be executed",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Volume creation [seconds]",
+	)
+	create.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, volumeCmd, core.CommandBuilder{
-		Namespace: "volume",
-		Resource:  "volume",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a Volume",
-		LongDesc: `Use this command to update a Volume. You may increase the size of an existing storage Volume. You cannot reduce the size of an existing storage Volume. The Volume size will be increased without reboot if the appropriate "hot plug" settings have been set to true. The additional capacity is not added to any partition therefore you will need to adjust the partition inside the operating system afterwards.
+	update := core.NewCommand(
+		ctx, volumeCmd, core.CommandBuilder{
+			Namespace: "volume",
+			Resource:  "volume",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a Volume",
+			LongDesc: `Use this command to update a Volume. You may increase the size of an existing storage Volume. You cannot reduce the size of an existing storage Volume. The Volume size will be increased without reboot if the appropriate "hot plug" settings have been set to true. The additional capacity is not added to any partition therefore you will need to adjust the partition inside the operating system afterwards.
 
 Once you have increased the Volume size you cannot decrease the Volume size using the Cloud API. Certain attributes can only be set when a Volume is created and are considered immutable once the Volume has been provisioned.
 
@@ -205,45 +320,93 @@ Required values to run command:
 
 * Data Center Id
 * Volume Id`,
-		Example:    updateVolumeExample,
-		PreCmdRun:  PreRunDcVolumeIds,
-		CmdRun:     RunVolumeUpdate,
-		InitClient: true,
-	})
+			Example:    updateVolumeExample,
+			PreCmdRun:  PreRunDcVolumeIds,
+			CmdRun:     RunVolumeUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(update.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption(),
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Name of the Volume")
-	update.AddStringFlag(cloudapiv6.ArgSize, "", "", "The size of the Volume in GB. e.g. 10 or 10GB. The maximum volume size is determined by your contract limit")
-	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgSize, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	update.AddStringFlag(
+		cloudapiv6.ArgSize, "", "",
+		"The size of the Volume in GB. e.g. 10 or 10GB. The maximum volume size is determined by your contract limit",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgSize,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"10GB", "20GB", "50GB", "100GB", "1TB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(cloudapiv6.ArgBus, "", "VIRTIO", "Bus of the Volume")
-	update.AddBoolFlag(cloudapiv6.ArgCpuHotPlug, "", false, "It is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgRamHotPlug, "", false, "It is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotPlug, "", false, "It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgNicHotUnplug, "", false, "It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotPlug, "", false, "It is capable of Virt-IO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false")
-	update.AddBoolFlag(cloudapiv6.ArgDiscVirtioHotUnplug, "", false, "It is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false")
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Volume update to be executed")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Volume update [seconds]")
-	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
+	update.AddBoolFlag(
+		cloudapiv6.ArgCpuHotPlug, "", false,
+		"It is capable of CPU hot plug (no reboot required). E.g.: --cpu-hot-plug=true, --cpu-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgRamHotPlug, "", false,
+		"It is capable of memory hot plug (no reboot required). E.g.: --ram-hot-plug=true, --ram-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgNicHotPlug, "", false,
+		"It is capable of nic hot plug (no reboot required). E.g.: --nic-hot-plug=true, --nic-hot-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgNicHotUnplug, "", false,
+		"It is capable of nic hot unplug (no reboot required). E.g.: --nic-hot-unplug=true, --nic-hot-unplug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotPlug, "", false,
+		"It is capable of Virt-IO drive hot plug (no reboot required). E.g.: --disc-virtio-plug=true, --disc-virtio-plug=false",
+	)
+	update.AddBoolFlag(
+		cloudapiv6.ArgDiscVirtioHotUnplug, "", false,
+		"It is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. E.g.: --disc-virtio-unplug=true, --disc-virtio-unplug=false",
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Volume update to be executed",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Volume update [seconds]",
+	)
+	update.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, volumeCmd, core.CommandBuilder{
-		Namespace: "volume",
-		Resource:  "volume",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a Volume",
-		LongDesc: `Use this command to delete specified Volume. This will result in the Volume being removed from your Virtual Data Center. Please use this with caution!
+	deleteCmd := core.NewCommand(
+		ctx, volumeCmd, core.CommandBuilder{
+			Namespace: "volume",
+			Resource:  "volume",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a Volume",
+			LongDesc: `Use this command to delete specified Volume. This will result in the Volume being removed from your Virtual Data Center. Please use this with caution!
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -251,29 +414,56 @@ Required values to run command:
 
 * Data Center Id
 * Volume Id`,
-		Example:    deleteVolumeExample,
-		PreCmdRun:  PreRunDcVolumeDelete,
-		CmdRun:     RunVolumeDelete,
-		InitClient: true,
-	})
+			Example:    deleteVolumeExample,
+			PreCmdRun:  PreRunDcVolumeDelete,
+			CmdRun:     RunVolumeDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(deleteCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Volume deletion to be executed")
-	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Volumes from a virtual Datacenter.")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Volume deletion [seconds]")
-	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption(),
+	)
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						deleteCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Volume deletion to be executed",
+	)
+	deleteCmd.AddBoolFlag(
+		cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all Volumes from a virtual Datacenter.",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Volume deletion [seconds]",
+	)
+	deleteCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return volumeCmd
 }
 
 func PreRunVolumeList(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+	if err := core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId},
 		[]string{cloudapiv6.ArgAll},
 	); err != nil {
@@ -290,7 +480,8 @@ func PreRunDcVolumeIds(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcVolumeDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgVolumeId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgAll},
 	)
@@ -317,8 +508,10 @@ func PreRunVolumeCreate(c *core.PreCommandConfig) error {
 			{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgImageAlias},
 		}
 
-		img, _, err := client.Must().CloudClient.ImagesApi.ImagesFindById(context.Background(),
-			viper.GetString(fn)).Execute()
+		img, _, err := client.Must().CloudClient.ImagesApi.ImagesFindById(
+			context.Background(),
+			viper.GetString(fn),
+		).Execute()
 		if err != nil {
 			return fmt.Errorf("failed getting image %s: %w", viper.GetString(fn), err)
 		}
@@ -384,13 +577,18 @@ func RunVolumeListAll(c *core.CommandConfig) error {
 	}
 
 	if totalTime != time.Duration(0) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, totalTime),
+		)
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(allVolumes, allVolumesConverted,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		allVolumes, allVolumesConverted,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -404,8 +602,12 @@ func RunVolumeList(c *core.CommandConfig) error {
 		return RunVolumeListAll(c)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Listing Volumes from Datacenter with ID: %v", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Listing Volumes from Datacenter with ID: %v",
+			viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
 	if err != nil {
@@ -428,9 +630,18 @@ func RunVolumeList(c *core.CommandConfig) error {
 		}
 	}
 
-	volumes, resp, err := c.CloudApiV6Services.Volumes().List(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), listQueryParams)
+	volumes, resp, err := c.CloudApiV6Services.Volumes().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), listQueryParams,
+	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -438,8 +649,10 @@ func RunVolumeList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Volume, volumes.Volumes,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Volume, volumes.Volumes,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -456,10 +669,16 @@ func RunVolumeGet(c *core.CommandConfig) error {
 
 	queryParams := listQueryParams.QueryParams
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId))))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Volume with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.DatacenterId, viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		),
+	)
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Volume with id: %v is getting...", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId)),
+		),
+	)
 
 	vol, resp, err := c.CloudApiV6Services.Volumes().Get(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
@@ -467,7 +686,10 @@ func RunVolumeGet(c *core.CommandConfig) error {
 		queryParams,
 	)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -475,8 +697,10 @@ func RunVolumeGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Volume, vol.Volume,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Volume, vol.Volume,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -498,9 +722,18 @@ func RunVolumeCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	vol, resp, err := c.CloudApiV6Services.Volumes().Create(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)), *input, queryParams)
+	vol, resp, err := c.CloudApiV6Services.Volumes().Create(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, cloudapiv6.ArgDataCenterId,
+			),
+		), *input, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -512,8 +745,10 @@ func RunVolumeCreate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Volume, vol.Volume,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Volume, vol.Volume,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -535,10 +770,15 @@ func RunVolumeUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	vol, resp, err := c.CloudApiV6Services.Volumes().Update(viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
-		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId)), *input, queryParams)
+	vol, resp, err := c.CloudApiV6Services.Volumes().Update(
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgDataCenterId)),
+		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId)), *input, queryParams,
+	)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -550,8 +790,10 @@ func RunVolumeUpdate(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Volume, vol.Volume,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Volume, vol.Volume,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -578,15 +820,23 @@ func RunVolumeDelete(c *core.CommandConfig) error {
 		return nil
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete volume", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete volume", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Volume with id: %v...", volumeId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Starting deleting Volume with id: %v...", volumeId),
+	)
 
 	resp, err := c.CloudApiV6Services.Volumes().Delete(dcId, volumeId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -614,9 +864,12 @@ func getNewVolume(c *core.CommandConfig) (*resources.Volume, error) {
 	proper.SetType(volumeType)
 	proper.SetAvailabilityZone(availabilityZone)
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Properties set for creating the Volume: Name: %v, Bus: %v, VolumeType: %v, AvailabilityZone: %v",
-		name, bus, volumeType, availabilityZone))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Properties set for creating the Volume: Name: %v, Bus: %v, VolumeType: %v, AvailabilityZone: %v",
+			name, bus, volumeType, availabilityZone,
+		),
+	)
 
 	size, err := utils2.ConvertSize(
 		viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgSize)),
@@ -628,14 +881,19 @@ func getNewVolume(c *core.CommandConfig) (*resources.Volume, error) {
 
 	proper.SetSize(float32(size))
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Size set: %vGB", float32(size)))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Size set: %vGB", float32(size)),
+	)
 
 	// Check if flags are set and set options
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId)) {
 		backupUnitId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgBackupUnitId))
 		proper.SetBackupunitId(backupUnitId)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property BackupUnitId set: %v", backupUnitId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property BackupUnitId set: %v", backupUnitId),
+		)
 	}
 
 	if (!viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) &&
@@ -644,21 +902,29 @@ func getNewVolume(c *core.CommandConfig) (*resources.Volume, error) {
 		licenceType := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgLicenceType))
 		proper.SetLicenceType(licenceType)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property LicenceType set: %v", licenceType))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property LicenceType set: %v", licenceType),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) {
 		imageId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId))
 		proper.SetImage(imageId)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Image set: %v", imageId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Image set: %v", imageId),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)) {
 		imageAlias := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias))
 		proper.SetImageAlias(imageAlias)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property ImageAlias set: %v", imageAlias))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property ImageAlias set: %v", imageAlias),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgPassword)) {
@@ -671,7 +937,9 @@ func getNewVolume(c *core.CommandConfig) (*resources.Volume, error) {
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgSshKeyPaths)) {
 		sshKeysPaths := viper.GetStringSlice(core.GetFlagName(c.NS, cloudapiv6.ArgSshKeyPaths))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SSH Key Paths: %v", sshKeysPaths))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SSH Key Paths: %v", sshKeysPaths),
+		)
 
 		sshKeys, err := getSshKeysFromPaths(sshKeysPaths)
 		if err != nil {
@@ -687,49 +955,69 @@ func getNewVolume(c *core.CommandConfig) (*resources.Volume, error) {
 		userData := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgUserData))
 		proper.SetUserData(userData)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property UserData set: %v", userData))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property UserData set: %v", userData),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotPlug)) {
 		cpuHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotPlug))
 		proper.SetCpuHotPlug(cpuHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug)) {
 		ramHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug))
 		proper.SetRamHotPlug(ramHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug)) {
 		nicHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug))
 		proper.SetNicHotPlug(nicHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug)) {
 		nicHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug))
 		proper.SetNicHotUnplug(nicHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NicHotUnplug set: %v", nicHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property NicHotUnplug set: %v", nicHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug)) {
 		discVirtioHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug))
 		proper.SetDiscVirtioHotPlug(discVirtioHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug)) {
 		discVirtioHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug))
 		proper.SetDiscVirtioHotUnplug(discVirtioHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug),
+		)
 	}
 
 	return &resources.Volume{
@@ -767,7 +1055,10 @@ func getVolumeInfo(c *core.CommandConfig) (*resources.VolumeProperties, error) {
 
 		input.SetSize(float32(size))
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property Size set: %vGB", float32(size)))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property Size set: %vGB", float32(size)),
+		)
 	}
 
 	// Check if flags are set and set options
@@ -775,42 +1066,60 @@ func getVolumeInfo(c *core.CommandConfig) (*resources.VolumeProperties, error) {
 		cpuHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgCpuHotPlug))
 		input.SetCpuHotPlug(cpuHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property CpuHotPlug set: %v", cpuHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug)) {
 		ramHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgRamHotPlug))
 		input.SetRamHotPlug(ramHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property RamHotPlug set: %v", ramHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug)) {
 		nicHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotPlug))
 		input.SetNicHotPlug(nicHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property NicHotPlug set: %v", nicHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug)) {
 		nicHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgNicHotUnplug))
 		input.SetNicHotUnplug(nicHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property NicHotUnplug set: %v", nicHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property NicHotUnplug set: %v", nicHotUnplug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug)) {
 		discVirtioHotPlug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotPlug))
 		input.SetDiscVirtioHotPlug(discVirtioHotPlug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotPlug set: %v", discVirtioHotPlug),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug)) {
 		discVirtioHotUnplug := viper.GetBool(core.GetFlagName(c.NS, cloudapiv6.ArgDiscVirtioHotUnplug))
 		input.SetDiscVirtioHotUnplug(discVirtioHotUnplug)
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Property DiscVirtioHotUnplug set: %v", discVirtioHotUnplug),
+		)
 	}
 
 	return &input, nil
@@ -856,7 +1165,10 @@ func DeleteAllVolumes(c *core.CommandConfig) error {
 		}
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete all the Volumes", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete all the Volumes",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -869,18 +1181,27 @@ func DeleteAllVolumes(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting deleting Volume with id: %v is...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting deleting Volume with id: %v is...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Volumes().Delete(dcId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
@@ -912,13 +1233,14 @@ func ServerVolumeCmd() *core.Command {
 	/*
 		Attach Volume Command
 	*/
-	attachVolume := core.NewCommand(ctx, serverVolumeCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "volume",
-		Verb:      "attach",
-		Aliases:   []string{"a"},
-		ShortDesc: "Attach a Volume to a Server",
-		LongDesc: `Use this command to attach a pre-existing Volume to a Server.
+	attachVolume := core.NewCommand(
+		ctx, serverVolumeCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "volume",
+			Verb:      "attach",
+			Aliases:   []string{"a"},
+			ShortDesc: "Attach a Volume to a Server",
+			LongDesc: `Use this command to attach a pre-existing Volume to a Server.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option.
 
@@ -927,111 +1249,204 @@ Required values to run command:
 * Data Center Id
 * Server Id
 * Volume Id`,
-		Example:    attachVolumeServerExample,
-		PreCmdRun:  PreRunDcServerVolumeIds,
-		CmdRun:     RunServerVolumeAttach,
-		InitClient: true,
-	})
+			Example:    attachVolumeServerExample,
+			PreCmdRun:  PreRunDcServerVolumeIds,
+			CmdRun:     RunServerVolumeAttach,
+			InitClient: true,
+		},
+	)
 	attachVolume.AddStringSliceFlag(constants.ArgCols, "", defaultVolumeCols, tabheaders.ColsMessage(allVolumeCols))
-	_ = attachVolume.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = attachVolume.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	attachVolume.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = attachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	attachVolume.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = attachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesIds(viper.GetString(core.GetFlagName(attachVolume.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = attachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	attachVolume.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption(),
+	)
+	_ = attachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						attachVolume.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	attachVolume.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = attachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(attachVolume.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	attachVolume.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Volume attachment to be executed")
-	attachVolume.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Volume attachment [seconds]")
+	_ = attachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						attachVolume.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	attachVolume.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Volume attachment to be executed",
+	)
+	attachVolume.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Volume attachment [seconds]",
+	)
 
 	/*
 		List Volumes Command
 	*/
-	listVolumes := core.NewCommand(ctx, serverVolumeCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "volume",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List attached Volumes from a Server",
-		LongDesc:   "Use this command to retrieve a list of Volumes attached to the Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.VolumesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
-		Example:    listVolumesServerExample,
-		PreCmdRun:  PreRunServerVolumeList,
-		CmdRun:     RunServerVolumesList,
-		InitClient: true,
-	})
+	listVolumes := core.NewCommand(
+		ctx, serverVolumeCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "volume",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List attached Volumes from a Server",
+			LongDesc:   "Use this command to retrieve a list of Volumes attached to the Server.\n\nYou can filter the results using `--filters` option. Use the following format to set filters: `--filters KEY1=VALUE1,KEY2=VALUE2`.\n" + completer.VolumesFiltersUsage() + "\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id",
+			Example:    listVolumesServerExample,
+			PreCmdRun:  PreRunServerVolumeList,
+			CmdRun:     RunServerVolumesList,
+			InitClient: true,
+		},
+	)
 	listVolumes.AddStringSliceFlag(constants.ArgCols, "", defaultVolumeCols, tabheaders.ColsMessage(allVolumeCols))
-	_ = listVolumes.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listVolumes.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	listVolumes.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listVolumes.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	listVolumes.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(listVolumes.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	listVolumes.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
-	listVolumes.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
+	_ = listVolumes.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						listVolumes.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listVolumes.AddInt32Flag(
+		constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults,
+	)
+	listVolumes.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription,
+	)
 	listVolumes.AddStringFlag(cloudapiv6.ArgOrderBy, "", "", cloudapiv6.ArgOrderByDescription)
-	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgOrderBy, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
-	listVolumes.AddStringSliceFlag(cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription)
-	_ = listVolumes.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgFilters, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = listVolumes.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgOrderBy,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	listVolumes.AddStringSliceFlag(
+		cloudapiv6.ArgFilters, cloudapiv6.ArgFiltersShort, []string{""}, cloudapiv6.ArgFiltersDescription,
+	)
+	_ = listVolumes.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgFilters,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.VolumesFilters(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Volume Command
 	*/
-	getVolumeCmd := core.NewCommand(ctx, serverVolumeCmd, core.CommandBuilder{
-		Namespace:  "server",
-		Resource:   "volume",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get an attached Volume from a Server",
-		LongDesc:   "Use this command to retrieve information about an attached Volume on Server.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Volume Id",
-		Example:    getVolumeServerExample,
-		InitClient: true,
-		PreCmdRun:  PreRunDcServerVolumeIds,
-		CmdRun:     RunServerVolumeGet,
-	})
+	getVolumeCmd := core.NewCommand(
+		ctx, serverVolumeCmd, core.CommandBuilder{
+			Namespace:  "server",
+			Resource:   "volume",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get an attached Volume from a Server",
+			LongDesc:   "Use this command to retrieve information about an attached Volume on Server.\n\nRequired values to run command:\n\n* Data Center Id\n* Server Id\n* Volume Id",
+			Example:    getVolumeServerExample,
+			InitClient: true,
+			PreCmdRun:  PreRunDcServerVolumeIds,
+			CmdRun:     RunServerVolumeGet,
+		},
+	)
 	getVolumeCmd.AddStringSliceFlag(constants.ArgCols, "", defaultVolumeCols, tabheaders.ColsMessage(allVolumeCols))
-	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	getVolumeCmd.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	getVolumeCmd.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(getVolumeCmd.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	getVolumeCmd.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AttachedVolumesIds(viper.GetString(core.GetFlagName(getVolumeCmd.NS, cloudapiv6.ArgDataCenterId)), viper.GetString(core.GetFlagName(getVolumeCmd.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	getVolumeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						getVolumeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	getVolumeCmd.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption(),
+	)
+	_ = getVolumeCmd.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, ags []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AttachedVolumesIds(
+				viper.GetString(
+					core.GetFlagName(
+						getVolumeCmd.NS, cloudapiv6.ArgDataCenterId,
+					),
+				), viper.GetString(core.GetFlagName(getVolumeCmd.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	getVolumeCmd.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	/*
 		Detach Volume Command
 	*/
-	detachVolume := core.NewCommand(ctx, serverVolumeCmd, core.CommandBuilder{
-		Namespace: "server",
-		Resource:  "volume",
-		Verb:      "detach",
-		Aliases:   []string{"d"},
-		ShortDesc: "Detach a Volume from a Server",
-		LongDesc: `This will detach the Volume from the Server. Depending on the Volume HotUnplug settings, this may result in the Server being rebooted. This will NOT delete the Volume from your Virtual Data Center. You will need to use a separate command to delete a Volume.
+	detachVolume := core.NewCommand(
+		ctx, serverVolumeCmd, core.CommandBuilder{
+			Namespace: "server",
+			Resource:  "volume",
+			Verb:      "detach",
+			Aliases:   []string{"d"},
+			ShortDesc: "Detach a Volume from a Server",
+			LongDesc: `This will detach the Volume from the Server. Depending on the Volume HotUnplug settings, this may result in the Server being rebooted. This will NOT delete the Volume from your Virtual Data Center. You will need to use a separate command to delete a Volume.
 
 You can wait for the Request to be executed using ` + "`" + `--wait-for-request` + "`" + ` option. You can force the command to execute without user input using ` + "`" + `--force` + "`" + ` option.
 
@@ -1040,32 +1455,64 @@ Required values to run command:
 * Data Center Id
 * Server Id
 * Volume Id`,
-		Example:    detachVolumeServerExample,
-		PreCmdRun:  PreRunDcServerVolumeDetach,
-		CmdRun:     RunServerVolumeDetach,
-		InitClient: true,
-	})
+			Example:    detachVolumeServerExample,
+			PreCmdRun:  PreRunDcServerVolumeDetach,
+			CmdRun:     RunServerVolumeDetach,
+			InitClient: true,
+		},
+	)
+	detachVolume.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	detachVolume.AddStringSliceFlag(constants.ArgCols, "", defaultVolumeCols, tabheaders.ColsMessage(allVolumeCols))
-	_ = detachVolume.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = detachVolume.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allVolumeCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	detachVolume.AddUUIDFlag(cloudapiv6.ArgDataCenterId, "", "", cloudapiv6.DatacenterId, core.RequiredFlagOption())
-	_ = detachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDataCenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	detachVolume.AddUUIDFlag(cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption())
-	_ = detachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgVolumeId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.AttachedVolumesIds(viper.GetString(core.GetFlagName(detachVolume.NS, cloudapiv6.ArgDataCenterId)),
-			viper.GetString(core.GetFlagName(detachVolume.NS, cloudapiv6.ArgServerId))), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = detachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgDataCenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	detachVolume.AddUUIDFlag(
+		cloudapiv6.ArgVolumeId, cloudapiv6.ArgIdShort, "", cloudapiv6.VolumeId, core.RequiredFlagOption(),
+	)
+	_ = detachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgVolumeId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.AttachedVolumesIds(
+				viper.GetString(core.GetFlagName(detachVolume.NS, cloudapiv6.ArgDataCenterId)),
+				viper.GetString(core.GetFlagName(detachVolume.NS, cloudapiv6.ArgServerId)),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	detachVolume.AddUUIDFlag(cloudapiv6.ArgServerId, "", "", cloudapiv6.ServerId, core.RequiredFlagOption())
-	_ = detachVolume.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgServerId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ServersIds(viper.GetString(core.GetFlagName(detachVolume.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	detachVolume.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Volume detachment to be executed")
-	detachVolume.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Volume detachment [seconds]")
+	_ = detachVolume.Command.RegisterFlagCompletionFunc(
+		cloudapiv6.ArgServerId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ServersIds(
+				viper.GetString(
+					core.GetFlagName(
+						detachVolume.NS, cloudapiv6.ArgDataCenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	detachVolume.AddBoolFlag(
+		constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for Volume detachment to be executed",
+	)
+	detachVolume.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds,
+		"Timeout option for Request for Volume detachment [seconds]",
+	)
 	detachVolume.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Detach all Volumes.")
-	detachVolume.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
+	detachVolume.AddInt32Flag(
+		cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription,
+	)
 
 	return serverVolumeCmd
 }
@@ -1081,11 +1528,14 @@ func PreRunServerVolumeList(c *core.PreCommandConfig) error {
 }
 
 func PreRunDcServerVolumeIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgVolumeId)
+	return core.CheckRequiredFlags(
+		c.Command, c.NS, cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgVolumeId,
+	)
 }
 
 func PreRunDcServerVolumeDetach(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS,
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS,
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgVolumeId},
 		[]string{cloudapiv6.ArgDataCenterId, cloudapiv6.ArgServerId, cloudapiv6.ArgAll},
 	)
@@ -1103,12 +1553,18 @@ func RunServerVolumeAttach(c *core.CommandConfig) error {
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Attaching Volume with ID: %v to Server with ID: %v...", volumeId, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Attaching Volume with ID: %v to Server with ID: %v...", volumeId, serverId,
+		),
+	)
 
 	attachedVol, resp, err := c.CloudApiV6Services.Servers().AttachVolume(dcId, serverId, volumeId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1120,8 +1576,10 @@ func RunServerVolumeAttach(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Volume, attachedVol.Volume,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Volume, attachedVol.Volume,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -1135,7 +1593,10 @@ func RunServerVolumesList(c *core.CommandConfig) error {
 	serverId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgServerId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Listing attached Volumes from Server with ID: %v...", serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(),
+		jsontabwriter.GenerateVerboseOutput("Listing attached Volumes from Server with ID: %v...", serverId),
+	)
 
 	// Add Query Parameters for GET Requests
 	listQueryParams, err := query.GetListQueryParams(c)
@@ -1161,7 +1622,10 @@ func RunServerVolumesList(c *core.CommandConfig) error {
 
 	attachedVols, resp, err := c.CloudApiV6Services.Servers().ListVolumes(dcId, serverId, listQueryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1169,8 +1633,10 @@ func RunServerVolumesList(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Volume, attachedVols.AttachedVolumes,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"items", jsonpaths.Volume, attachedVols.AttachedVolumes,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -1191,12 +1657,18 @@ func RunServerVolumeGet(c *core.CommandConfig) error {
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Getting attached Volume with ID: %v from Server with ID: %v...", volumeId, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Getting attached Volume with ID: %v from Server with ID: %v...", volumeId, serverId,
+		),
+	)
 
 	attachedVol, resp, err := c.CloudApiV6Services.Servers().GetVolume(dcId, serverId, volumeId, queryParams)
 	if resp != nil {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestTime, resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1204,8 +1676,10 @@ func RunServerVolumeGet(c *core.CommandConfig) error {
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
-	out, err := jsontabwriter.GenerateOutput("", jsonpaths.Volume, attachedVol.Volume,
-		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols))
+	out, err := jsontabwriter.GenerateOutput(
+		"", jsonpaths.Volume, attachedVol.Volume,
+		tabheaders.GetHeaders(allVolumeCols, defaultVolumeCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -1229,7 +1703,10 @@ func RunServerVolumeDetach(c *core.CommandConfig) error {
 
 		return nil
 	}
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "detach volume from server", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "detach volume from server",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1238,12 +1715,18 @@ func RunServerVolumeDetach(c *core.CommandConfig) error {
 	volumeId := viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgVolumeId))
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.DatacenterId, dcId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Detaching Volume with ID: %v from Server with ID: %v...", volumeId, serverId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Detaching Volume with ID: %v from Server with ID: %v...", volumeId, serverId,
+		),
+	)
 
 	resp, err := c.CloudApiV6Services.Servers().DetachVolume(dcId, serverId, volumeId, queryParams)
 	if resp != nil && request.GetId(resp) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+		)
 	}
 	if err != nil {
 		return err
@@ -1271,7 +1754,9 @@ func DetachAllServerVolumes(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Server ID: %v", serverId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Volumes..."))
 
-	volumes, resp, err := c.CloudApiV6Services.Servers().ListVolumes(dcId, serverId, cloudapiv6.ParentResourceListQueryParams)
+	volumes, resp, err := c.CloudApiV6Services.Servers().ListVolumes(
+		dcId, serverId, cloudapiv6.ParentResourceListQueryParams,
+	)
 	if err != nil {
 		return err
 	}
@@ -1302,7 +1787,10 @@ func DetachAllServerVolumes(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(delIdAndName))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "detach all the Volumes", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "detach all the Volumes",
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -1315,18 +1803,27 @@ func DetachAllServerVolumes(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Starting detaching Volume with id: %v...", *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Starting detaching Volume with id: %v...", *id),
+		)
 
 		resp, err = c.CloudApiV6Services.Servers().DetachVolume(dcId, serverId, *id, queryParams)
 		if resp != nil && request.GetId(resp) != "" {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput(constants.MessageRequestInfo, request.GetId(resp), resp.RequestTime),
+			)
 		}
 		if err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrDeleteAll, c.Resource, *id, err))
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageRemovingAll, c.Resource, *id))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageRemovingAll, c.Resource, *id),
+		)
 
 		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))

--- a/commands/cloudapi-v6/volume_test.go
+++ b/commands/cloudapi-v6/volume_test.go
@@ -195,597 +195,729 @@ func TestVolumeCmd(t *testing.T) {
 func TestPreRunVolumeList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		err := PreRunVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			err := PreRunVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunVolumeListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdBy=%s", testQueryParamVar)})
-		err := PreRunVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdBy=%s", testQueryParamVar)},
+			)
+			err := PreRunVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunVolumeListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunVolumeList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunVolumeList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcVolumeIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		err := PreRunDcVolumeIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			err := PreRunDcVolumeIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunDcVolumeIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcVolumeIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcVolumeIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunVolumeCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		err := PreRunVolumeCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			err := PreRunVolumeCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunVolumeCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunVolumeCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunVolumeCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeListAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(dcs, &testResponse, nil)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vsList, &testResponse, nil).Times(len(getDataCenters(dcs)))
-		err := RunVolumeListAll(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(
+				dcs, &testResponse, nil,
+			)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testDatacenterVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vsList, &testResponse, nil).Times(len(getDataCenters(dcs)))
+			err := RunVolumeListAll(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vs, &testResponse, nil)
-		err := RunVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vs, &testResponse, nil)
+			err := RunVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeListQueryParams(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Volumes{}, &testResponse, nil)
-		err := RunVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgOrderBy), testQueryParamVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagMaxResults), testMaxResultsVar)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Volumes{}, &testResponse, nil)
+			err := RunVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vs, nil, testVolumeErr)
-		err := RunVolumeList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vs, nil, testVolumeErr)
+			err := RunVolumeList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Get(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, &testResponse, nil)
-		err := RunVolumeGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Get(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, &testResponse, nil)
+			err := RunVolumeGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Get(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
-		err := RunVolumeGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Get(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
+			err := RunVolumeGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Create(testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, &testResponse, nil)
-		err := RunVolumeCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Create(
+				testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, &testResponse, nil)
+			err := RunVolumeCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeCreateImg(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Create(testVolumeVar, testVolumeImg, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, nil)
-		err := RunVolumeCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Create(
+				testVolumeVar, testVolumeImg, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, nil, nil)
+			err := RunVolumeCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeCreateSshKeyErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testVolumeVar})
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		err := RunVolumeCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSshKeyPaths), []string{testVolumeVar})
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			err := RunVolumeCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Create(testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
-		err := RunVolumeCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Create(
+				testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
+			err := RunVolumeCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeCreateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Create(testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunVolumeCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgLicenceType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagType), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagAvailabilityZone), zoneVolume)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgUserData), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Create(
+				testVolumeVar, testVolume, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunVolumeCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Update(testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&volumeNew, &testResponse, nil)
-		err := RunVolumeUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Update(
+				testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&volumeNew, &testResponse, nil)
+			err := RunVolumeUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Update(testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&volumeNew, nil, testVolumeErr)
-		err := RunVolumeUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Update(
+				testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&volumeNew, nil, testVolumeErr)
+			err := RunVolumeUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeUpdateWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Update(testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&volumeNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunVolumeUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgName), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgSize), sizeVolumeNew)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBus), testVolumeNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgCpuHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgRamHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgNicHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotPlug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDiscVirtioHotUnplug), testVolumeBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Update(
+				testVolumeVar, testVolumeVar, volumeProperties, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&volumeNew, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunVolumeUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunVolumeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunVolumeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunVolumeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunVolumeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vsList, nil, testVolumeErr)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vsList, nil, testVolumeErr)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(resources.Volumes{}, &testResponse, nil)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(resources.Volumes{}, &testResponse, nil)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(
-			resources.Volumes{Volumes: ionoscloud.Volumes{Items: &[]ionoscloud.Volume{}}}, &testResponse, nil)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(
+				resources.Volumes{Volumes: ionoscloud.Volumes{Items: &[]ionoscloud.Volume{}}}, &testResponse, nil,
+			)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().List(testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam)).Return(vsList, &testResponse, nil)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testVolumeErr)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().List(
+				testVolumeVar, gomock.AssignableToTypeOf(testListQueryParam),
+			).Return(vsList, &testResponse, nil)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, testVolumeErr)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, testVolumeErr)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, testVolumeErr)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Volume.EXPECT().Delete(testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil)
-		err := RunVolumeDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Volume.EXPECT().Delete(
+				testVolumeVar, testVolumeVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(nil, nil)
+			err := RunVolumeDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunVolumeDeleteAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunVolumeDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testVolumeVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunVolumeDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 // Server Volume
@@ -793,136 +925,168 @@ func TestRunVolumeDeleteAskForConfirmErr(t *testing.T) {
 func TestPreRunDcServerIdsRequiredFlagsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerVolumeIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		err := PreRunDcServerVolumeIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			err := PreRunDcServerVolumeIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerVolumeList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		err := PreRunServerVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			err := PreRunServerVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerVolumeListFilters(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("createdby=%s", testQueryParamVar)})
-		err := PreRunServerVolumeList(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("createdby=%s", testQueryParamVar)},
+			)
+			err := PreRunServerVolumeList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunServerVolumeListFiltersErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters), []string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)})
-		err := PreRunServerVolumeList(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(
+				core.GetFlagName(cfg.NS, cloudapiv6.ArgFilters),
+				[]string{fmt.Sprintf("%s=%s", testQueryParamVar, testQueryParamVar)},
+			)
+			err := PreRunServerVolumeList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunDcServerVolumeIdsRequiredFlagsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunDcServerVolumeIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunDcServerVolumeIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerVolumeAttach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, nil)
-		err := RunServerVolumeAttach(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(
+				testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, nil, nil)
+			err := RunServerVolumeAttach(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunServerVolumeAttachErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
-		err := RunServerVolumeAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(
+				testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, nil, testVolumeErr)
+			err := RunServerVolumeAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunServerVolumeAttachWaitErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
-		rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
-		err := RunServerVolumeAttach(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
+			rm.CloudApiV6Mocks.Server.EXPECT().AttachVolume(
+				testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+			).Return(&resources.Volume{Volume: v}, &testResponse, nil)
+			rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+				&testRequestStatus, nil, testRequestErr,
+			)
+			err := RunServerVolumeAttach(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 // / NEW TESTS
@@ -930,282 +1094,325 @@ func TestServerVolumeList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	var funcToTest = RunServerVolumesList
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		var tests = []core.TestCase{
-			{
-				Name: "server volume list",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			var tests = []core.TestCase{
+				{
+					Name: "server volume list",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testResourceVar),
+								gomock.AssignableToTypeOf(testListQueryParam),
+							).Return(vsAttached, nil, nil),
+						)
+					},
+					ExpectedErr: false,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testListQueryParam)).Return(vsAttached, nil, nil),
-					)
+				{
+					Name: "server volume list error",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testResourceVar),
+								gomock.AssignableToTypeOf(testListQueryParam),
+							).Return(vsAttached, nil, testVolumeErr),
+						)
+					},
+					ExpectedErr: true,
 				},
-				ExpectedErr: false,
-			},
-			{
-				Name: "server volume list error",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testResourceVar), gomock.AssignableToTypeOf(testListQueryParam)).Return(vsAttached, nil, testVolumeErr),
-					)
-				},
-				ExpectedErr: true,
-			},
-		}
-		core.ExecuteTestCases(t, funcToTest, tests, cfg)
-	})
+			}
+			core.ExecuteTestCases(t, funcToTest, tests, cfg)
+		},
+	)
 }
 
 func TestServerVolumeGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	var funcToTest = RunServerVolumeGet
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		var tests = []core.TestCase{
-			{
-				Name: "server volume get",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			var tests = []core.TestCase{
+				{
+					Name: "server volume get",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().GetVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&resources.Volume{Volume: v}, nil, nil),
+						)
+					},
+					ExpectedErr: false,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().GetVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, nil),
-					)
+				{
+					Name: "server volume get error",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().GetVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&resources.Volume{Volume: v}, nil, testVolumeErr),
+						)
+					},
+					ExpectedErr: true,
 				},
-				ExpectedErr: false,
-			},
-			{
-				Name: "server volume get error",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().GetVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&resources.Volume{Volume: v}, nil, testVolumeErr),
-					)
-				},
-				ExpectedErr: true,
-			},
-		}
-		core.ExecuteTestCases(t, funcToTest, tests, cfg)
-	})
+			}
+			core.ExecuteTestCases(t, funcToTest, tests, cfg)
+		},
+	)
 }
 
 func TestServerVolumeDetach(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	var funcToTest = RunServerVolumeDetach
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		var tests = []core.TestCase{
-			{
-				Name: "server volume detach",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{constants.ArgForce, true},
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			var tests = []core.TestCase{
+				{
+					Name: "server volume detach",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(nil, nil),
+						)
+					},
+					ExpectedErr: false,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(nil, nil),
-					)
+				{
+					Name: "server volume detach error",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&testResponse, testVolumeErr),
+						)
+					},
+					ExpectedErr: true,
 				},
-				ExpectedErr: false,
-			},
-			{
-				Name: "server volume detach error",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{constants.ArgForce, true},
+				{
+					Name: "server volume detach all",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								testServerVar, testServerVar, cloudapiv6.ParentResourceListQueryParams,
+							).Return(vsAttachedList, nil, nil),
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&testResponse, nil),
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&testResponse, nil),
+						)
+					},
+					ExpectedErr: false,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testVolumeErr),
-					)
-				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach all",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
-					{constants.ArgForce, true},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(testServerVar, testServerVar, cloudapiv6.ParentResourceListQueryParams).Return(vsAttachedList, nil, nil),
-						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil),
-						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil),
-					)
-				},
-				ExpectedErr: false,
-			},
-			{
-				Name: "server volume detach all (error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
-					{constants.ArgForce, true},
-				},
-				Calls: func(...*gomock.Call) {
-					rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(testServerVar, testServerVar, cloudapiv6.ParentResourceListQueryParams).Return(vsAttachedList, nil, nil)
-					rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, testVolumeErr)
-					rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach all (list error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
-					{constants.ArgForce, true},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
+				{
+					Name: "server volume detach all (error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
 						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
-							testServerVar,
-							testServerVar,
-							cloudapiv6.ParentResourceListQueryParams,
-						).Return(
-							vsAttachedList,
-							nil,
-							testVolumeErr,
-						),
-					)
-				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach all (wrong items error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
-					{constants.ArgForce, true},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
-							testServerVar,
-							testServerVar,
-							cloudapiv6.ParentResourceListQueryParams,
-						).Return(
-							vsAttachedList,
-							nil,
-							testVolumeErr,
-						),
-					)
-				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach all (length error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
-					{constants.ArgForce, true},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
-							testServerVar,
-							testServerVar,
-							cloudapiv6.ParentResourceListQueryParams,
-						).Return(
-							resources.AttachedVolumes{AttachedVolumes: ionoscloud.AttachedVolumes{Items: &[]ionoscloud.Volume{}}},
-							nil,
-							nil,
-						),
-					)
-				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach (user confirm)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{constants.ArgForce, false},
-				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
+							testServerVar, testServerVar, cloudapiv6.ParentResourceListQueryParams,
+						).Return(vsAttachedList, nil, nil)
 						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
-							testServerVar,
-							testServerVar,
-							testServerVar,
-							testQueryParamOther,
-						).Return(
-							nil,
-							nil,
-						),
-					)
+							testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+						).Return(&testResponse, testVolumeErr)
+						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+							testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther),
+						).Return(&testResponse, nil)
+					},
+					ExpectedErr: true,
 				},
-				UserInput:   bytes.NewReader([]byte("YES\n")),
-				ExpectedErr: false,
-			},
-			{
-				Name: "server volume detach (wait error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true},
-					{constants.ArgForce, true},
+				{
+					Name: "server volume detach all (list error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								testServerVar,
+								testServerVar,
+								cloudapiv6.ParentResourceListQueryParams,
+							).Return(
+								vsAttachedList,
+								nil,
+								testVolumeErr,
+							),
+						)
+					},
+					ExpectedErr: true,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder(
-						rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(testServerVar, testServerVar, testServerVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil),
-						rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr),
-					)
+				{
+					Name: "server volume detach all (wrong items error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								testServerVar,
+								testServerVar,
+								cloudapiv6.ParentResourceListQueryParams,
+							).Return(
+								vsAttachedList,
+								nil,
+								testVolumeErr,
+							),
+						)
+					},
+					ExpectedErr: true,
 				},
-				ExpectedErr: true,
-			},
-			{
-				Name: "server volume detach (user confirm error)",
-				Args: []core.FlagValuePair{
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
-					{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
-					{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
-					{constants.ArgForce, false},
+				{
+					Name: "server volume detach all (length error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgAll), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().ListVolumes(
+								testServerVar,
+								testServerVar,
+								cloudapiv6.ParentResourceListQueryParams,
+							).Return(
+								resources.AttachedVolumes{AttachedVolumes: ionoscloud.AttachedVolumes{Items: &[]ionoscloud.Volume{}}},
+								nil,
+								nil,
+							),
+						)
+					},
+					ExpectedErr: true,
 				},
-				Calls: func(...*gomock.Call) {
-					gomock.InOrder()
+				{
+					Name: "server volume detach (user confirm)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{constants.ArgForce, false},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar,
+								testServerVar,
+								testServerVar,
+								testQueryParamOther,
+							).Return(
+								nil,
+								nil,
+							),
+						)
+					},
+					UserInput:   bytes.NewReader([]byte("YES\n")),
+					ExpectedErr: false,
 				},
-				UserInput:   bytes.NewReader([]byte("\n")),
-				ExpectedErr: true,
-			},
-		}
-		core.ExecuteTestCases(t, funcToTest, tests, cfg)
-	})
+				{
+					Name: "server volume detach (wait error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true},
+						{constants.ArgForce, true},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder(
+							rm.CloudApiV6Mocks.Server.EXPECT().DetachVolume(
+								testServerVar, testServerVar, testServerVar,
+								gomock.AssignableToTypeOf(testQueryParamOther),
+							).Return(&testResponse, nil),
+							rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(
+								&testRequestStatus, nil, testRequestErr,
+							),
+						)
+					},
+					ExpectedErr: true,
+				},
+				{
+					Name: "server volume detach (user confirm error)",
+					Args: []core.FlagValuePair{
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgDataCenterId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgServerId), testServerVar},
+						{core.GetFlagName(cfg.NS, cloudapiv6.ArgVolumeId), testServerVar},
+						{core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), false},
+						{constants.ArgForce, false},
+					},
+					Calls: func(...*gomock.Call) {
+						gomock.InOrder()
+					},
+					UserInput:   bytes.NewReader([]byte("\n")),
+					ExpectedErr: true,
+				},
+			}
+			core.ExecuteTestCases(t, funcToTest, tests, cfg)
+		},
+	)
 }
 
 // END NEW TESTS

--- a/commands/container-registry/registry/delete.go
+++ b/commands/container-registry/registry/delete.go
@@ -29,6 +29,7 @@ func RegDeleteCmd() *core.Command {
 		},
 	)
 
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddStringFlag(FlagRegId, "i", "", "Specify the Registry ID", core.RequiredFlagOption())
 	_ = cmd.Command.RegisterFlagCompletionFunc(
 		FlagRegId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -55,7 +56,10 @@ func CmdDelete(c *core.CommandConfig) error {
 	}
 
 	if allFlag {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all Container Registries..."))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Deleting all Container Registries..."),
+		)
 
 		regs, _, err := c.ContainerRegistryServices.Registry().List("")
 		if err != nil {
@@ -65,7 +69,9 @@ func CmdDelete(c *core.CommandConfig) error {
 		for _, reg := range *regs.Items {
 			msg := fmt.Sprintf("delete Container Registry: %s", *reg.Id)
 
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+			if !confirm.FAsk(
+				c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			) {
 				return fmt.Errorf(confirm.UserDenied)
 			}
 
@@ -82,7 +88,9 @@ func CmdDelete(c *core.CommandConfig) error {
 
 		msg := fmt.Sprintf("delete Container Registry: %s", id)
 
-		if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+		if !confirm.FAsk(
+			c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+		) {
 			return fmt.Errorf(confirm.UserDenied)
 		}
 

--- a/commands/container-registry/registry/registry_integration_test.go
+++ b/commands/container-registry/registry/registry_integration_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/cilium/fake"
-	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
-
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	ionoscloud "github.com/ionos-cloud/sdk-go-container-registry"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -35,71 +35,78 @@ func teardown() {
 }
 
 func TestRegistryService(t *testing.T) {
-	t.Run("registry functions", func(t *testing.T) {
-		t.Cleanup(teardown)
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
+	t.Run(
+		"registry functions", func(t *testing.T) {
+			t.Cleanup(teardown)
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
 
-		name := "ionosctl-crreg-test-" + fake.AlphaNum(8)
-		c := RegPostCmd()
-		c.Command.Flags().Set(FlagName, name)
-		c.Command.Flags().Set(FlagLocation, "de/fra")
+			name := "ionosctl-crreg-test-" + fake.AlphaNum(8)
+			c := RegPostCmd()
+			c.Command.Flags().Set(FlagName, name)
+			c.Command.Flags().Set(FlagLocation, "de/fra")
 
-		err := c.Command.Execute()
-		assert.NoError(t, err)
+			err := c.Command.Execute()
+			assert.NoError(t, err)
 
-		registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
-		assert.NoError(t, err)
+			registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
+			assert.NoError(t, err)
 
-		var newRegistry *ionoscloud.RegistryResponse
-		for _, registry := range *registries.GetItems() {
-			if *registry.GetProperties().GetName() == name {
-				newRegistry = &registry
+			var newRegistry *ionoscloud.RegistryResponse
+			for _, registry := range *registries.GetItems() {
+				if *registry.GetProperties().GetName() == name {
+					newRegistry = &registry
+				}
 			}
-		}
 
-		g := RegGetCmd()
-		g.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
-		assert.NoError(t, err)
+			g := RegGetCmd()
+			g.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
+			assert.NoError(t, err)
 
-		err = g.Command.Execute()
-		assert.NoError(t, err)
+			err = g.Command.Execute()
+			assert.NoError(t, err)
 
-		patch := RegUpdateCmd()
-		patch.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
-		patch.Command.Flags().Set(FlagRegGCDays, "Tuesday")
-		assert.NoError(t, err)
+			patch := RegUpdateCmd()
+			patch.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
+			patch.Command.Flags().Set(FlagRegGCDays, "Tuesday")
+			assert.NoError(t, err)
 
-		err = patch.Command.Execute()
-		assert.NoError(t, err)
+			err = patch.Command.Execute()
+			assert.NoError(t, err)
 
-		checkRegistry, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesFindById(context.Background(), *newRegistry.GetId()).Execute()
-		assert.NoError(t, err)
-		assert.Equal(t, []ionoscloud.Day([]ionoscloud.Day{"Tuesday"}), *checkRegistry.GetProperties().GetGarbageCollectionSchedule().GetDays())
+			checkRegistry, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesFindById(
+				context.Background(), *newRegistry.GetId(),
+			).Execute()
+			assert.NoError(t, err)
+			assert.Equal(
+				t, []ionoscloud.Day([]ionoscloud.Day{"Tuesday"}),
+				*checkRegistry.GetProperties().GetGarbageCollectionSchedule().GetDays(),
+			)
 
-		d := RegDeleteCmd()
-		d.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
-		assert.NoError(t, err)
+			d := RegDeleteCmd()
+			d.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
+			viper.Set(core.GetFlagName(d.NS, constants.ArgForce), true)
+			assert.NoError(t, err)
 
-		err = d.Command.Execute()
-		assert.NoError(t, err)
+			err = d.Command.Execute()
+			assert.NoError(t, err)
 
-		replace := RegReplaceCmd()
-		name = "ionosctl-crreg-test-" + fake.AlphaNum(8)
-		replace.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
-		replace.Command.Flags().Set(FlagName, name)
-		replace.Command.Flags().Set(FlagLocation, "de/fra")
-		replace.Command.Flags().Set(FlagRegGCDays, "Tuesday")
+			replace := RegReplaceCmd()
+			name = "ionosctl-crreg-test-" + fake.AlphaNum(8)
+			replace.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
+			replace.Command.Flags().Set(FlagName, name)
+			replace.Command.Flags().Set(FlagLocation, "de/fra")
+			replace.Command.Flags().Set(FlagRegGCDays, "Tuesday")
 
-		err = replace.Command.Execute()
-		assert.NoError(t, err)
+			err = replace.Command.Execute()
+			assert.NoError(t, err)
 
-		d.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
+			d.Command.Flags().Set(FlagRegId, *newRegistry.GetId())
 
-		err = d.Command.Execute()
-		assert.NoError(t, err)
-	})
+			err = d.Command.Execute()
+			assert.NoError(t, err)
+		},
+	)
 }

--- a/commands/container-registry/token/delete.go
+++ b/commands/container-registry/token/delete.go
@@ -28,7 +28,7 @@ func TokenDeleteCmd() *core.Command {
 			InitClient: true,
 		},
 	)
-
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all tokens from all registries")
 	cmd.AddStringFlag(FlagRegId, "r", "", "Registry ID")
 	_ = cmd.Command.RegisterFlagCompletionFunc(
@@ -39,7 +39,8 @@ func TokenDeleteCmd() *core.Command {
 	cmd.AddBoolFlag(FlagAllTokens, "", false, "Delete all tokens from a registry")
 	cmd.AddStringFlag(FlagTokenId, "t", "", "Token ID")
 	_ = cmd.Command.RegisterFlagCompletionFunc(
-		FlagTokenId, func(cobracmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		FlagTokenId,
+		func(cobracmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return TokensIds(viper.GetString(core.GetFlagName(cmd.NS, FlagRegId))), cobra.ShellCompDirectiveNoFileComp
 		},
 	)
@@ -66,7 +67,9 @@ func CmdDeleteToken(c *core.CommandConfig) error {
 
 			msg := fmt.Sprintf("delete Token: %s", tokenId)
 
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+			if !confirm.FAsk(
+				c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			) {
 				return fmt.Errorf(confirm.UserDenied)
 			}
 
@@ -86,7 +89,9 @@ func CmdDeleteToken(c *core.CommandConfig) error {
 		for _, token := range *tokens.GetItems() {
 			msg := fmt.Sprintf("delete Token: %s", *token.Id)
 
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+			if !confirm.FAsk(
+				c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			) {
 				return fmt.Errorf(confirm.UserDenied)
 			}
 
@@ -113,7 +118,9 @@ func CmdDeleteToken(c *core.CommandConfig) error {
 		for _, token := range *tokens.GetItems() {
 			msg := fmt.Sprintf("delete Token: %s", *token.Id)
 
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+			if !confirm.FAsk(
+				c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			) {
 				return fmt.Errorf(confirm.UserDenied)
 			}
 

--- a/commands/container-registry/token/scopes/delete.go
+++ b/commands/container-registry/token/scopes/delete.go
@@ -30,7 +30,7 @@ func TokenScopesDeleteCmd() *core.Command {
 			InitClient: true,
 		},
 	)
-
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddStringFlag(FlagRegId, "r", "", "Registry ID")
 	_ = cmd.Command.RegisterFlagCompletionFunc(
 		FlagRegId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -39,7 +39,8 @@ func TokenScopesDeleteCmd() *core.Command {
 	)
 	cmd.AddStringFlag(FlagTokenId, "t", "", "Token ID")
 	_ = cmd.Command.RegisterFlagCompletionFunc(
-		FlagTokenId, func(cobracmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		FlagTokenId,
+		func(cobracmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return TokensIds(viper.GetString(core.GetFlagName(cmd.NS, FlagRegId))), cobra.ShellCompDirectiveNoFileComp
 		},
 	)
@@ -82,7 +83,9 @@ func CmdGetTokenScopesDelete(c *core.CommandConfig) error {
 
 		msg := fmt.Sprintf("delete all scopes from Token: %s", *token.Id)
 
-		if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+		if !confirm.FAsk(
+			c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+		) {
 			return fmt.Errorf(confirm.UserDenied)
 		}
 
@@ -119,7 +122,7 @@ func CmdGetTokenScopesDelete(c *core.CommandConfig) error {
 
 	msg := fmt.Sprintf("delete scope %d from Token: %s", id+1, *token.Id)
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(c.Command.Command.InOrStdin(), msg, viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce))) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 

--- a/commands/container-registry/token/token_integration_test.go
+++ b/commands/container-registry/token/token_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/fake"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 
@@ -38,141 +39,147 @@ func teardown() {
 }
 
 func TestTokenService(t *testing.T) {
-	t.Run("token functions", func(t *testing.T) {
-		t.Cleanup(teardown)
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
+	t.Run(
+		"token functions", func(t *testing.T) {
+			t.Cleanup(teardown)
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
 
-		// create registry
-		name := "ionosctl-crreg-test-" + fake.AlphaNum(8)
-		c := registry.RegPostCmd()
-		c.Command.Flags().Set(FlagName, name)
-		c.Command.Flags().Set(registry.FlagLocation, "de/fra")
+			// create registry
+			name := "ionosctl-crreg-test-" + fake.AlphaNum(8)
+			c := registry.RegPostCmd()
+			c.Command.Flags().Set(FlagName, name)
+			c.Command.Flags().Set(registry.FlagLocation, "de/fra")
 
-		err := c.Command.Execute()
-		assert.NoError(t, err)
-		time.Sleep(20 * time.Second)
+			err := c.Command.Execute()
+			assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
 
-		// get registry
-		assert.NoError(t, err)
-		registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
-		assert.NoError(t, err)
+			// get registry
+			assert.NoError(t, err)
+			registries, _, err := client.Must().RegistryClient.RegistriesApi.RegistriesGet(context.Background()).Execute()
+			assert.NoError(t, err)
 
-		var newReg *ionoscloud.RegistryResponse
-		for _, reg := range *registries.GetItems() {
-			if *reg.GetProperties().GetName() == name {
-				newReg = &reg
+			var newReg *ionoscloud.RegistryResponse
+			for _, reg := range *registries.GetItems() {
+				if *reg.GetProperties().GetName() == name {
+					newReg = &reg
+				}
 			}
-		}
 
-		time.Sleep(20 * time.Second)
-		// create token
-		tokenName := "ionosctl-crreg-test-" + fake.AlphaNum(8)
-		cToken := TokenPostCmd()
-		cToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		cToken.Command.Flags().Set(FlagName, tokenName)
-		assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
+			// create token
+			tokenName := "ionosctl-crreg-test-" + fake.AlphaNum(8)
+			cToken := TokenPostCmd()
+			cToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			cToken.Command.Flags().Set(FlagName, tokenName)
+			assert.NoError(t, err)
 
-		err = cToken.Command.Execute()
-		assert.NoError(t, err)
+			err = cToken.Command.Execute()
+			assert.NoError(t, err)
 
-		time.Sleep(20 * time.Second)
-		// get token
-		tokens, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensGet(context.Background(), *newReg.GetId()).Execute()
-		assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
+			// get token
+			tokens, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensGet(
+				context.Background(), *newReg.GetId(),
+			).Execute()
+			assert.NoError(t, err)
 
-		var newToken *ionoscloud.TokenResponse
-		for _, token := range *tokens.GetItems() {
-			if *token.GetProperties().GetName() == tokenName {
-				newToken = &token
+			var newToken *ionoscloud.TokenResponse
+			for _, token := range *tokens.GetItems() {
+				if *token.GetProperties().GetName() == tokenName {
+					newToken = &token
+				}
 			}
-		}
 
-		time.Sleep(20 * time.Second)
-		// add scopes
-		addScopes := scopes.TokenScopesAddCmd()
-		addScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		addScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
-		addScopes.Command.Flags().Set(scopes.FlagName, "test")
-		addScopes.Command.Flags().Set(scopes.FlagType, "repository")
-		addScopes.Command.Flags().Set(scopes.FlagActions, "pull")
+			time.Sleep(20 * time.Second)
+			// add scopes
+			addScopes := scopes.TokenScopesAddCmd()
+			addScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			addScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			addScopes.Command.Flags().Set(scopes.FlagName, "test")
+			addScopes.Command.Flags().Set(scopes.FlagType, "repository")
+			addScopes.Command.Flags().Set(scopes.FlagActions, "pull")
 
-		err = addScopes.Command.Execute()
-		assert.NoError(t, err)
-		time.Sleep(20 * time.Second)
+			err = addScopes.Command.Execute()
+			assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
 
-		addScopes = scopes.TokenScopesAddCmd()
-		addScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		addScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
-		addScopes.Command.Flags().Set(scopes.FlagName, "test2")
-		addScopes.Command.Flags().Set(scopes.FlagType, "repository")
-		addScopes.Command.Flags().Set(scopes.FlagActions, "push")
-		time.Sleep(20 * time.Second)
+			addScopes = scopes.TokenScopesAddCmd()
+			addScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			addScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			addScopes.Command.Flags().Set(scopes.FlagName, "test2")
+			addScopes.Command.Flags().Set(scopes.FlagType, "repository")
+			addScopes.Command.Flags().Set(scopes.FlagActions, "push")
+			time.Sleep(20 * time.Second)
 
-		err = addScopes.Command.Execute()
-		assert.NoError(t, err)
+			err = addScopes.Command.Execute()
+			assert.NoError(t, err)
 
-		// delete scopes
-		deleteScopes := scopes.TokenScopesDeleteCmd()
-		deleteScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		deleteScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
-		deleteScopes.Command.Flags().Set(constants.ArgAll, "true")
+			// delete scopes
+			deleteScopes := scopes.TokenScopesDeleteCmd()
+			deleteScopes.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			deleteScopes.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			deleteScopes.Command.Flags().Set(constants.ArgAll, "true")
 
-		err = deleteScopes.Command.Execute()
-		assert.NoError(t, err)
+			err = deleteScopes.Command.Execute()
+			assert.NoError(t, err)
 
-		time.Sleep(20 * time.Second)
+			time.Sleep(20 * time.Second)
 
-		gToken := TokenGetCmd()
-		gToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		gToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			gToken := TokenGetCmd()
+			gToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			gToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
 
-		err = gToken.Command.Execute()
-		assert.NoError(t, err)
+			err = gToken.Command.Execute()
+			assert.NoError(t, err)
 
-		uToken := TokenUpdateCmd()
-		uToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		uToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
-		uToken.Command.Flags().Set(FlagName, "newName")
-		uToken.Command.Flags().Set(FlagStatus, "disabled")
+			uToken := TokenUpdateCmd()
+			uToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			uToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			uToken.Command.Flags().Set(FlagName, "newName")
+			uToken.Command.Flags().Set(FlagStatus, "disabled")
 
-		err = uToken.Command.Execute()
-		assert.NoError(t, err)
-		time.Sleep(20 * time.Second)
+			err = uToken.Command.Execute()
+			assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
 
-		checkProp, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensFindById(context.Background(), *newReg.GetId(), *newToken.GetId()).Execute()
-		assert.NoError(t, err)
-		assert.Equal(t, "disabled", *checkProp.GetProperties().GetStatus())
-		time.Sleep(20 * time.Second)
-		// delete token
-		dToken := TokenDeleteCmd()
-		dToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		dToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			checkProp, _, err := client.Must().RegistryClient.TokensApi.RegistriesTokensFindById(
+				context.Background(), *newReg.GetId(), *newToken.GetId(),
+			).Execute()
+			assert.NoError(t, err)
+			assert.Equal(t, "disabled", *checkProp.GetProperties().GetStatus())
+			time.Sleep(20 * time.Second)
+			// delete token
+			dToken := TokenDeleteCmd()
+			dToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			dToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
 
-		err = dToken.Command.Execute()
-		assert.NoError(t, err)
-		time.Sleep(20 * time.Second)
+			err = dToken.Command.Execute()
+			assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
 
-		// replace token
-		rToken := TokenReplaceCmd()
-		rToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
-		rToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
-		rToken.Command.Flags().Set(FlagName, "newName")
-		time.Sleep(20 * time.Second)
+			// replace token
+			rToken := TokenReplaceCmd()
+			rToken.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			rToken.Command.Flags().Set(FlagTokenId, *newToken.GetId())
+			rToken.Command.Flags().Set(FlagName, "newName")
+			time.Sleep(20 * time.Second)
 
-		err = rToken.Command.Execute()
-		assert.NoError(t, err)
-		time.Sleep(20 * time.Second)
+			err = rToken.Command.Execute()
+			assert.NoError(t, err)
+			time.Sleep(20 * time.Second)
 
-		// delete registry
-		d := registry.RegDeleteCmd()
-		d.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			// delete registry
+			d := registry.RegDeleteCmd()
+			d.Command.Flags().Set(FlagRegId, *newReg.GetId())
+			viper.Set(core.GetFlagName(d.NS, constants.ArgForce), true)
 
-		err = d.Command.Execute()
-		assert.NoError(t, err)
+			err = d.Command.Execute()
+			assert.NoError(t, err)
 
-	})
+		},
+	)
 }

--- a/commands/dataplatform/cluster/delete.go
+++ b/commands/dataplatform/cluster/delete.go
@@ -18,42 +18,60 @@ import (
 )
 
 func ClusterDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.TODO(), nil, core.CommandBuilder{
-		Namespace: "dataplatform",
-		Resource:  "cluster",
-		Verb:      "delete",
-		Aliases:   []string{"del", "d"},
-		ShortDesc: "Delete a Dataplatform Cluster by ID",
-		Example:   "ionosctl dataplatform cluster delete --cluster-id <cluster-id>",
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId})
-		},
-		CmdRun: func(c *core.CommandConfig) error {
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c)
-			}
+	cmd := core.NewCommand(
+		context.TODO(), nil, core.CommandBuilder{
+			Namespace: "dataplatform",
+			Resource:  "cluster",
+			Verb:      "delete",
+			Aliases:   []string{"del", "d"},
+			ShortDesc: "Delete a Dataplatform Cluster by ID",
+			Example:   "ionosctl dataplatform cluster delete --cluster-id <cluster-id>",
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c)
+				}
 
-			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
-			if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster %s", clusterId), viper.GetBool(constants.ArgForce)) {
-				return fmt.Errorf(confirm.UserDenied)
-			}
+				clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
+				if !confirm.FAsk(
+					c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster %s", clusterId),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				) {
+					return fmt.Errorf(confirm.UserDenied)
+				}
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting cluster: %s", clusterId))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Deleting cluster: %s", clusterId),
+				)
 
-			_, _, err := client.Must().DataplatformClient.DataPlatformClusterApi.ClustersDelete(c.Context, clusterId).Execute()
-			if err != nil {
+				_, _, err := client.Must().DataplatformClient.DataPlatformClusterApi.ClustersDelete(
+					c.Context, clusterId,
+				).Execute()
+				if err != nil {
+					return err
+				}
+
 				return err
-			}
-
-			return err
+			},
+			InitClient: true,
 		},
-		InitClient: true,
-	})
+	)
 
-	cmd.AddStringFlag(constants.FlagClusterId, constants.FlagIdShort, "", "The unique ID of the cluster", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataplatformClusterIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	cmd.AddStringFlag(
+		constants.FlagClusterId, constants.FlagIdShort, "", "The unique ID of the cluster", core.RequiredFlagOption(),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataplatformClusterIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all clusters")
 
 	cmd.Command.SilenceUsage = true
@@ -68,16 +86,23 @@ func deleteAll(c *core.CommandConfig) error {
 		return err
 	}
 
-	err = functional.ApplyAndAggregateErrors(*xs.GetItems(), func(x ionoscloud.ClusterResponseData) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster %s (%s)", *x.Id, *x.Properties.Name), viper.GetBool(constants.ArgForce))
-		if yes {
-			_, _, delErr := client.Must().DataplatformClient.DataPlatformClusterApi.ClustersDelete(c.Context, *x.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s: %w", *x.Id, delErr)
+	err = functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(x ionoscloud.ClusterResponseData) error {
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster %s (%s)", *x.Id, *x.Properties.Name),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
+			if yes {
+				_, _, delErr := client.Must().DataplatformClient.DataPlatformClusterApi.ClustersDelete(
+					c.Context, *x.Id,
+				).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s: %w", *x.Id, delErr)
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		},
+	)
 
 	return err
 }

--- a/commands/dataplatform/nodepool/delete.go
+++ b/commands/dataplatform/nodepool/delete.go
@@ -18,49 +18,84 @@ import (
 )
 
 func NodepoolDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.TODO(), nil, core.CommandBuilder{
-		Namespace: "dataplatform",
-		Resource:  "nodepool",
-		Verb:      "delete",
-		Aliases:   []string{"del", "d"},
-		ShortDesc: "Delete a Dataplatform Cluster by ID",
-		Example:   "ionosctl dataplatform cluster delete --cluster-id <cluster-id>",
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId, constants.FlagNodepoolId}, []string{constants.ArgAll, constants.FlagClusterId})
+	cmd := core.NewCommand(
+		context.TODO(), nil, core.CommandBuilder{
+			Namespace: "dataplatform",
+			Resource:  "nodepool",
+			Verb:      "delete",
+			Aliases:   []string{"del", "d"},
+			ShortDesc: "Delete a Dataplatform Cluster by ID",
+			Example:   "ionosctl dataplatform cluster delete --cluster-id <cluster-id>",
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.ArgAll},
+					[]string{constants.FlagClusterId, constants.FlagNodepoolId},
+					[]string{constants.ArgAll, constants.FlagClusterId},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c, clusterId)
+				}
+
+				nodepoolId := viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))
+				np, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsFindById(
+					context.Background(), clusterId, nodepoolId,
+				).Execute()
+				if err != nil {
+					return fmt.Errorf("couldn't find nodepool: %w", err)
+				}
+
+				ok := confirm.FAsk(
+					c.Command.Command.InOrStdin(),
+					fmt.Sprintf("delete nodepool %s (%s)", nodepoolId, *np.Properties.Name),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				)
+				if !ok {
+					return fmt.Errorf("canceled deletion: invalid input")
+				}
+
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Deleting nodepool: %s", nodepoolId),
+				)
+				_, _, err = client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsDelete(
+					c.Context, clusterId, nodepoolId,
+				).Execute()
+				return err
+			},
+			InitClient: true,
 		},
-		CmdRun: func(c *core.CommandConfig) error {
-			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c, clusterId)
-			}
+	)
 
-			nodepoolId := viper.GetString(core.GetFlagName(c.NS, constants.FlagNodepoolId))
-			np, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsFindById(context.Background(), clusterId, nodepoolId).Execute()
-			if err != nil {
-				return fmt.Errorf("couldn't find nodepool: %w", err)
-			}
-
-			ok := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete nodepool %s (%s)", nodepoolId, *np.Properties.Name), viper.GetBool(constants.ArgForce))
-			if !ok {
-				return fmt.Errorf("canceled deletion: invalid input")
-			}
-
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting nodepool: %s", nodepoolId))
-			_, _, err = client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsDelete(c.Context, clusterId, nodepoolId).Execute()
-			return err
-		},
-		InitClient: true,
-	})
-
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddUUIDFlag(constants.FlagClusterId, "", "", "The unique ID of the cluster", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataplatformClusterIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	cmd.AddUUIDFlag(constants.FlagNodepoolId, constants.FlagIdShort, "", "The unique ID of the nodepool", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagNodepoolId, func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.DataplatformNodepoolsIds(viper.GetString(core.GetFlagName(cmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all clusters. If cluster ID is provided, delete all nodepools in given cluster")
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataplatformClusterIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	cmd.AddUUIDFlag(
+		constants.FlagNodepoolId, constants.FlagIdShort, "", "The unique ID of the nodepool", core.RequiredFlagOption(),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagNodepoolId,
+		func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.DataplatformNodepoolsIds(
+				viper.GetString(
+					core.GetFlagName(
+						cmd.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	cmd.AddBoolFlag(
+		constants.ArgAll, constants.ArgAllShort, false,
+		"Delete all clusters. If cluster ID is provided, delete all nodepools in given cluster",
+	)
 
 	cmd.Command.SilenceUsage = true
 
@@ -81,22 +116,33 @@ func deleteAll(c *core.CommandConfig, clusterId string) error {
 	}
 
 	// accumulate the error. If it's not nil break out of the fold
-	return functional.ApplyAndAggregateErrors(*ls.GetItems(), func(x ionoscloud.ClusterResponseData) error {
-		return deleteNodePools(c, *x.Id)
-	})
+	return functional.ApplyAndAggregateErrors(
+		*ls.GetItems(), func(x ionoscloud.ClusterResponseData) error {
+			return deleteNodePools(c, *x.Id)
+		},
+	)
 }
 
 func deleteNodePools(c *core.CommandConfig, clusterId string) error {
-	xs, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsGet(context.Background(), clusterId).Execute()
+	xs, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsGet(
+		context.Background(), clusterId,
+	).Execute()
 	if err != nil {
 		return err
 	}
-	return functional.ApplyAndAggregateErrors(*xs.GetItems(), func(x ionoscloud.NodePoolResponseData) error {
-		ok := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete nodepool %s (%s)", *x.Id, *x.Properties.Name), viper.GetBool(constants.ArgForce))
-		if !ok {
-			return fmt.Errorf("canceled deletion for %s (%s): invalid input", *x.Id, *x.Properties.Name)
-		}
-		_, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsDelete(context.Background(), clusterId, *x.Id).Execute()
-		return err
-	})
+	return functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(x ionoscloud.NodePoolResponseData) error {
+			ok := confirm.FAsk(
+				c.Command.Command.InOrStdin(), fmt.Sprintf("delete nodepool %s (%s)", *x.Id, *x.Properties.Name),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
+			if !ok {
+				return fmt.Errorf("canceled deletion for %s (%s): invalid input", *x.Id, *x.Properties.Name)
+			}
+			_, _, err := client.Must().DataplatformClient.DataPlatformNodePoolApi.ClustersNodepoolsDelete(
+				context.Background(), clusterId, *x.Id,
+			).Execute()
+			return err
+		},
+	)
 }

--- a/commands/dbaas/mongo/cluster/delete.go
+++ b/commands/dbaas/mongo/cluster/delete.go
@@ -43,55 +43,81 @@ func confirmStringForCluster(c sdkgo.ClusterResponse) string {
 }
 
 func ClusterDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.TODO(), nil, core.CommandBuilder{
-		Namespace: "dbaas-mongo",
-		Resource:  "cluster",
-		Verb:      "delete",
-		Aliases:   []string{"del", "d"},
-		ShortDesc: "Delete a Mongo Cluster by ID",
-		Example: `ionosctl dbaas mongo cluster delete --cluster-id <cluster-id>
+	cmd := core.NewCommand(
+		context.TODO(), nil, core.CommandBuilder{
+			Namespace: "dbaas-mongo",
+			Resource:  "cluster",
+			Verb:      "delete",
+			Aliases:   []string{"del", "d"},
+			ShortDesc: "Delete a Mongo Cluster by ID",
+			Example: `ionosctl dbaas mongo cluster delete --cluster-id <cluster-id>
 ionosctl db m c d --all
 ionosctl db m c d --all --name <name>`,
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId})
-		},
-		CmdRun: func(c *core.CommandConfig) error {
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c)
-			}
-
-			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
-			chosenCluster, _, err := client.Must().MongoClient.ClustersApi.ClustersFindById(context.Background(), clusterId).Execute()
-			if err != nil {
-				wrapped := fmt.Errorf("failed trying to find cluster by id: %w", err)
-				keepGoing := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("%s, try deleting %s anyways", wrapped.Error(), clusterId))
-				if !keepGoing {
-					return wrapped
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c)
 				}
-			}
 
-			ok := confirm.FAsk(c.Command.Command.InOrStdin(), confirmStringForCluster(chosenCluster), viper.GetBool(constants.ArgForce))
-			if !ok {
-				return fmt.Errorf(confirm.UserDenied)
-			}
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting cluster: %s", clusterId))
+				clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
+				chosenCluster, _, err := client.Must().MongoClient.ClustersApi.ClustersFindById(
+					context.Background(), clusterId,
+				).Execute()
+				if err != nil {
+					wrapped := fmt.Errorf("failed trying to find cluster by id: %w", err)
+					keepGoing := confirm.FAsk(
+						c.Command.Command.InOrStdin(),
+						fmt.Sprintf("%s, try deleting %s anyways", wrapped.Error(), clusterId),
+					)
+					if !keepGoing {
+						return wrapped
+					}
+				}
 
-			_, _, err = client.Must().MongoClient.ClustersApi.ClustersDelete(context.Background(), clusterId).Execute()
-			return err
+				ok := confirm.FAsk(
+					c.Command.Command.InOrStdin(), confirmStringForCluster(chosenCluster),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				)
+				if !ok {
+					return fmt.Errorf(confirm.UserDenied)
+				}
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateVerboseOutput("Deleting cluster: %s", clusterId),
+				)
+
+				_, _, err = client.Must().MongoClient.ClustersApi.ClustersDelete(
+					context.Background(), clusterId,
+				).Execute()
+				return err
+			},
+			InitClient: true,
 		},
-		InitClient: true,
-	})
+	)
 
-	cmd.AddStringFlag(constants.FlagClusterId, constants.FlagIdShort, "", "The unique ID of the cluster", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	cmd.AddStringFlag(
+		constants.FlagClusterId, constants.FlagIdShort, "", "The unique ID of the cluster", core.RequiredFlagOption(),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all mongo clusters")
 	cmd.AddBoolFlag(constants.FlagName, "", false, "When deleting all clusters, filter the clusters by a name")
 	cmd.AddStringSliceFlag(constants.ArgCols, "", nil, tabheaders.ColsMessage(allCols))
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false
@@ -106,14 +132,19 @@ func deleteAll(c *core.CommandConfig) error {
 		return err
 	}
 
-	return functional.ApplyAndAggregateErrors(*xs.GetItems(), func(x sdkgo.ClusterResponse) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), confirmStringForCluster(x), viper.GetBool(constants.ArgForce))
-		if yes {
-			_, _, delErr := client.Must().MongoClient.ClustersApi.ClustersDelete(c.Context, *x.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting cluster %s: %w", *x.Properties.DisplayName, delErr)
+	return functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(x sdkgo.ClusterResponse) error {
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(), confirmStringForCluster(x),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
+			if yes {
+				_, _, delErr := client.Must().MongoClient.ClustersApi.ClustersDelete(c.Context, *x.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting cluster %s: %w", *x.Properties.DisplayName, delErr)
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		},
+	)
 }

--- a/commands/dbaas/mongo/user/delete.go
+++ b/commands/dbaas/mongo/user/delete.go
@@ -19,57 +19,70 @@ import (
 )
 
 func UserDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.TODO(), nil, core.CommandBuilder{
-		Namespace: "dbaas-mongo",
-		Resource:  "user",
-		Verb:      "delete",
-		Aliases:   []string{"g"},
-		ShortDesc: "Delete a MongoDB user",
-		Example:   "ionosctl dbaas mongo user delete",
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.FlagClusterId, constants.ArgAll}, []string{constants.FlagClusterId, constants.FlagName})
+	cmd := core.NewCommand(
+		context.TODO(), nil, core.CommandBuilder{
+			Namespace: "dbaas-mongo",
+			Resource:  "user",
+			Verb:      "delete",
+			Aliases:   []string{"g"},
+			ShortDesc: "Delete a MongoDB user",
+			Example:   "ionosctl dbaas mongo user delete",
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.FlagClusterId, constants.ArgAll},
+					[]string{constants.FlagClusterId, constants.FlagName},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c, clusterId)
+				}
+				user := viper.GetString(core.GetFlagName(c.NS, constants.FlagName))
+
+				yes := confirm.FAsk(
+					c.Command.Command.InOrStdin(), fmt.Sprintf("delete user %s", user),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				)
+				if !yes {
+					return fmt.Errorf("operation canceled by confirmation check")
+				}
+
+				u, _, err := client.Must().MongoClient.UsersApi.
+					ClustersUsersDelete(context.Background(), clusterId, user).Execute()
+				if err != nil {
+					return err
+				}
+
+				cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
+
+				uConverted, err := resource2table.ConvertDbaasMongoUserToTable(u)
+				if err != nil {
+					return err
+				}
+
+				out, err := jsontabwriter.GenerateOutputPreconverted(
+					u, uConverted, tabheaders.GetHeadersAllDefault(allCols, cols),
+				)
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
+				return nil
+			},
+			InitClient: true,
 		},
-		CmdRun: func(c *core.CommandConfig) error {
-			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c, clusterId)
-			}
-			user := viper.GetString(core.GetFlagName(c.NS, constants.FlagName))
+	)
 
-			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete user %s", user),
-				viper.GetBool(constants.ArgForce))
-			if !yes {
-				return fmt.Errorf("operation canceled by confirmation check")
-			}
-
-			u, _, err := client.Must().MongoClient.UsersApi.
-				ClustersUsersDelete(context.Background(), clusterId, user).Execute()
-			if err != nil {
-				return err
-			}
-
-			cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
-
-			uConverted, err := resource2table.ConvertDbaasMongoUserToTable(u)
-			if err != nil {
-				return err
-			}
-
-			out, err := jsontabwriter.GenerateOutputPreconverted(u, uConverted, tabheaders.GetHeadersAllDefault(allCols, cols))
-			if err != nil {
-				return err
-			}
-
-			fmt.Fprintf(c.Command.Command.OutOrStdout(), out)
-			return nil
-		},
-		InitClient: true,
-	})
-
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddStringFlag(constants.FlagClusterId, constants.FlagIdShort, "", "The unique ID of the cluster")
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.MongoClusterIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	cmd.AddStringFlag(FlagDatabase, FlagDatabaseShort, "", "The authentication database")
 	cmd.AddStringFlag(constants.FlagName, "", "", "The authentication username")
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all users in a cluster")
@@ -86,15 +99,22 @@ func deleteAll(c *core.CommandConfig, clusterId string) error {
 		return err
 	}
 
-	return functional.ApplyAndAggregateErrors(*xs.GetItems(), func(x sdkgo.User) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete user %s", *x.Properties.Username), viper.GetBool(constants.ArgForce))
-		if !yes {
-			return fmt.Errorf("user %s skipped by confirmation check", *x.Properties.Username)
-		}
-		_, _, delErr := client.Must().MongoClient.UsersApi.ClustersUsersDelete(c.Context, clusterId, *x.Properties.Username).Execute()
-		if delErr != nil {
-			return fmt.Errorf("failed deleting one of the resources: %w", delErr)
-		}
-		return nil
-	})
+	return functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(x sdkgo.User) error {
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(), fmt.Sprintf("delete user %s", *x.Properties.Username),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
+			if !yes {
+				return fmt.Errorf("user %s skipped by confirmation check", *x.Properties.Username)
+			}
+			_, _, delErr := client.Must().MongoClient.UsersApi.ClustersUsersDelete(
+				c.Context, clusterId, *x.Properties.Username,
+			).Execute()
+			if delErr != nil {
+				return fmt.Errorf("failed deleting one of the resources: %w", delErr)
+			}
+			return nil
+		},
+	)
 }

--- a/commands/dbaas/postgres/cluster.go
+++ b/commands/dbaas/postgres/cluster.go
@@ -41,60 +41,83 @@ func ClusterCmd() *core.Command {
 	/*
 		List Command
 	*/
-	list := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace:  "dbaas-postgres",
-		Resource:   "cluster",
-		Verb:       "list",
-		Aliases:    []string{"l", "ls"},
-		ShortDesc:  "List PostgreSQL Clusters",
-		LongDesc:   "Use this command to retrieve a list of PostgreSQL Clusters provisioned under your account. You can filter the result based on Cluster Name using `--name` option.",
-		Example:    listClusterExample,
-		PreCmdRun:  core.NoPreRun,
-		CmdRun:     RunClusterList,
-		InitClient: true,
-	})
-	list.AddStringFlag(dbaaspg.ArgName, dbaaspg.ArgNameShort, "", "Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive")
+	list := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace:  "dbaas-postgres",
+			Resource:   "cluster",
+			Verb:       "list",
+			Aliases:    []string{"l", "ls"},
+			ShortDesc:  "List PostgreSQL Clusters",
+			LongDesc:   "Use this command to retrieve a list of PostgreSQL Clusters provisioned under your account. You can filter the result based on Cluster Name using `--name` option.",
+			Example:    listClusterExample,
+			PreCmdRun:  core.NoPreRun,
+			CmdRun:     RunClusterList,
+			InitClient: true,
+		},
+	)
+	list.AddStringFlag(
+		dbaaspg.ArgName, dbaaspg.ArgNameShort, "",
+		"Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive",
+	)
 	list.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = list.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = list.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Get Command
 	*/
-	get := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace:  "dbaas-postgres",
-		Resource:   "cluster",
-		Verb:       "get",
-		Aliases:    []string{"g"},
-		ShortDesc:  "Get a PostgreSQL Cluster",
-		Example:    getClusterExample,
-		LongDesc:   "Use this command to retrieve details about a PostgreSQL Cluster by using its ID.\n\nRequired values to run command:\n\n* Cluster Id",
-		PreCmdRun:  PreRunClusterId,
-		CmdRun:     RunClusterGet,
-		InitClient: true,
-	})
+	get := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace:  "dbaas-postgres",
+			Resource:   "cluster",
+			Verb:       "get",
+			Aliases:    []string{"g"},
+			ShortDesc:  "Get a PostgreSQL Cluster",
+			Example:    getClusterExample,
+			LongDesc:   "Use this command to retrieve details about a PostgreSQL Cluster by using its ID.\n\nRequired values to run command:\n\n* Cluster Id",
+			PreCmdRun:  PreRunClusterId,
+			CmdRun:     RunClusterGet,
+			InitClient: true,
+		},
+	)
 	get.AddUUIDFlag(constants.FlagClusterId, dbaaspg.ArgIdShort, "", dbaaspg.ClusterId, core.RequiredFlagOption())
-	_ = get.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	get.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for Cluster to be in AVAILABLE state")
-	get.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout, "Timeout option for Cluster to be in AVAILABLE state [seconds]")
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	get.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for Cluster to be in AVAILABLE state",
+	)
+	get.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout,
+		"Timeout option for Cluster to be in AVAILABLE state [seconds]",
+	)
 	get.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = get.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = get.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Create Command
 	*/
-	create := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace: "dbaas-postgres",
-		Resource:  "cluster",
-		Verb:      "create",
-		Aliases:   []string{"c"},
-		ShortDesc: "Create a PostgreSQL Cluster",
-		LongDesc: `Use this command to create a new PostgreSQL Cluster. You must set the unique ID of the Datacenter, the unique ID of the LAN, and IP and subnet. If the other options are not set, the default values will be used. Regarding the location field, if it is not manually set, it will be used the location of the Datacenter.
+	create := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace: "dbaas-postgres",
+			Resource:  "cluster",
+			Verb:      "create",
+			Aliases:   []string{"c"},
+			ShortDesc: "Create a PostgreSQL Cluster",
+			LongDesc: `Use this command to create a new PostgreSQL Cluster. You must set the unique ID of the Datacenter, the unique ID of the LAN, and IP and subnet. If the other options are not set, the default values will be used. Regarding the location field, if it is not manually set, it will be used the location of the Datacenter.
 
 Required values to run command:
 
@@ -102,197 +125,409 @@ Required values to run command:
 * Lan Id
 * CIDR (IP and subnet)
 * Credentials for the database user: Username and Password`,
-		Example:    createClusterExample,
-		PreCmdRun:  PreRunClusterCreate,
-		CmdRun:     RunClusterCreate,
-		InitClient: true,
-	})
+			Example:    createClusterExample,
+			PreCmdRun:  PreRunClusterCreate,
+			CmdRun:     RunClusterCreate,
+			InitClient: true,
+		},
+	)
 	create.AddStringFlag(dbaaspg.ArgVersion, dbaaspg.ArgVersionShort, "13", "The PostgreSQL version of your Cluster")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PostgresVersions(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddIntFlag(dbaaspg.ArgInstances, dbaaspg.ArgInstancesShort, 1, "The number of instances in your cluster (one master and n-1 standbys). Minimum: 1. Maximum: 5")
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgVersion,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PostgresVersions(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddIntFlag(
+		dbaaspg.ArgInstances, dbaaspg.ArgInstancesShort, 1,
+		"The number of instances in your cluster (one master and n-1 standbys). Minimum: 1. Maximum: 5",
+	)
 	create.AddIntFlag(dbaaspg.ArgCores, "", 2, "The number of CPU cores per instance. Minimum: 1")
-	create.AddStringFlag(dbaaspg.ArgRam, "", "3GB", "The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgRam, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgBackupLocation, dbaaspg.ArgBackupLocationShort, "", "The S3 location where the backups will be stored")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"de", "eu-south-2", "eu-central-2"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgSyncMode, dbaaspg.ArgSyncModeShort, "ASYNCHRONOUS", "Synchronization Mode. Represents different modes of replication")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgSyncMode, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"ASYNCHRONOUS", "SYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgStorageSize, "", "20GB", "The amount of storage per instance. The default unit is MB. e.g.: --size 20480 or --size 20480MB or --size 20GB")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgStorageSize, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"2048MB", "10GB", "20GB", "50GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgStorageType, "", "HDD", "The storage type used in your cluster: HDD, SSD, SSD_PREMIUM, SSD_STANDARD. (Value \"SSD\" is deprecated. Use the equivalent \"SSD_PREMIUM\" instead)")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgStorageType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HDD", "SSD", "SSD_PREMIUM", "SSD_STANDARD"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgLocation, "", "", "The physical location where the cluster will be created. It cannot be modified after datacenter creation. If not set, it will be used Datacenter's location")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cloudapiv6completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	create.AddStringFlag(
+		dbaaspg.ArgRam, "", "3GB",
+		"The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgRam,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgBackupLocation, dbaaspg.ArgBackupLocationShort, "",
+		"The S3 location where the backups will be stored",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgBackupLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"de", "eu-south-2", "eu-central-2"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgSyncMode, dbaaspg.ArgSyncModeShort, "ASYNCHRONOUS",
+		"Synchronization Mode. Represents different modes of replication",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgSyncMode,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"ASYNCHRONOUS", "SYNCHRONOUS", "STRICTLY_SYNCHRONOUS"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgStorageSize, "", "20GB",
+		"The amount of storage per instance. The default unit is MB. e.g.: --size 20480 or --size 20480MB or --size 20GB",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgStorageSize,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"2048MB", "10GB", "20GB", "50GB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgStorageType, "", "HDD",
+		"The storage type used in your cluster: HDD, SSD, SSD_PREMIUM, SSD_STANDARD. (Value \"SSD\" is deprecated. Use the equivalent \"SSD_PREMIUM\" instead)",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgStorageType,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"HDD", "SSD", "SSD_PREMIUM", "SSD_STANDARD"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgLocation, "", "",
+		"The physical location where the cluster will be created. It cannot be modified after datacenter creation. If not set, it will be used Datacenter's location",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cloudapiv6completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	create.AddStringFlag(dbaaspg.ArgName, dbaaspg.ArgNameShort, "UnnamedCluster", "The friendly name of your cluster")
-	create.AddUUIDFlag(dbaaspg.ArgDatacenterId, dbaaspg.ArgDatacenterIdShort, "", "The unique ID of the Datacenter to connect to your cluster", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgDatacenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cloudapiv6completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgLanId, dbaaspg.ArgLanIdShort, "", "The unique ID of the LAN to connect your cluster to", core.RequiredFlagOption())
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cloudapiv6completer.LansIds(viper.GetString(core.GetFlagName(create.NS, dbaaspg.ArgDatacenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgCidr, dbaaspg.ArgCidrShort, "", "The IP and subnet for the cluster. Note the following unavailable IP ranges: 10.233.64.0/18, 10.233.0.0/18, 10.233.114.0/24. e.g.: 192.168.1.100/24", core.RequiredFlagOption())
-	create.AddStringFlag(dbaaspg.ArgBackupId, dbaaspg.ArgBackupIdShort, "", "The unique ID of the backup you want to restore")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupsIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddStringFlag(dbaaspg.ArgRecoveryTime, dbaaspg.ArgRecoveryTimeShort, "", "If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely")
-	create.AddStringFlag(dbaaspg.ArgDbUsername, dbaaspg.ArgDbUsernameShort, "", "Username for the initial postgres user. Some system usernames are restricted (e.g. postgres, admin, standby)", core.RequiredFlagOption())
-	create.AddStringFlag(dbaaspg.ArgDbPassword, dbaaspg.ArgDbPasswordShort, "", "Password for the initial postgres user", core.RequiredFlagOption())
-	create.AddStringFlag(dbaaspg.ArgMaintenanceTime, dbaaspg.ArgMaintenanceTimeShort, "", "Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59")
-	create.AddStringFlag(dbaaspg.ArgMaintenanceDay, dbaaspg.ArgMaintenanceDayShort, "", "Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur")
-	_ = create.Command.RegisterFlagCompletionFunc(dbaaspg.ArgMaintenanceDay, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	create.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for Cluster to be in AVAILABLE state")
-	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout, "Timeout option for Cluster to be in AVAILABLE state[seconds]")
+	create.AddUUIDFlag(
+		dbaaspg.ArgDatacenterId, dbaaspg.ArgDatacenterIdShort, "",
+		"The unique ID of the Datacenter to connect to your cluster", core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgDatacenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cloudapiv6completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgLanId, dbaaspg.ArgLanIdShort, "", "The unique ID of the LAN to connect your cluster to",
+		core.RequiredFlagOption(),
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cloudapiv6completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						create.NS, dbaaspg.ArgDatacenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgCidr, dbaaspg.ArgCidrShort, "",
+		"The IP and subnet for the cluster. Note the following unavailable IP ranges: 10.233.64.0/18, 10.233.0.0/18, 10.233.114.0/24. e.g.: 192.168.1.100/24",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgBackupId, dbaaspg.ArgBackupIdShort, "", "The unique ID of the backup you want to restore",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgBackupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupsIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgRecoveryTime, dbaaspg.ArgRecoveryTimeShort, "",
+		"If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely",
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgDbUsername, dbaaspg.ArgDbUsernameShort, "",
+		"Username for the initial postgres user. Some system usernames are restricted (e.g. postgres, admin, standby)",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgDbPassword, dbaaspg.ArgDbPasswordShort, "", "Password for the initial postgres user",
+		core.RequiredFlagOption(),
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgMaintenanceTime, dbaaspg.ArgMaintenanceTimeShort, "",
+		"Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59",
+	)
+	create.AddStringFlag(
+		dbaaspg.ArgMaintenanceDay, dbaaspg.ArgMaintenanceDayShort, "",
+		"Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur",
+	)
+	_ = create.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgMaintenanceDay,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	create.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for Cluster to be in AVAILABLE state",
+	)
+	create.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout,
+		"Timeout option for Cluster to be in AVAILABLE state[seconds]",
+	)
 	create.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = create.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = create.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Update Command
 	*/
-	update := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace: "dbaas-postgres",
-		Resource:  "cluster",
-		Verb:      "update",
-		Aliases:   []string{"u", "up"},
-		ShortDesc: "Update a PostgreSQL Cluster",
-		LongDesc: `Use this command to update attributes of a PostgreSQL Cluster.
+	update := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace: "dbaas-postgres",
+			Resource:  "cluster",
+			Verb:      "update",
+			Aliases:   []string{"u", "up"},
+			ShortDesc: "Update a PostgreSQL Cluster",
+			LongDesc: `Use this command to update attributes of a PostgreSQL Cluster.
 
 Required values to run command:
 
 * Cluster Id`,
-		Example:    updateClusterExample,
-		PreCmdRun:  PreRunClusterId,
-		CmdRun:     RunClusterUpdate,
-		InitClient: true,
-	})
+			Example:    updateClusterExample,
+			PreCmdRun:  PreRunClusterId,
+			CmdRun:     RunClusterUpdate,
+			InitClient: true,
+		},
+	)
 	update.AddUUIDFlag(constants.FlagClusterId, dbaaspg.ArgIdShort, "", dbaaspg.ClusterId, core.RequiredFlagOption())
-	_ = update.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(dbaaspg.ArgVersion, dbaaspg.ArgVersionShort, "", "The PostgreSQL version of your cluster")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.PostgresVersions(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgVersion,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.PostgresVersions(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddBoolFlag(dbaaspg.ArgRemoveConnection, "", false, "Remove the connection completely")
-	update.AddUUIDFlag(dbaaspg.ArgDatacenterId, dbaaspg.ArgDatacenterIdShort, "", "The unique ID of the Datacenter to connect to your cluster. It has to be in the same location as the current datacenter")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgDatacenterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cloudapiv6completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(dbaaspg.ArgLanId, dbaaspg.ArgLanIdShort, "", "The unique ID of the LAN to connect your cluster to")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgLanId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cloudapiv6completer.LansIds(viper.GetString(core.GetFlagName(update.NS, dbaaspg.ArgDatacenterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(dbaaspg.ArgCidr, dbaaspg.ArgCidrShort, "", "The IP and subnet for the cluster. Note the following unavailable IP ranges: 10.233.64.0/18, 10.233.0.0/18, 10.233.114.0/24. e.g.: 192.168.1.100/24")
-	update.AddIntFlag(dbaaspg.ArgInstances, dbaaspg.ArgInstancesShort, 0, "The number of instances in your cluster. Minimum: 0. Maximum: 5")
+	update.AddUUIDFlag(
+		dbaaspg.ArgDatacenterId, dbaaspg.ArgDatacenterIdShort, "",
+		"The unique ID of the Datacenter to connect to your cluster. It has to be in the same location as the current datacenter",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgDatacenterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cloudapiv6completer.DataCentersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		dbaaspg.ArgLanId, dbaaspg.ArgLanIdShort, "", "The unique ID of the LAN to connect your cluster to",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgLanId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cloudapiv6completer.LansIds(
+				viper.GetString(
+					core.GetFlagName(
+						update.NS, dbaaspg.ArgDatacenterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		dbaaspg.ArgCidr, dbaaspg.ArgCidrShort, "",
+		"The IP and subnet for the cluster. Note the following unavailable IP ranges: 10.233.64.0/18, 10.233.0.0/18, 10.233.114.0/24. e.g.: 192.168.1.100/24",
+	)
+	update.AddIntFlag(
+		dbaaspg.ArgInstances, dbaaspg.ArgInstancesShort, 0,
+		"The number of instances in your cluster. Minimum: 0. Maximum: 5",
+	)
 	update.AddIntFlag(dbaaspg.ArgCores, "", 0, "The number of CPU cores per instance")
-	update.AddStringFlag(dbaaspg.ArgRam, "", "", "The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgRam, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddStringFlag(dbaaspg.ArgStorageSize, "", "", "The amount of storage per instance. The default unit is MB. e.g.: --size 20480 or --size 20480MB or --size 20GB")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgStorageSize, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"2048MB", "10GB", "20GB", "50GB"}, cobra.ShellCompDirectiveNoFileComp
-	})
+	update.AddStringFlag(
+		dbaaspg.ArgRam, "", "",
+		"The amount of memory per instance. Size must be specified in multiples of 1024. The default unit is MB. Minimum: 2048. e.g. --ram 2048, --ram 2048MB, --ram 2GB",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgRam,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"2GB", "3GB", "4GB", "5GB", "10GB", "16GB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddStringFlag(
+		dbaaspg.ArgStorageSize, "", "",
+		"The amount of storage per instance. The default unit is MB. e.g.: --size 20480 or --size 20480MB or --size 20GB",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgStorageSize,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"2048MB", "10GB", "20GB", "50GB"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	update.AddStringFlag(dbaaspg.ArgName, dbaaspg.ArgNameShort, "", "The friendly name of your cluster")
-	update.AddStringFlag(dbaaspg.ArgMaintenanceTime, dbaaspg.ArgMaintenanceTimeShort, "", "Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59")
-	update.AddStringFlag(dbaaspg.ArgMaintenanceDay, dbaaspg.ArgMaintenanceDayShort, "", "Day of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur")
-	_ = update.Command.RegisterFlagCompletionFunc(dbaaspg.ArgMaintenanceDay, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	update.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for Cluster to be in AVAILABLE state")
-	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout, "Timeout option for Cluster to be in AVAILABLE state[seconds]")
+	update.AddStringFlag(
+		dbaaspg.ArgMaintenanceTime, dbaaspg.ArgMaintenanceTimeShort, "",
+		"Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59",
+	)
+	update.AddStringFlag(
+		dbaaspg.ArgMaintenanceDay, dbaaspg.ArgMaintenanceDayShort, "",
+		"Day of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur",
+	)
+	_ = update.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgMaintenanceDay,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{
+				"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+			}, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	update.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for Cluster to be in AVAILABLE state",
+	)
+	update.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout,
+		"Timeout option for Cluster to be in AVAILABLE state[seconds]",
+	)
 	update.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = update.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = update.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Restore Command
 	*/
-	restoreCmd := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace: "dbaas-postgres",
-		Resource:  "cluster",
-		Verb:      "restore",
-		Aliases:   []string{"r"},
-		ShortDesc: "Restore a PostgreSQL Cluster",
-		LongDesc: `Use this command to trigger an in-place restore of the specified PostgreSQL Cluster.
+	restoreCmd := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace: "dbaas-postgres",
+			Resource:  "cluster",
+			Verb:      "restore",
+			Aliases:   []string{"r"},
+			ShortDesc: "Restore a PostgreSQL Cluster",
+			LongDesc: `Use this command to trigger an in-place restore of the specified PostgreSQL Cluster.
 
 Required values to run command:
 
 * Cluster Id
 * Backup Id`,
-		Example:    restoreClusterExample,
-		PreCmdRun:  PreRunClusterBackupIds,
-		CmdRun:     RunClusterRestore,
-		InitClient: true,
-	})
-	restoreCmd.AddUUIDFlag(constants.FlagClusterId, dbaaspg.ArgIdShort, "", dbaaspg.ClusterId, core.RequiredFlagOption())
-	_ = restoreCmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
-	restoreCmd.AddStringFlag(dbaaspg.ArgBackupId, "", "", "The unique ID of the backup you want to restore", core.RequiredFlagOption())
-	_ = restoreCmd.Command.RegisterFlagCompletionFunc(dbaaspg.ArgBackupId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.BackupsIdsForCluster(viper.GetString(core.GetFlagName(restoreCmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
-	})
-	restoreCmd.AddStringFlag(dbaaspg.ArgRecoveryTime, dbaaspg.ArgRecoveryTimeShort, "", "If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely")
-	restoreCmd.AddBoolFlag(constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for Cluster to be in AVAILABLE state")
-	restoreCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout, "Timeout option for Cluster to be in AVAILABLE state[seconds]")
+			Example:    restoreClusterExample,
+			PreCmdRun:  PreRunClusterBackupIds,
+			CmdRun:     RunClusterRestore,
+			InitClient: true,
+		},
+	)
+	restoreCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	restoreCmd.AddUUIDFlag(
+		constants.FlagClusterId, dbaaspg.ArgIdShort, "", dbaaspg.ClusterId, core.RequiredFlagOption(),
+	)
+	_ = restoreCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	restoreCmd.AddStringFlag(
+		dbaaspg.ArgBackupId, "", "", "The unique ID of the backup you want to restore", core.RequiredFlagOption(),
+	)
+	_ = restoreCmd.Command.RegisterFlagCompletionFunc(
+		dbaaspg.ArgBackupId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.BackupsIdsForCluster(
+				viper.GetString(
+					core.GetFlagName(
+						restoreCmd.NS, constants.FlagClusterId,
+					),
+				),
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	restoreCmd.AddStringFlag(
+		dbaaspg.ArgRecoveryTime, dbaaspg.ArgRecoveryTimeShort, "",
+		"If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely",
+	)
+	restoreCmd.AddBoolFlag(
+		constants.ArgWaitForState, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for Cluster to be in AVAILABLE state",
+	)
+	restoreCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout,
+		"Timeout option for Cluster to be in AVAILABLE state[seconds]",
+	)
 	restoreCmd.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = restoreCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = restoreCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	/*
 		Delete Command
 	*/
-	deleteCmd := core.NewCommand(ctx, clusterCmd, core.CommandBuilder{
-		Namespace: "dbaas-postgres",
-		Resource:  "cluster",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete a PostgreSQL Cluster",
-		LongDesc: `Use this command to delete a specified PostgreSQL Cluster from your account. You can wait for the cluster to be deleted with the wait-for-deletion option.
+	deleteCmd := core.NewCommand(
+		ctx, clusterCmd, core.CommandBuilder{
+			Namespace: "dbaas-postgres",
+			Resource:  "cluster",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete a PostgreSQL Cluster",
+			LongDesc: `Use this command to delete a specified PostgreSQL Cluster from your account. You can wait for the cluster to be deleted with the wait-for-deletion option.
 
 Required values to run command:
 
 * Cluster Id`,
-		Example:    deleteClusterExample,
-		PreCmdRun:  PreRunClusterDelete,
-		CmdRun:     RunClusterDelete,
-		InitClient: true,
-	})
+			Example:    deleteClusterExample,
+			PreCmdRun:  PreRunClusterDelete,
+			CmdRun:     RunClusterDelete,
+			InitClient: true,
+		},
+	)
+	deleteCmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	deleteCmd.AddUUIDFlag(constants.FlagClusterId, dbaaspg.ArgIdShort, "", dbaaspg.ClusterId, core.RequiredFlagOption())
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.FlagClusterId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagClusterId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.ClustersIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	deleteCmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all Clusters")
-	deleteCmd.AddStringFlag(dbaaspg.ArgName, dbaaspg.ArgNameShort, "", "Delete all Clusters after filtering based on name. It does not require an exact match. Can be used with --all flag")
-	deleteCmd.AddBoolFlag(constants.ArgWaitForDelete, constants.ArgWaitForStateShort, constants.DefaultWait, "Wait for Cluster to be completely removed")
-	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout, "Timeout option for Cluster to be completely removed[seconds]")
+	deleteCmd.AddStringFlag(
+		dbaaspg.ArgName, dbaaspg.ArgNameShort, "",
+		"Delete all Clusters after filtering based on name. It does not require an exact match. Can be used with --all flag",
+	)
+	deleteCmd.AddBoolFlag(
+		constants.ArgWaitForDelete, constants.ArgWaitForStateShort, constants.DefaultWait,
+		"Wait for Cluster to be completely removed",
+	)
+	deleteCmd.AddIntFlag(
+		constants.ArgTimeout, constants.ArgTimeoutShort, dbaaspg.DefaultClusterTimeout,
+		"Timeout option for Cluster to be completely removed[seconds]",
+	)
 	deleteCmd.AddStringSliceFlag(constants.ArgCols, "", defaultClusterCols, tabheaders.ColsMessage(allClusterCols))
-	_ = deleteCmd.Command.RegisterFlagCompletionFunc(constants.ArgCols, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return allClusterCols, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = deleteCmd.Command.RegisterFlagCompletionFunc(
+		constants.ArgCols,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return allClusterCols, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	clusterCmd.AddCommand(ClusterBackupCmd())
 
@@ -318,7 +553,10 @@ func PreRunClusterDelete(c *core.PreCommandConfig) error {
 }
 
 func PreRunClusterCreate(c *core.PreCommandConfig) error {
-	err := core.CheckRequiredFlags(c.Command, c.NS, dbaaspg.ArgDatacenterId, dbaaspg.ArgLanId, dbaaspg.ArgCidr, dbaaspg.ArgDbUsername, dbaaspg.ArgDbPassword)
+	err := core.CheckRequiredFlags(
+		c.Command, c.NS, dbaaspg.ArgDatacenterId, dbaaspg.ArgLanId, dbaaspg.ArgCidr, dbaaspg.ArgDbUsername,
+		dbaaspg.ArgDbPassword,
+	)
 	if err != nil {
 		return err
 	}
@@ -326,7 +564,11 @@ func PreRunClusterCreate(c *core.PreCommandConfig) error {
 	if viper.GetInt32(core.GetFlagName(c.NS, dbaaspg.ArgCores)) < 1 {
 		return errors.New("cores must be set to minimum: 1")
 	}
-	if viper.GetInt32(core.GetFlagName(c.NS, dbaaspg.ArgInstances)) < 1 || viper.GetInt32(core.GetFlagName(c.NS, dbaaspg.ArgInstances)) > 5 {
+	if viper.GetInt32(core.GetFlagName(c.NS, dbaaspg.ArgInstances)) < 1 || viper.GetInt32(
+		core.GetFlagName(
+			c.NS, dbaaspg.ArgInstances,
+		),
+	) > 5 {
 		return errors.New("instances must be set to minimum: 1, maximum: 5")
 	}
 	return nil
@@ -340,10 +582,20 @@ func RunClusterList(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Clusters..."))
 
 	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgName)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Filtering after Cluster Name: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Filtering after Cluster Name: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName)),
+			),
+		)
 	}
 
-	clusters, _, err := c.CloudApiDbaasPgsqlServices.Clusters().List(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName)))
+	clusters, _, err := c.CloudApiDbaasPgsqlServices.Clusters().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, dbaaspg.ArgName,
+			),
+		),
+	)
 	if err != nil {
 		return err
 	}
@@ -355,8 +607,10 @@ func RunClusterList(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(clusters, clustersConverted,
-		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		clusters, clustersConverted,
+		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -366,14 +620,26 @@ func RunClusterList(c *core.CommandConfig) error {
 }
 
 func RunClusterGet(c *core.CommandConfig) error {
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.ClusterId, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			constants.ClusterId, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		),
+	)
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Cluster..."))
 
-	if err := waitfor.WaitForState(c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))); err != nil {
+	if err := waitfor.WaitForState(
+		c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+	); err != nil {
 		return err
 	}
 
-	cluster, _, err := c.CloudApiDbaasPgsqlServices.Clusters().Get(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)))
+	cluster, _, err := c.CloudApiDbaasPgsqlServices.Clusters().Get(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, constants.FlagClusterId,
+			),
+		),
+	)
 	if err != nil {
 		return err
 	}
@@ -385,8 +651,10 @@ func RunClusterGet(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(cluster, clusterConverted,
-		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		cluster, clusterConverted,
+		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -429,8 +697,10 @@ func RunClusterCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(cluster, clusterConverted,
-		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		cluster, clusterConverted,
+		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -457,11 +727,16 @@ func RunClusterUpdate(c *core.CommandConfig) error {
 	}
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgWaitForState)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Wait 10 seconds before checking state..."))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Wait 10 seconds before checking state..."),
+		)
 		// TODO: Sleeping 10 seconds to make sure the cluster is in BUSY state. This will be removed in future releases.
 		time.Sleep(10 * time.Second)
 
-		if err = waitfor.WaitForState(c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))); err != nil {
+		if err = waitfor.WaitForState(
+			c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+		); err != nil {
 			return err
 		}
 	}
@@ -473,8 +748,10 @@ func RunClusterUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	out, err := jsontabwriter.GenerateOutputPreconverted(item, clusterConverted,
-		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols))
+	out, err := jsontabwriter.GenerateOutputPreconverted(
+		item, clusterConverted,
+		tabheaders.GetHeaders(allClusterCols, defaultClusterCols, cols),
+	)
 	if err != nil {
 		return err
 	}
@@ -490,7 +767,10 @@ func RunClusterRestore(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.ClusterId, clusterId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Backup ID: %v", backupId))
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("restore cluster with id: %v from backup: %v", clusterId, backupId), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("restore cluster with id: %v from backup: %v", clusterId, backupId),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -501,9 +781,16 @@ func RunClusterRestore(c *core.CommandConfig) error {
 	}
 
 	if viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Setting RecoveryTargetTime [RFC3339 format]: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Setting RecoveryTargetTime [RFC3339 format]: %v",
+				viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)),
+			),
+		)
 
-		recoveryTargetTime, err := time.Parse(time.RFC3339, viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)))
+		recoveryTargetTime, err := time.Parse(
+			time.RFC3339, viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)),
+		)
 		if err != nil {
 			return err
 		}
@@ -511,17 +798,23 @@ func RunClusterRestore(c *core.CommandConfig) error {
 		input.SetRecoveryTargetTime(recoveryTargetTime)
 	}
 
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Restoring Cluster from Backup..."))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Restoring Cluster from Backup..."),
+	)
 
 	_, err := c.CloudApiDbaasPgsqlServices.Restores().Restore(clusterId, input)
 	if err != nil {
 		return err
 	}
-	if err = waitfor.WaitForState(c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))); err != nil {
+	if err = waitfor.WaitForState(
+		c, waiter.ClusterStateInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+	); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("PostgreSQL Cluster successfully restored"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("PostgreSQL Cluster successfully restored"),
+	)
 	return nil
 }
 
@@ -531,7 +824,10 @@ func RunClusterDelete(c *core.CommandConfig) error {
 			return err
 		}
 
-		fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("PostgreSQL Clusters successfully deleted"))
+		fmt.Fprintf(
+			c.Command.Command.OutOrStdout(),
+			jsontabwriter.GenerateLogOutput("PostgreSQL Clusters successfully deleted"),
+		)
 		return nil
 	}
 
@@ -539,7 +835,10 @@ func RunClusterDelete(c *core.CommandConfig) error {
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(constants.ClusterId, clusterId))
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster with id: %v", clusterId), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete cluster with id: %v", clusterId),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -549,11 +848,15 @@ func RunClusterDelete(c *core.CommandConfig) error {
 	if err != nil {
 		return err
 	}
-	if err = waitfor.WaitForDelete(c, waiter.ClusterDeleteInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))); err != nil {
+	if err = waitfor.WaitForDelete(
+		c, waiter.ClusterDeleteInterrogator, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)),
+	); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("PostgreSQL Cluster successfully deleted"))
+	fmt.Fprintf(
+		c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("PostgreSQL Cluster successfully deleted"),
+	)
 	return nil
 }
 
@@ -561,10 +864,20 @@ func ClusterDeleteAll(c *core.CommandConfig) error {
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting all Clusters..."))
 
 	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgName)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Filtering based on Cluster Name: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Filtering based on Cluster Name: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName)),
+			),
+		)
 	}
 
-	clusters, _, err := c.CloudApiDbaasPgsqlServices.Clusters().List(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName)))
+	clusters, _, err := c.CloudApiDbaasPgsqlServices.Clusters().List(
+		viper.GetString(
+			core.GetFlagName(
+				c.NS, dbaaspg.ArgName,
+			),
+		),
+	)
 	if err != nil {
 		return err
 	}
@@ -594,7 +907,9 @@ func ClusterDeleteAll(c *core.CommandConfig) error {
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(log))
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), "delete ALL clusters", viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), "delete ALL clusters", viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
@@ -616,7 +931,10 @@ func ClusterDeleteAll(c *core.CommandConfig) error {
 			continue
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *idOk))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *idOk),
+		)
 
 		if err = waitfor.WaitForDelete(c, waiter.ClusterDeleteInterrogator, *idOk); err != nil {
 			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *idOk, err))
@@ -636,11 +954,15 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 
 	// Setting Attributes
 	pgsqlVersion := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgVersion))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("PostgresVersion: %v", pgsqlVersion))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("PostgresVersion: %v", pgsqlVersion),
+	)
 	input.SetPostgresVersion(pgsqlVersion)
 
 	syncMode := strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgSyncMode)))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SynchronizationMode: %v", syncMode))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("SynchronizationMode: %v", syncMode),
+	)
 	input.SetSynchronizationMode(sdkgo.SynchronizationMode(syncMode))
 
 	replicas := viper.GetInt32(core.GetFlagName(c.NS, dbaaspg.ArgInstances))
@@ -660,12 +982,16 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Ram: %v[MB]", int32(size)))
 
 	// Convert StorageSize
-	storageSize, err := utils2.ConvertSize(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgStorageSize)), utils2.MegaBytes)
+	storageSize, err := utils2.ConvertSize(
+		viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgStorageSize)), utils2.MegaBytes,
+	)
 	if err != nil {
 		return nil, err
 	}
 	input.SetStorageSize(int32(storageSize))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("StorageSize: %v[MB]", int32(storageSize)))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("StorageSize: %v[MB]", int32(storageSize)),
+	)
 	storageType := strings.ToUpper(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgStorageType)))
 	if storageType == "SSD_PREMIUM" || storageType == "SSD PREMIUM" {
 		storageType = string(sdkgo.SSD_PREMIUM)
@@ -677,7 +1003,11 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 	input.SetStorageType(sdkgo.StorageType(storageType))
 
 	if viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgBackupLocation)) != "" {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Backup Location: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgBackupLocation))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Backup Location: %v", viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgBackupLocation)),
+			),
+		)
 		input.SetBackupLocation(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgBackupLocation)))
 	}
 
@@ -686,15 +1016,25 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Location: %v", location))
 		input.SetLocation(location)
 	} else {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Location from VDC..."))
-		vdc, _, err := c.CloudApiV6Services.DataCenters().Get(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId)), cloudapiv6resources.QueryParams{})
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting Location from VDC..."),
+		)
+		vdc, _, err := c.CloudApiV6Services.DataCenters().Get(
+			viper.GetString(
+				core.GetFlagName(
+					c.NS, dbaaspg.ArgDatacenterId,
+				),
+			), cloudapiv6resources.QueryParams{},
+		)
 		if err != nil {
 			return nil, err
 		}
 
 		if properties, ok := vdc.GetPropertiesOk(); ok && properties != nil {
 			if location, ok := properties.GetLocationOk(); ok && location != nil {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Location: %v", *location))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Location: %v", *location),
+				)
 				input.SetLocation(*location)
 			}
 		}
@@ -717,7 +1057,9 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 
 	vdcConnection := sdkgo.Connection{}
 	vdcId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId))
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Connection - DatacenterId: %v", vdcId))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Connection - DatacenterId: %v", vdcId),
+	)
 	vdcConnection.SetDatacenterId(vdcId)
 
 	lanId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgLanId))
@@ -738,13 +1080,19 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime)) {
 			maintenanceTime := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("MaintenanceWindow - Time: %v", maintenanceTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("MaintenanceWindow - Time: %v", maintenanceTime),
+			)
 			maintenanceWindow.SetTime(maintenanceTime)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceDay)) {
 			maintenanceDay := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceDay))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("MaintenanceWindow - DayOfTheWeek: %v", maintenanceDay))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("MaintenanceWindow - DayOfTheWeek: %v", maintenanceDay),
+			)
 			maintenanceWindow.SetDayOfTheWeek(sdkgo.DayOfTheWeek(maintenanceDay))
 		}
 
@@ -756,18 +1104,27 @@ func getCreateClusterRequest(c *core.CommandConfig) (*resources.CreateClusterReq
 		createRestoreRequest := sdkgo.CreateRestoreRequest{}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)) {
-			recoveryTargetTime, err := time.Parse(time.RFC3339, viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)))
+			recoveryTargetTime, err := time.Parse(
+				time.RFC3339, viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgRecoveryTime)),
+			)
 			if err != nil {
 				return nil, err
 			}
 
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("From Backup - RecoveryTargetTime [RFC3339 format]: %v", recoveryTargetTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+					"From Backup - RecoveryTargetTime [RFC3339 format]: %v", recoveryTargetTime,
+				),
+			)
 			createRestoreRequest.SetRecoveryTargetTime(recoveryTargetTime)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgBackupId)) {
 			backupId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgBackupId))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("From Backup - BackupId: %v", backupId))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("From Backup - BackupId: %v", backupId),
+			)
 			createRestoreRequest.SetBackupId(backupId)
 		}
 
@@ -807,67 +1164,98 @@ func getPatchClusterRequest(c *core.CommandConfig) (*resources.PatchClusterReque
 
 	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgStorageSize)) {
 		// Convert StorageSize
-		storageSize, err := utils2.ConvertSize(viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgStorageSize)), utils2.MegaBytes)
+		storageSize, err := utils2.ConvertSize(
+			viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgStorageSize)), utils2.MegaBytes,
+		)
 		if err != nil {
 			return nil, err
 		}
 
 		input.SetStorageSize(int32(storageSize))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("StorageSize: %vMB", storageSize))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("StorageSize: %vMB", storageSize),
+		)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgVersion)) {
 		pgsqlVersion := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgVersion))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("PostgresVersion: %v", pgsqlVersion))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("PostgresVersion: %v", pgsqlVersion),
+		)
 		input.SetPostgresVersion(pgsqlVersion)
 	}
 
 	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgName)) {
 		displayName := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgName))
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("DisplayName: %v", displayName))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("DisplayName: %v", displayName),
+		)
 		input.SetDisplayName(displayName)
 	}
 
-	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime)) || viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceDay)) {
+	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, dbaaspg.ArgMaintenanceDay,
+		),
+	) {
 		maintenanceWindow := sdkgo.MaintenanceWindow{}
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime)) {
 			maintenanceTime := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceTime))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("MaintenanceTime: %v", maintenanceTime))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("MaintenanceTime: %v", maintenanceTime),
+			)
 			maintenanceWindow.SetTime(maintenanceTime)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceDay)) {
 			maintenanceDay := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgMaintenanceDay))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("MaintenanceDayOfWeek: %v", maintenanceDay))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("MaintenanceDayOfWeek: %v", maintenanceDay),
+			)
 			maintenanceWindow.SetDayOfTheWeek(sdkgo.DayOfTheWeek(maintenanceDay))
 		}
 
 		input.SetMaintenanceWindow(maintenanceWindow)
 	}
 
-	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId)) || viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgLanId)) || viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgCidr)) {
+	if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId)) || viper.IsSet(
+		core.GetFlagName(
+			c.NS, dbaaspg.ArgLanId,
+		),
+	) || viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgCidr)) {
 		connection, err := getConnectionFromCluster(c, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)))
 		if err != nil {
 			return nil, err
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(getConnectionMessage(connection)))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(getConnectionMessage(connection)),
+		)
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId)) {
 			lanId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgDatacenterId))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updated Datacenter Id: %v", lanId))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(),
+				jsontabwriter.GenerateVerboseOutput("Updated Datacenter Id: %v", lanId),
+			)
 			connection.SetDatacenterId(lanId)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgLanId)) {
 			lanId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgLanId))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updated Lan Id: %v", lanId))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updated Lan Id: %v", lanId),
+			)
 			connection.SetLanId(lanId)
 		}
 
 		if viper.IsSet(core.GetFlagName(c.NS, dbaaspg.ArgCidr)) {
 			cidrId := viper.GetString(core.GetFlagName(c.NS, dbaaspg.ArgCidr))
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updated Cidr: %v", cidrId))
+			fmt.Fprintf(
+				c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Updated Cidr: %v", cidrId),
+			)
 			connection.SetCidr(cidrId)
 		}
 
@@ -880,8 +1268,11 @@ func getPatchClusterRequest(c *core.CommandConfig) (*resources.PatchClusterReque
 			return nil, err
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-			"Removing Connection with: %v...", getConnectionMessage(connection)))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				"Removing Connection with: %v...", getConnectionMessage(connection),
+			),
+		)
 		input.SetConnections([]sdkgo.Connection{})
 
 	}
@@ -897,7 +1288,10 @@ func getConnectionFromCluster(c *core.CommandConfig, clusterId string) (sdkgo.Co
 			return sdkgo.Connection{}, err
 		}
 
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting properties from cluster with Id: %v", clusterId))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(),
+			jsontabwriter.GenerateVerboseOutput("Getting properties from cluster with Id: %v", clusterId),
+		)
 		if propertiesOk, ok := oldCluster.GetPropertiesOk(); ok && propertiesOk != nil {
 			fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Getting connection.."))
 
@@ -935,7 +1329,12 @@ func getConnectionMessage(connection sdkgo.Connection) string {
 // Output Printing
 
 var (
-	defaultClusterCols = []string{"ClusterId", "DisplayName", "Location", "DatacenterId", "LanId", "Cidr", "Instances", "State"}
-	allClusterCols     = []string{"ClusterId", "DisplayName", "Location", "State", "PostgresVersion", "Instances", "Ram", "Cores",
-		"StorageSize", "StorageType", "DatacenterId", "LanId", "Cidr", "MaintenanceWindow", "SynchronizationMode", "BackupLocation"}
+	defaultClusterCols = []string{
+		"ClusterId", "DisplayName", "Location", "DatacenterId", "LanId", "Cidr", "Instances", "State",
+	}
+	allClusterCols = []string{
+		"ClusterId", "DisplayName", "Location", "State", "PostgresVersion", "Instances", "Ram", "Cores",
+		"StorageSize", "StorageType", "DatacenterId", "LanId", "Cidr", "MaintenanceWindow", "SynchronizationMode",
+		"BackupLocation",
+	}
 )

--- a/commands/dbaas/postgres/cluster_test.go
+++ b/commands/dbaas/postgres/cluster_test.go
@@ -379,1058 +379,1199 @@ func TestClusterCmd(t *testing.T) {
 func TestPreClusterId(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		err := PreRunClusterId(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			err := PreRunClusterId(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreClusterIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunClusterId(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunClusterId(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterBackupIds(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		err := PreRunClusterBackupIds(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			err := PreRunClusterBackupIds(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterBackupIdsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunClusterBackupIds(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunClusterBackupIds(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		err := PreRunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			err := PreRunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterCreateInstancesErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), 10)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		err := PreRunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), 10)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			err := PreRunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterCreateCoresErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), 0)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		err := PreRunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), 0)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			err := PreRunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterCreateRecoveryTime(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		err := PreRunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			err := PreRunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		err := PreRunClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			err := PreRunClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		err := PreRunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			err := PreRunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestPreRunClusterDeleteNameErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.PreCmdConfigTest(t, w, func(cfg *core.PreCommandConfig) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		err := PreRunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.PreCmdConfigTest(
+		t, w, func(cfg *core.PreCommandConfig) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			err := PreRunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterList(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgCols), defaultClusterCols)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
-		err := RunClusterList(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgCols), defaultClusterCols)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
+			err := RunClusterList(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List("").Return(testClusters, nil, testClusterErr)
-		err := RunClusterList(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List("").Return(testClusters, nil, testClusterErr)
+			err := RunClusterList(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterGet(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		err := RunClusterGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			err := RunClusterGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterGetErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
-		err := RunClusterGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
+			err := RunClusterGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterGetWaitForState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		err := RunClusterGet(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			err := RunClusterGet(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterGetWaitForStateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGetFailed, nil, nil)
-		err := RunClusterGet(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGetFailed, nil, nil)
+			err := RunClusterGet(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, nil,
+			)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateSSDPremium(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), "SSD_Premium")
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequestSSDPremium).Return(&testClusterGetSSDPremium, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), "SSD_Premium")
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequestSSDPremium).Return(
+				&testClusterGetSSDPremium, nil, nil,
+			)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateSSDStandard(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), "SSD_standard")
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequestSSDStandard).Return(&testClusterGetSSDStandard, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), "SSD_standard")
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequestSSDStandard).Return(
+				&testClusterGetSSDStandard, nil, nil,
+			)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, testClusterErr)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, testClusterErr,
+			)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateConvertErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), "test")
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), "test")
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateLocation(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(testClusterVar, gomock.AssignableToTypeOf(cloudapiv6resources.QueryParams{})).Return(&testVdcGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(
+				testClusterVar, gomock.AssignableToTypeOf(cloudapiv6resources.QueryParams{}),
+			).Return(&testVdcGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, nil,
+			)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateLocationErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(testClusterVar, gomock.AssignableToTypeOf(cloudapiv6resources.QueryParams{})).Return(&testVdcGet, nil, testClusterErr)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), strings.ToUpper(testClusterVar))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiV6Mocks.Datacenter.EXPECT().Get(
+				testClusterVar, gomock.AssignableToTypeOf(cloudapiv6resources.QueryParams{}),
+			).Return(&testVdcGet, nil, testClusterErr)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateWaitForState(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil).Times(2)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, nil,
+			)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil).Times(2)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateWaitForStateResponse(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, &resources.Response{}, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil).Times(2)
-		err := RunClusterCreate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, &resources.Response{}, nil,
+			)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil).Times(2)
+			err := RunClusterCreate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateWaitForStateIdErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&resources.ClusterResponse{}, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&resources.ClusterResponse{}, nil, nil,
+			)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateWaitForStateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGetFailed, nil, nil)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, nil,
+			)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGetFailed, nil, nil)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterCreateWaitForStateNewClusterErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
-		err := RunClusterCreate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForState), testClusterBoolVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLocation), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgSyncMode), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterMbVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageType), string(sdkgo.HDD))
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbUsername), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDbPassword), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupLocation), testClusterBackupLocation)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Create(testCreateClusterRequest).Return(
+				&testClusterGet, nil, nil,
+			)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
+			err := RunClusterCreate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdate(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterNewVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(testClusterVar, testPatchClusterRequest).Return(&testClusterGetNew, nil, nil)
-		err := RunClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterNewVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(
+				testClusterVar, testPatchClusterRequest,
+			).Return(&testClusterGetNew, nil, nil)
+			err := RunClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdateRemoveConnection(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(testClusterVar, resources.PatchClusterRequest{PatchClusterRequest: sdkgo.PatchClusterRequest{
-			Properties: &sdkgo.PatchClusterProperties{
-				Connections: &[]sdkgo.Connection{},
-			},
-		}}).Return(&testClusterGetNoConnection, nil, nil)
-		err := RunClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(
+				testClusterVar, resources.PatchClusterRequest{
+					PatchClusterRequest: sdkgo.PatchClusterRequest{
+						Properties: &sdkgo.PatchClusterProperties{
+							Connections: &[]sdkgo.Connection{},
+						},
+					},
+				},
+			).Return(&testClusterGetNoConnection, nil, nil)
+			err := RunClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdateRemoveConnectionErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
-		err := RunClusterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, testClusterErr)
+			err := RunClusterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdateRemoveConnectionAskForConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(testClusterVar, resources.PatchClusterRequest{PatchClusterRequest: sdkgo.PatchClusterRequest{
-			Properties: &sdkgo.PatchClusterProperties{
-				Connections: &[]sdkgo.Connection{},
-			},
-		}}).Return(&testClusterGetNoConnection, nil, nil)
-		err := RunClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(
+				testClusterVar, resources.PatchClusterRequest{
+					PatchClusterRequest: sdkgo.PatchClusterRequest{
+						Properties: &sdkgo.PatchClusterProperties{
+							Connections: &[]sdkgo.Connection{},
+						},
+					},
+				},
+			).Return(&testClusterGetNoConnection, nil, nil)
+			err := RunClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdateRemoveConnectionAskForConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(testClusterVar, resources.PatchClusterRequest{PatchClusterRequest: sdkgo.PatchClusterRequest{
-			Properties: &sdkgo.PatchClusterProperties{
-				Connections: &[]sdkgo.Connection{},
-			},
-		}}).Return(&testClusterGetNoConnection, nil, nil)
-		err := RunClusterUpdate(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRemoveConnection), true)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(
+				testClusterVar, resources.PatchClusterRequest{
+					PatchClusterRequest: sdkgo.PatchClusterRequest{
+						Properties: &sdkgo.PatchClusterProperties{
+							Connections: &[]sdkgo.Connection{},
+						},
+					},
+				},
+			).Return(&testClusterGetNoConnection, nil, nil)
+			err := RunClusterUpdate(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterRestore(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		rm.CloudApiDbaasPgsqlMocks.Restore.EXPECT().Restore(testClusterVar, testCreateRestoreRequest).Return(nil, nil)
-		err := RunClusterRestore(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			rm.CloudApiDbaasPgsqlMocks.Restore.EXPECT().Restore(testClusterVar, testCreateRestoreRequest).Return(
+				nil, nil,
+			)
+			err := RunClusterRestore(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterRestoreErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		rm.CloudApiDbaasPgsqlMocks.Restore.EXPECT().Restore(testClusterVar, testCreateRestoreRequest).Return(nil, testClusterErr)
-		err := RunClusterRestore(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			rm.CloudApiDbaasPgsqlMocks.Restore.EXPECT().Restore(testClusterVar, testCreateRestoreRequest).Return(
+				nil, testClusterErr,
+			)
+			err := RunClusterRestore(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterRestoreAskConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunClusterRestore(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgBackupId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRecoveryTime), testTimeArgVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunClusterRestore(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDelete(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
-		err := RunClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
+			err := RunClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAll(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
-		err := RunClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
+			err := RunClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAllListErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, testClusterErr)
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, testClusterErr)
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAllItemsErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(resources.ClusterList{}, nil, nil)
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(resources.ClusterList{}, nil, nil)
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAllLenErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(
-			resources.ClusterList{ClusterList: sdkgo.ClusterList{Items: &[]sdkgo.ClusterResponse{}}}, nil, nil)
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(
+				resources.ClusterList{ClusterList: sdkgo.ClusterList{Items: &[]sdkgo.ClusterResponse{}}}, nil, nil,
+			)
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAllErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, testClusterErr)
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgAll), true)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().List(testClusterVar).Return(testClusters, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, testClusterErr)
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgForce, true)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, testClusterErr)
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(core.GetFlagName(cfg.NS, constants.ArgForce), true)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, testClusterErr)
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAskConfirm(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
-		err := RunClusterDelete(cfg)
-		assert.NoError(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("YES\n")))
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Delete(testClusterVar).Return(nil, nil)
+			err := RunClusterDelete(cfg)
+			assert.NoError(t, err)
+		},
+	)
 }
 
 func TestRunClusterDeleteAskConfirmErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
-		err := RunClusterDelete(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			cfg.Command.Command.SetIn(bytes.NewReader([]byte("\n")))
+			err := RunClusterDelete(cfg)
+			assert.Error(t, err)
+		},
+	)
 }
 
 func TestRunClusterUpdateErr(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
-	core.CmdConfigTest(t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
-		viper.Reset()
-		viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
-		viper.Set(constants.ArgQuiet, false)
-		viper.Set(constants.ArgVerbose, false)
-		viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
-		viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterIntNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterNewVar)
-		viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterNewVar)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
-		rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(testClusterVar, testPatchClusterRequest).Return(&testClusterGetNew, nil, testClusterErr)
-		err := RunClusterUpdate(cfg)
-		assert.Error(t, err)
-	})
+	core.CmdConfigTest(
+		t, w, func(cfg *core.CommandConfig, rm *core.ResourcesMocksTest) {
+			viper.Reset()
+			viper.Set(constants.ArgOutput, constants.DefaultOutputFormat)
+			viper.Set(constants.ArgQuiet, false)
+			viper.Set(constants.ArgVerbose, false)
+			viper.Set(constants.ArgServerUrl, constants.DefaultApiURL)
+			viper.Set(core.GetFlagName(cfg.NS, constants.FlagClusterId), testClusterVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgVersion), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgRam), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgInstances), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCores), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgStorageSize), testClusterIntNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceDay), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgMaintenanceTime), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgName), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgDatacenterId), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgLanId), testClusterNewVar)
+			viper.Set(core.GetFlagName(cfg.NS, dbaaspg.ArgCidr), testClusterNewVar)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Get(testClusterVar).Return(&testClusterGet, nil, nil)
+			rm.CloudApiDbaasPgsqlMocks.Cluster.EXPECT().Update(
+				testClusterVar, testPatchClusterRequest,
+			).Return(&testClusterGetNew, nil, testClusterErr)
+			err := RunClusterUpdate(cfg)
+			assert.Error(t, err)
+		},
+	)
 }

--- a/commands/dns/record/delete.go
+++ b/commands/dns/record/delete.go
@@ -20,13 +20,14 @@ import (
 )
 
 func ZonesRecordsDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.Background(), nil, core.CommandBuilder{
-		Namespace: "dns",
-		Resource:  "record",
-		Verb:      "delete",
-		Aliases:   []string{"del", "d"},
-		ShortDesc: "Delete a record",
-		LongDesc: `To delete a specific record from a specific zone:
+	cmd := core.NewCommand(
+		context.Background(), nil, core.CommandBuilder{
+			Namespace: "dns",
+			Resource:  "record",
+			Verb:      "delete",
+			Aliases:   []string{"del", "d"},
+			ShortDesc: "Delete a record",
+			LongDesc: `To delete a specific record from a specific zone:
 ionosctl dns r del --zone ZONE --record RECORD
 Here, ZONE is the ID or name of the DNS zone from where you want to delete a record, and RECORD is the ID or full name of the DNS record you want to delete.
 
@@ -37,77 +38,116 @@ Here, --all deletes all DNS records. You can also filter the records to delete b
 To delete a record by partial name, specifying the zone:
 ionosctl dns r delete --record PARTIAL_NAME --zone ZONE
 Here, PARTIAL_NAME is a part of the name of the DNS record you want to delete. If multiple records match the partial name, an error will be thrown: you will need to narrow down to a single record`,
-		Example: `ionosctl dns r del --zone ZONE --record RECORD
+			Example: `ionosctl dns r del --zone ZONE --record RECORD
 ionosctl dns r delete --all [--record PARTIAL_NAME] [--zone ZONE]
 ionosctl dns r delete --record PARTIAL_NAME --zone ZONE`,
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, // All with optional filters
-				[]string{constants.FlagZone, constants.FlagRecord}, // Known resource
-			)
-			if err != nil {
-				return fmt.Errorf("either provide --%s and optionally filters, or --%s and --%s, or narrow down to one record with --%s and/or --%s: %w",
-					constants.ArgAll, constants.FlagZone, constants.FlagRecord, constants.FlagName, constants.FlagZone, err)
-			}
-			return nil
-		},
-		CmdRun: func(c *core.CommandConfig) error {
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c)
-			}
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				err := core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.ArgAll}, // All with optional filters
+					[]string{constants.FlagZone, constants.FlagRecord}, // Known resource
+				)
+				if err != nil {
+					return fmt.Errorf(
+						"either provide --%s and optionally filters, or --%s and --%s, or narrow down to one record with --%s and/or --%s: %w",
+						constants.ArgAll, constants.FlagZone, constants.FlagRecord, constants.FlagName,
+						constants.FlagZone, err,
+					)
+				}
+				return nil
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c)
+				}
 
-			zoneId, err := zone.Resolve(viper.GetString(core.GetFlagName(c.NS, constants.FlagZone)))
-			if err != nil {
-				return err
-			}
+				zoneId, err := zone.Resolve(viper.GetString(core.GetFlagName(c.NS, constants.FlagZone)))
+				if err != nil {
+					return err
+				}
 
-			r := dns.RecordRead{}
+				r := dns.RecordRead{}
 
-			if fn := core.GetFlagName(c.NS, constants.FlagRecord); viper.IsSet(fn) {
-				if _, ok := uuid.FromString(viper.GetString(fn)); ok != nil /* not ok (name is provided) */ {
-					// record name is provided for FlagRecord
-					r, err = deleteSingleWithFilters(c)
-					if err != nil {
-						return fmt.Errorf("failed deleting a single record using filters: %w", err)
-					}
-				} else {
-					// record uuid is provided for FlagRecord
-					r, _, err = client.Must().DnsClient.RecordsApi.ZonesRecordsFindById(context.Background(), zoneId, viper.GetString(fn)).Execute()
-					if err != nil {
-						return fmt.Errorf("failed finding record using Zone and Record IDs: %w", err)
+				if fn := core.GetFlagName(c.NS, constants.FlagRecord); viper.IsSet(fn) {
+					if _, ok := uuid.FromString(viper.GetString(fn)); ok != nil /* not ok (name is provided) */ {
+						// record name is provided for FlagRecord
+						r, err = deleteSingleWithFilters(c)
+						if err != nil {
+							return fmt.Errorf("failed deleting a single record using filters: %w", err)
+						}
+					} else {
+						// record uuid is provided for FlagRecord
+						r, _, err = client.Must().DnsClient.RecordsApi.ZonesRecordsFindById(
+							context.Background(), zoneId, viper.GetString(fn),
+						).Execute()
+						if err != nil {
+							return fmt.Errorf("failed finding record using Zone and Record IDs: %w", err)
+						}
 					}
 				}
-			}
 
-			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("Are you sure you want to delete record %s (type: '%s'; content: '%s')", *r.Metadata.Fqdn, *r.Properties.Type, *r.Properties.Content),
-				viper.GetBool(constants.ArgForce))
-			if !yes {
-				return fmt.Errorf("user cancelled deletion")
-			}
+				yes := confirm.FAsk(
+					c.Command.Command.InOrStdin(), fmt.Sprintf(
+						"Are you sure you want to delete record %s (type: '%s'; content: '%s')", *r.Metadata.Fqdn,
+						*r.Properties.Type, *r.Properties.Content,
+					),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				)
+				if !yes {
+					return fmt.Errorf("user cancelled deletion")
+				}
 
-			_, err = client.Must().DnsClient.RecordsApi.ZonesRecordsDelete(context.Background(),
-				*r.Metadata.ZoneId,
-				*r.Id,
-			).Execute()
+				_, err = client.Must().DnsClient.RecordsApi.ZonesRecordsDelete(
+					context.Background(),
+					*r.Metadata.ZoneId,
+					*r.Id,
+				).Execute()
 
-			return err
+				return err
+			},
+			InitClient: true,
 		},
-		InitClient: true,
-	})
+	)
 
-	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all records. You can optionally filter the deleted records using --%s (full name / ID) and --%s (partial name)", constants.FlagZone, constants.FlagRecord))
-	cmd.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", fmt.Sprintf("The full name or ID of the zone of the containing the target record. If --%s is set this is applied as a filter - limiting to records within this zone", constants.ArgAll))
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return zone.ZonesProperty(func(t dns.ZoneRead) string {
-			return *t.Properties.ZoneName
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	cmd.AddBoolFlag(
+		constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf(
+			"Delete all records. You can optionally filter the deleted records using --%s (full name / ID) and --%s (partial name)",
+			constants.FlagZone, constants.FlagRecord,
+		),
+	)
+	cmd.AddStringFlag(
+		constants.FlagZone, constants.FlagZoneShort, "", fmt.Sprintf(
+			"The full name or ID of the zone of the containing the target record. If --%s is set this is applied as a filter - limiting to records within this zone",
+			constants.ArgAll,
+		),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagZone,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return zone.ZonesProperty(
+				func(t dns.ZoneRead) string {
+					return *t.Properties.ZoneName
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
-	cmd.AddStringFlag(constants.FlagRecord, constants.FlagRecordShort, "", fmt.Sprintf("The ID, or full name of the DNS record. Required together with --%s. Can also provide partial names, but must narrow down to a single record result if not using --%s. If using it, will however delete all records that match.", constants.FlagZone, constants.ArgAll))
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagRecord, func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return RecordsProperty(func(r dns.RecordRead) string {
-			return *r.Properties.Name
-		}, FilterRecordsByZoneAndRecordFlags(cmd.NS)), cobra.ShellCompDirectiveNoSpace
-	})
+	cmd.AddStringFlag(
+		constants.FlagRecord, constants.FlagRecordShort, "", fmt.Sprintf(
+			"The ID, or full name of the DNS record. Required together with --%s. Can also provide partial names, but must narrow down to a single record result if not using --%s. If using it, will however delete all records that match.",
+			constants.FlagZone, constants.ArgAll,
+		),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagRecord,
+		func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return RecordsProperty(
+				func(r dns.RecordRead) string {
+					return *r.Properties.Name
+				}, FilterRecordsByZoneAndRecordFlags(cmd.NS),
+			), cobra.ShellCompDirectiveNoSpace
+		},
+	)
 
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false
@@ -125,18 +165,27 @@ func deleteAll(c *core.CommandConfig) error {
 		return fmt.Errorf("found no records matching given filters")
 	}
 
-	err = functional.ApplyAndAggregateErrors(*xs.GetItems(), func(r dns.RecordRead) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("Are you sure you want to delete record %s (type: '%s'; content: '%s')", *r.Properties.Name, *r.Properties.Type, *r.Properties.Content),
-			viper.GetBool(constants.ArgForce))
+	err = functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(r dns.RecordRead) error {
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(), fmt.Sprintf(
+					"Are you sure you want to delete record %s (type: '%s'; content: '%s')", *r.Properties.Name,
+					*r.Properties.Type, *r.Properties.Content,
+				),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
 
-		if yes {
-			_, delErr := client.Must().DnsClient.RecordsApi.ZonesRecordsDelete(c.Context, *r.Metadata.ZoneId, *r.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s (name: %s): %w", *r.Id, *r.Properties.Name, delErr)
+			if yes {
+				_, delErr := client.Must().DnsClient.RecordsApi.ZonesRecordsDelete(
+					c.Context, *r.Metadata.ZoneId, *r.Id,
+				).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s (name: %s): %w", *r.Id, *r.Properties.Name, delErr)
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		},
+	)
 
 	return err
 }
@@ -149,18 +198,24 @@ func deleteSingleWithFilters(c *core.CommandConfig) (dns.RecordRead, error) {
 
 	recsLen := len(*recs.Items)
 	if recsLen == 0 {
-		return dns.RecordRead{}, fmt.Errorf("found no records matching given filters (--%s and/or --%s). They"+
-			" must narrow down to a single result", constants.FlagRecord, constants.FlagZone)
+		return dns.RecordRead{}, fmt.Errorf(
+			"found no records matching given filters (--%s and/or --%s). They"+
+				" must narrow down to a single result", constants.FlagRecord, constants.FlagZone,
+		)
 	}
 
 	if recsLen > 1 {
-		recsNames := functional.Fold(*recs.Items, func(acc []string, t dns.RecordRead) []string {
-			return append(acc, *t.Properties.Name)
-		}, []string{})
+		recsNames := functional.Fold(
+			*recs.Items, func(acc []string, t dns.RecordRead) []string {
+				return append(acc, *t.Properties.Name)
+			}, []string{},
+		)
 
-		return dns.RecordRead{}, fmt.Errorf("got %d but expected 1: %+v. The given filters (--%s and/or --%s) "+
-			"must narrow down to a single result. You can delete all of them by using --%s",
-			recsLen, strings.Join(recsNames, ", "), constants.FlagRecord, constants.FlagZone, constants.ArgAll)
+		return dns.RecordRead{}, fmt.Errorf(
+			"got %d but expected 1: %+v. The given filters (--%s and/or --%s) "+
+				"must narrow down to a single result. You can delete all of them by using --%s",
+			recsLen, strings.Join(recsNames, ", "), constants.FlagRecord, constants.FlagZone, constants.ArgAll,
+		)
 	}
 
 	return (*recs.Items)[0], nil

--- a/commands/dns/zone/delete.go
+++ b/commands/dns/zone/delete.go
@@ -18,51 +18,72 @@ import (
 )
 
 func ZonesDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.Background(), nil, core.CommandBuilder{
-		Namespace: "dns",
-		Resource:  "zone",
-		Verb:      "delete",
-		Aliases:   []string{"del", "d"},
-		ShortDesc: "Delete a zone",
-		Example:   "ionosctl dns z delete --zone ZONE",
-		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagZone})
-		},
-		CmdRun: func(c *core.CommandConfig) error {
-			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
-				return deleteAll(c)
-			}
+	cmd := core.NewCommand(
+		context.Background(), nil, core.CommandBuilder{
+			Namespace: "dns",
+			Resource:  "zone",
+			Verb:      "delete",
+			Aliases:   []string{"del", "d"},
+			ShortDesc: "Delete a zone",
+			Example:   "ionosctl dns z delete --zone ZONE",
+			PreCmdRun: func(c *core.PreCommandConfig) error {
+				return core.CheckRequiredFlagsSets(
+					c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagZone},
+				)
+			},
+			CmdRun: func(c *core.CommandConfig) error {
+				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
+					return deleteAll(c)
+				}
 
-			zoneId, err := Resolve(viper.GetString(core.GetFlagName(c.NS, constants.FlagZone)))
-			if err != nil {
+				zoneId, err := Resolve(viper.GetString(core.GetFlagName(c.NS, constants.FlagZone)))
+				if err != nil {
+					return err
+				}
+
+				z, _, err := client.Must().DnsClient.ZonesApi.ZonesFindById(context.Background(), zoneId).Execute()
+				if err != nil {
+					return fmt.Errorf("failed getting zone by id %s: %w", zoneId, err)
+				}
+				yes := confirm.FAsk(
+					c.Command.Command.InOrStdin(), fmt.Sprintf(
+						"Are you sure you want to delete zone %s (desc: '%s')", *z.Properties.ZoneName,
+						*z.Properties.Description,
+					),
+					viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+				)
+				if !yes {
+					return fmt.Errorf(confirm.UserDenied)
+				}
+
+				_, err = client.Must().DnsClient.ZonesApi.ZonesDelete(context.Background(), zoneId).Execute()
+
 				return err
-			}
-
-			z, _, err := client.Must().DnsClient.ZonesApi.ZonesFindById(context.Background(), zoneId).Execute()
-			if err != nil {
-				return fmt.Errorf("failed getting zone by id %s: %w", zoneId, err)
-			}
-			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("Are you sure you want to delete zone %s (desc: '%s')", *z.Properties.ZoneName, *z.Properties.Description),
-				viper.GetBool(constants.ArgForce))
-			if !yes {
-				return fmt.Errorf(confirm.UserDenied)
-			}
-
-			_, err = client.Must().DnsClient.ZonesApi.ZonesDelete(context.Background(), zoneId).Execute()
-
-			return err
+			},
+			InitClient: true,
 		},
-		InitClient: true,
-	})
+	)
 
-	cmd.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", fmt.Sprintf("%s. Required or -%s", constants.DescZone, constants.ArgAllShort))
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return ZonesProperty(func(t dns.ZoneRead) string {
-			return *t.Properties.ZoneName
-		}), cobra.ShellCompDirectiveNoFileComp
-	})
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
+	cmd.AddStringFlag(
+		constants.FlagZone, constants.FlagZoneShort, "",
+		fmt.Sprintf("%s. Required or -%s", constants.DescZone, constants.ArgAllShort),
+	)
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagZone,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return ZonesProperty(
+				func(t dns.ZoneRead) string {
+					return *t.Properties.ZoneName
+				},
+			), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
-	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all zones. Required or -%s", constants.FlagZoneShort))
+	cmd.AddBoolFlag(
+		constants.ArgAll, constants.ArgAllShort, false,
+		fmt.Sprintf("Delete all zones. Required or -%s", constants.FlagZoneShort),
+	)
 
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false
@@ -77,17 +98,24 @@ func deleteAll(c *core.CommandConfig) error {
 		return err
 	}
 
-	err = functional.ApplyAndAggregateErrors(*xs.GetItems(), func(z dns.ZoneRead) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("Are you sure you want to delete zone %s (desc: '%s')", *z.Properties.ZoneName, *z.Properties.Description),
-			viper.GetBool(constants.ArgForce))
-		if yes {
-			_, delErr := client.Must().DnsClient.ZonesApi.ZonesDelete(c.Context, *z.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s (name: %s): %w", *z.Id, *z.Properties.ZoneName, delErr)
+	err = functional.ApplyAndAggregateErrors(
+		*xs.GetItems(), func(z dns.ZoneRead) error {
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(), fmt.Sprintf(
+					"Are you sure you want to delete zone %s (desc: '%s')", *z.Properties.ZoneName,
+					*z.Properties.Description,
+				),
+				viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+			)
+			if yes {
+				_, delErr := client.Must().DnsClient.ZonesApi.ZonesDelete(c.Context, *z.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s (name: %s): %w", *z.Id, *z.Properties.ZoneName, delErr)
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		},
+	)
 
 	return err
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -115,15 +115,13 @@ func init() {
 	_ = rootCmd.Command.RegisterFlagCompletionFunc(
 		constants.ArgOutput,
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return []string{jsontabwriter.JSONFormat, jsontabwriter.TextFormat, jsontabwriter.APIFormat}, cobra.ShellCompDirectiveNoFileComp
+			return []string{
+				jsontabwriter.JSONFormat, jsontabwriter.TextFormat, jsontabwriter.APIFormat,
+			}, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
 	rootPFlagSet.BoolVarP(&Quiet, constants.ArgQuiet, constants.ArgQuietShort, false, "Quiet output")
 	_ = viper.BindPFlag(constants.ArgQuiet, rootPFlagSet.Lookup(constants.ArgQuiet))
-	rootPFlagSet.BoolVarP(
-		&Force, constants.ArgForce, constants.ArgForceShort, false, "Force command to execute without user input",
-	)
-	_ = viper.BindPFlag(constants.ArgForce, rootPFlagSet.Lookup(constants.ArgForce))
 	rootPFlagSet.BoolVarP(
 		&Verbose, constants.ArgVerbose, constants.ArgVerboseShort, false,
 		"Print step-by-step process when running command",
@@ -225,7 +223,8 @@ func addCommands() {
 	funcChangeDefaultApiUrl := func(command *core.Command, newDefault string) *core.Command {
 		// For some reason, this line only changes the help text
 		command.Command.PersistentFlags().StringP(
-			constants.ArgServerUrl, constants.ArgServerUrlShort, newDefault, "Override default host url")
+			constants.ArgServerUrl, constants.ArgServerUrlShort, newDefault, "Override default host url",
+		)
 
 		// If unset, manually set the flag to the new default. SIDE EFFECT: Now, this flag will always be considered "set", within DNS sub commands. Can't find a better alternative
 		command.Command.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/commands/token/delete.go
+++ b/commands/token/delete.go
@@ -18,54 +18,92 @@ import (
 )
 
 func TokenDeleteCmd() *core.Command {
-	cmd := core.NewCommand(context.Background(), nil, core.CommandBuilder{
-		Namespace: "token",
-		Resource:  "token",
-		Verb:      "delete",
-		Aliases:   []string{"d"},
-		ShortDesc: "Delete one or multiple Tokens",
-		LongDesc: `Use this command to delete a specified Token by token Id or multiple Tokens (based on a criteria: CURRENT, EXPIRED, ALL) from your account. With parameter values ALL and EXPIRED, 'Basic Authentication' or 'Token Authentication' tokens with valid credentials must be encapsulated in the header. With value CURRENT, only the 'Token Authentication' with valid credentials is required.
+	cmd := core.NewCommand(
+		context.Background(), nil, core.CommandBuilder{
+			Namespace: "token",
+			Resource:  "token",
+			Verb:      "delete",
+			Aliases:   []string{"d"},
+			ShortDesc: "Delete one or multiple Tokens",
+			LongDesc: `Use this command to delete a specified Token by token Id or multiple Tokens (based on a criteria: CURRENT, EXPIRED, ALL) from your account. With parameter values ALL and EXPIRED, 'Basic Authentication' or 'Token Authentication' tokens with valid credentials must be encapsulated in the header. With value CURRENT, only the 'Token Authentication' with valid credentials is required.
 
 Required values to run command:
 
 * Token Id/Token/CURRENT/EXPIRED/ALL`,
-		Example:    deleteTokenExample,
-		PreCmdRun:  preRunTokenDelete,
-		CmdRun:     runTokenDelete,
-		InitClient: true,
-	})
+			Example:    deleteTokenExample,
+			PreCmdRun:  preRunTokenDelete,
+			CmdRun:     runTokenDelete,
+			InitClient: true,
+		},
+	)
+	cmd.AddBoolFlag(constants.ArgForce, constants.ArgForceShort, false, constants.DescForce)
 	cmd.AddUUIDFlag(authservice.ArgTokenId, authservice.ArgIdShort, "", authservice.TokenId, core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(authservice.ArgTokenId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.TokensIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		authservice.ArgTokenId,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completer.TokensIds(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 	cmd.AddStringFlag(authservice.ArgToken, authservice.ArgTokenShort, "", authservice.Token, core.RequiredFlagOption())
-	cmd.AddBoolFlag(authservice.ArgCurrent, authservice.ArgCurrentShort, false, "Delete the Token that is currently used. This requires a token to be set for authentication via environment variable IONOS_TOKEN or via config file", core.RequiredFlagOption())
-	cmd.AddBoolFlag(authservice.ArgExpired, authservice.ArgExpiredShort, false, "Delete the Tokens that are currently expired", core.RequiredFlagOption())
-	cmd.AddBoolFlag(authservice.ArgAll, authservice.ArgAllShort, false, "Delete the Tokens under your account", core.RequiredFlagOption())
-	cmd.AddIntFlag(authservice.ArgContractNo, "", 0, "Users with multiple contracts must provide the contract number, for which the tokens are deleted")
+	cmd.AddBoolFlag(
+		authservice.ArgCurrent, authservice.ArgCurrentShort, false,
+		"Delete the Token that is currently used. This requires a token to be set for authentication via environment variable IONOS_TOKEN or via config file",
+		core.RequiredFlagOption(),
+	)
+	cmd.AddBoolFlag(
+		authservice.ArgExpired, authservice.ArgExpiredShort, false, "Delete the Tokens that are currently expired",
+		core.RequiredFlagOption(),
+	)
+	cmd.AddBoolFlag(
+		authservice.ArgAll, authservice.ArgAllShort, false, "Delete the Tokens under your account",
+		core.RequiredFlagOption(),
+	)
+	cmd.AddIntFlag(
+		authservice.ArgContractNo, "", 0,
+		"Users with multiple contracts must provide the contract number, for which the tokens are deleted",
+	)
 
 	return cmd
 }
 
 func preRunTokenDelete(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{authservice.ArgTokenId}, []string{authservice.ArgCurrent}, []string{authservice.ArgExpired}, []string{authservice.ArgAll}, []string{authservice.ArgToken})
+	return core.CheckRequiredFlagsSets(
+		c.Command, c.NS, []string{authservice.ArgTokenId}, []string{authservice.ArgCurrent},
+		[]string{authservice.ArgExpired}, []string{authservice.ArgAll}, []string{authservice.ArgToken},
+	)
 }
 
 func runTokenDelete(c *core.CommandConfig) error {
 	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgContractNo)) {
-		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(contractNumberMessage,
-			viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo))))
+		fmt.Fprintf(
+			c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+				contractNumberMessage,
+				viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+			),
+		)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgTokenId)) {
 		return runTokenDeleteById(c)
 	}
-	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgCurrent)) && viper.GetBool(core.GetFlagName(c.NS, authservice.ArgCurrent)) {
+	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgCurrent)) && viper.GetBool(
+		core.GetFlagName(
+			c.NS, authservice.ArgCurrent,
+		),
+	) {
 		return runTokenDeleteCurrent(c)
 	}
-	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgExpired)) && viper.GetBool(core.GetFlagName(c.NS, authservice.ArgExpired)) {
+	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgExpired)) && viper.GetBool(
+		core.GetFlagName(
+			c.NS, authservice.ArgExpired,
+		),
+	) {
 		return runTokenDeleteExpired(c)
 	}
-	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgAll)) && viper.GetBool(core.GetFlagName(c.NS, authservice.ArgAll)) {
+	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgAll)) && viper.GetBool(
+		core.GetFlagName(
+			c.NS, authservice.ArgAll,
+		),
+	) {
 		return runTokenDeleteAll(c)
 	}
 	if viper.IsSet(core.GetFlagName(c.NS, authservice.ArgToken)) {
@@ -75,13 +113,18 @@ func runTokenDelete(c *core.CommandConfig) error {
 }
 
 func runTokenDeleteAll(c *core.CommandConfig) error {
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete all tokens"), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete all tokens"),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting all tokens..."))
 
-	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria("ALL", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)))
+	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria(
+		"ALL", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+	)
 	if err != nil {
 		return err
 	}
@@ -89,7 +132,10 @@ func runTokenDeleteAll(c *core.CommandConfig) error {
 	if tokenResponse != nil {
 		if success, ok := tokenResponse.GetSuccessOk(); ok && success != nil {
 			if *success {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: all tokens have been successfully deleted"))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Status: all tokens have been successfully deleted"),
+				)
 				return nil
 			}
 		}
@@ -99,13 +145,18 @@ func runTokenDeleteAll(c *core.CommandConfig) error {
 }
 
 func runTokenDeleteExpired(c *core.CommandConfig) error {
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete expired tokens"), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete expired tokens"),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting expired tokens..."))
 
-	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria("EXPIRED", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)))
+	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria(
+		"EXPIRED", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+	)
 	if err != nil {
 		return err
 	}
@@ -113,7 +164,10 @@ func runTokenDeleteExpired(c *core.CommandConfig) error {
 	if tokenResponse != nil {
 		if success, ok := tokenResponse.GetSuccessOk(); ok && success != nil {
 			if *success {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: expired tokens have been successfully deleted"))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Status: expired tokens have been successfully deleted"),
+				)
 				return nil
 			}
 		}
@@ -123,21 +177,33 @@ func runTokenDeleteExpired(c *core.CommandConfig) error {
 }
 
 func runTokenDeleteCurrent(c *core.CommandConfig) error {
-	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
-		"Note: This operation is based on Authorization Header for Bearer Token"))
+	fmt.Fprintf(
+		c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput(
+			"Note: This operation is based on Authorization Header for Bearer Token",
+		),
+	)
 
 	if viper.GetString(constants.CfgToken) == "" {
-		return errors.New(fmt.Sprintf("no token found. Please make sure you have exported the %s environment variable or you have token set in the config file",
-			sdkgoauth.IonosTokenEnvVar))
+		return errors.New(
+			fmt.Sprintf(
+				"no token found. Please make sure you have exported the %s environment variable or you have token set in the config file",
+				sdkgoauth.IonosTokenEnvVar,
+			),
+		)
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete CURRENT token"), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete CURRENT token"),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Deleting current token..."))
 
-	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria("CURRENT", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)))
+	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByCriteria(
+		"CURRENT", viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+	)
 	if err != nil {
 		return err
 	}
@@ -145,7 +211,10 @@ func runTokenDeleteCurrent(c *core.CommandConfig) error {
 	if tokenResponse != nil {
 		if success, ok := tokenResponse.GetSuccessOk(); ok && success != nil {
 			if *success {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: current token have been successfully deleted"))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Status: current token have been successfully deleted"),
+				)
 				return nil
 			}
 		}
@@ -156,17 +225,25 @@ func runTokenDeleteCurrent(c *core.CommandConfig) error {
 func runTokenDeleteById(c *core.CommandConfig) error {
 	tokenId := viper.GetString(core.GetFlagName(c.NS, authservice.ArgTokenId))
 	fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateVerboseOutput("Token ID: %s", tokenId))
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete token with ID: %s", tokenId), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete token with ID: %s", tokenId),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
-	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByID(tokenId, viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)))
+	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByID(
+		tokenId, viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+	)
 	if err != nil {
 		return err
 	}
 	if tokenResponse != nil {
 		if success, ok := tokenResponse.GetSuccessOk(); ok && success != nil {
 			if *success {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: token has been successfully deleted"))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Status: token has been successfully deleted"),
+				)
 				return nil
 			}
 		}
@@ -188,11 +265,16 @@ func runTokenDeleteByToken(c *core.CommandConfig) error {
 		return err
 	}
 
-	if !confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("delete token with ID: %s", tokenId), viper.GetBool(constants.ArgForce)) {
+	if !confirm.FAsk(
+		c.Command.Command.InOrStdin(), fmt.Sprintf("delete token with ID: %s", tokenId),
+		viper.GetBool(core.GetFlagName(c.NS, constants.ArgForce)),
+	) {
 		return fmt.Errorf(confirm.UserDenied)
 	}
 
-	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByID(fmt.Sprintf("%v", tokenId), viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)))
+	tokenResponse, _, err := c.AuthV1Services.Tokens().DeleteByID(
+		fmt.Sprintf("%v", tokenId), viper.GetInt32(core.GetFlagName(c.NS, authservice.ArgContractNo)),
+	)
 	if err != nil {
 		return err
 	}
@@ -200,7 +282,10 @@ func runTokenDeleteByToken(c *core.CommandConfig) error {
 	if tokenResponse != nil {
 		if success, ok := tokenResponse.GetSuccessOk(); ok && success != nil {
 			if *success {
-				fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput("Status: token has been successfully deleted"))
+				fmt.Fprintf(
+					c.Command.Command.ErrOrStderr(),
+					jsontabwriter.GenerateLogOutput("Status: token has been successfully deleted"),
+				)
 				return nil
 			}
 		}

--- a/commands/token/token_integration_test.go
+++ b/commands/token/token_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/commands/token"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	authservice "github.com/ionos-cloud/ionosctl/v6/services/auth-v1"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 	"github.com/spf13/viper"
@@ -155,9 +156,9 @@ func testParseToken(t *testing.T) {
 
 func testDeleteTokens(t *testing.T) {
 	var err error
-	viper.Set(constants.ArgForce, true)
 
 	c := token.TokenDeleteCmd()
+	viper.Set(core.GetFlagName(c.NS, constants.ArgForce), true)
 	c.Command.Flags().Set(authservice.ArgTokenId, *testToken.Id)
 
 	err = c.Command.Execute()

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -86,6 +86,7 @@ const (
 	ArgAllShort            = "a"
 	ArgForce               = "force"
 	ArgForceShort          = "f"
+	DescForce              = "Force command to execute without user input"
 	ArgWaitForRequest      = "wait-for-request"
 	ArgWaitForRequestShort = "w"
 	ArgWaitForState        = "wait-for-state"


### PR DESCRIPTION
The `--force` flag is now a per command, local flag instead of a global flag.
Refactor done for https://github.com/ionos-cloud/ionosctl/pull/404