### PR TITLE
Fix missing output of cluster k8sVersion 

### DIFF
--- a/internal/printer/json2table/jsonpaths/cloudapi.go
+++ b/internal/printer/json2table/jsonpaths/cloudapi.go
@@ -190,7 +190,7 @@ var (
 	K8sCluster = map[string]string{
 		"ClusterId":                "id",
 		"Name":                     "properties.name",
-		"K8sVersion":               "properties,k8sVersion",
+		"K8sVersion":               "properties.k8sVersion",
 		"AvailableUpgradeVersions": "properties.availableUpgradeVersions",
 		"ViableNodePoolVersions":   "properties.viableNodePoolVersions",
 		"State":                    "metadata.state",


### PR DESCRIPTION
fixes #408  
Due wrong jsonpath mapping it is not possible to get cluster k8sVersion.
According to documentation it should be possible https://github.com/ionos-cloud/ionosctl/blob/117a6e4c4db9c282f44817a76195fbb4e6d46d04/docs/subcommands/Managed-Kubernetes/cluster/list.md?plain=1#L33

Tested with v6.7.1

## Before fix

```
ionosctl k8s cluster list --verbose --cols ClusterId,k8sVersion,name
```
```
ClusterId                              Name
732bc882-ffff-oooo-oooo-18ff2d6d0bbe   foo-dev
362f552e-ffff-oooo-oooo-418cd25aa620   foo-live
44d3359b-ffff-oooo-oooo-73542a77dc81   foo-test
```

## After fix
```
ionosctl k8s cluster list --verbose --cols ClusterId,k8sVersion,name
```
```
ClusterId                              K8sVersion   Name
732bc882-ffff-ooo-ooo-18ff2d6d0bbe   1.25.12      foo-dev
362f552e-ffff-ooo-ooo-418cd25aa620   1.25.12      foo-live
44d3359b-ffff-ooo-ooo-73542a77dc81   1.25.12      foo-test
```

## What does this fix or implement?

Fixes the json mapping for k8sVersion response property

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
