### PR TITLE
enhancement: snap core20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
         *) echo "Unsupported architecture: $SNAPCRAFT_ARCH_TRIPLET" && exit 1 ;;
       esac
       
-      OUT_D=$SNAPCRAFT_PART_INSTALL/bin GOARCH=$GOARCH GOOS=linux SIMPLE_NAME=true tools/build.sh build
+      OUT_D=$SNAPCRAFT_PART_INSTALL/bin GOARCH=$GOARCH GOOS=linux RELEASE_BUILD=true SIMPLE_NAME=true tools/build.sh build
     build-snaps:
     - go
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ionosctl # registered name
 summary: IONOS Cloud CLI tool.
-base: core18
+base: core20
 description: |
   The IONOS Cloud CLI (ionosctl) gives the ability to manage IONOS Cloud infrastructure directly from Command Line.
 
@@ -37,13 +37,19 @@ parts:
         git checkout "${last_committed_tag}"
       fi
       snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
-      override-build: |
+    override-build: |
       export GOPATH=$PWD
-      env CGO_ENABLED=0 GOOS=linux \
-      go build --ldflags "-s -w \
-        -X 'github.com/ionos-cloud/ionosctl/v6/commands.Version=$(git describe --tags --abbrev=0)' \
-        -X 'github.com/ionos-cloud/ionosctl/v6/commands.Label=release'" \
-        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/ionosctl
+      cd src/github.com/ionos-cloud/ionosctl
+      
+      case "$SNAPCRAFT_ARCH_TRIPLET" in
+        "x86_64-linux-gnu") GOARCH=amd64 ;;
+        "arm-linux-gnueabihf") GOARCH=arm ;;
+        "aarch64-linux-gnu") GOARCH=arm64 ;;
+        "i386-linux-gnu") GOARCH=386 ;;
+        *) echo "Unsupported architecture: $SNAPCRAFT_ARCH_TRIPLET" && exit 1 ;;
+      esac
+      
+      OUT_D=$SNAPCRAFT_PART_INSTALL/bin GOARCH=$GOARCH GOOS=linux SIMPLE_NAME=true tools/build.sh build
     build-snaps:
     - go
     build-packages:

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -10,7 +10,16 @@ VERSION="$(git tag -l | sort --version-sort | tail -n1 | cut -c 2-)"
 GIT_COMMIT="$(git rev-parse --short HEAD)"
 [[ -n $(git status -s) ]] && echo 'modified and/or untracked diff' && GIT_COMMIT="${GIT_COMMIT}+"
 
-ldflags="-X github.com/ionos-cloud/ionosctl/v6/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/v6/commands.GitCommit=${GIT_COMMIT}"
+label=""
+if [ "${RELEASE_BUILD:-}" = "true" ]; then
+  label="release"
+fi
+
+ldflags_base="-X github.com/ionos-cloud/ionosctl/v6/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/v6/commands.GitCommit=${GIT_COMMIT}"
+ldflags="${ldflags_base}"
+if [ -n "${label}" ]; then
+  ldflags="${ldflags} -X github.com/ionos-cloud/ionosctl/v6/commands.Label=${label}"
+fi
 
 echo "VERSION: ${VERSION}"
 echo "GIT_COMMIT: ${GIT_COMMIT}"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -23,5 +23,9 @@ if [[ $1 == "install" ]]; then
   go install -ldflags "$ldflags"
 else
   mkdir -p "${OUT_D}"
-  go build -ldflags "$ldflags" -o "${OUT_D}/${BINARY_NAME}_${GOOS}_${GOARCH}"
+  if [ "${SIMPLE_NAME:-}" = "true" ]; then
+    go build -ldflags "$ldflags" -o "${OUT_D}/${BINARY_NAME}"
+  else
+    go build -ldflags "$ldflags" -o "${OUT_D}/${BINARY_NAME}_${GOOS}_${GOARCH}"
+  fi
 fi


### PR DESCRIPTION
Updates `snapcraft.yml` to use core20 (Ubuntu 20.04).

I decided not to update to core22 because of [this issue](https://forum.snapcraft.io/t/snapcraft-network-error-seemingly-with-all-core22/34588) which I couldn't easily work around