### PR TITLE
fix #406: empty result should return a zero status code

### DIFF
--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -761,12 +761,6 @@ func RunImageList(c *core.CommandConfig) error {
 		images = sortImagesByTime(images, viper.GetInt(core.GetFlagName(c.NS, cloudapiv6.ArgLatest)))
 	}
 
-	if itemsOk, ok := images.GetItemsOk(); ok && itemsOk != nil {
-		if len(*itemsOk) == 0 {
-			return errors.New("error getting images based on given criteria")
-		}
-	}
-
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Image, images.Images,

--- a/commands/cloudapi-v6/image.go
+++ b/commands/cloudapi-v6/image.go
@@ -761,6 +761,10 @@ func RunImageList(c *core.CommandConfig) error {
 		images = sortImagesByTime(images, viper.GetInt(core.GetFlagName(c.NS, cloudapiv6.ArgLatest)))
 	}
 
+	if itemsOk, ok := images.GetItemsOk(); !ok || itemsOk == nil {
+		return nil
+	}
+
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.Image, images.Images,

--- a/commands/cloudapi-v6/image_test.go
+++ b/commands/cloudapi-v6/image_test.go
@@ -204,7 +204,7 @@ func TestRunImageListSortOptionErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgImageAlias), "no alias")
 		rm.CloudApiV6Mocks.Image.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testImages, nil, nil)
 		err := RunImageList(cfg)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -182,12 +182,6 @@ func RunRequestList(c *core.CommandConfig) error {
 		requests = sortRequestsByTime(requests, viper.GetInt(core.GetFlagName(c.NS, cloudapiv6.ArgLatest)))
 	}
 
-	if itemsOk, ok := requests.GetItemsOk(); ok && itemsOk != nil {
-		if len(*itemsOk) == 0 {
-			return fmt.Errorf("error getting requests based on given criteria")
-		}
-	}
-
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	convertedRequests, err := resource2table.ConvertRequestsToTable(requests.Requests)

--- a/commands/cloudapi-v6/request.go
+++ b/commands/cloudapi-v6/request.go
@@ -182,6 +182,10 @@ func RunRequestList(c *core.CommandConfig) error {
 		requests = sortRequestsByTime(requests, viper.GetInt(core.GetFlagName(c.NS, cloudapiv6.ArgLatest)))
 	}
 
+	if itemsOk, ok := requests.GetItemsOk(); !ok || itemsOk == nil {
+		return nil
+	}
+
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
 	convertedRequests, err := resource2table.ConvertRequestsToTable(requests.Requests)

--- a/commands/cloudapi-v6/request_test.go
+++ b/commands/cloudapi-v6/request_test.go
@@ -283,7 +283,7 @@ func TestRunRequestListSortedErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgMethod), "no method")
 		rm.CloudApiV6Mocks.Request.EXPECT().List(gomock.AssignableToTypeOf(testListQueryParam)).Return(testRequests, nil, nil)
 		err := RunRequestList(cfg)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Fixes #406: Getting no results for images, requests should return a zero status code.