### PR TITLE
fix: Allow disabling node pool autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Upcoming
+
+### Fixed
+- Kubernetes node pool auto scaling can be disabled by setting `--min-node-count` and `--max-node-count` to 0.
+
 ## [v6.7.4] (January 2024)
 
 ### Added

--- a/docs/subcommands/Managed-Kubernetes/nodepool/update.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/update.md
@@ -59,8 +59,8 @@ Required values to run command:
       --lan-ids ints                 Collection of LAN Ids of existing LANs to be attached to worker Nodes. It will be added to the existing LANs attached
       --maintenance-day string       The day of the week for Maintenance Window has the English day format as following: Monday or Saturday
       --maintenance-time string      The time for Maintenance Window has the HH:mm:ss format as following: 08:00:00
-      --max-node-count int           The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count (default 1)
-      --min-node-count int           The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count (default 1)
+      --max-node-count int           The maximum number of worker Nodes that the managed NodePool can scale out. Should be set together with --min-node-count. Set to 0 to disable autoscaling (default 1)
+      --min-node-count int           The minimum number of worker Nodes that the managed NodePool can scale in. Should be set together with --max-node-count. Set to 0 to disable autoscaling. (default 1)
       --no-headers                   Don't print table headers when table output is used
       --node-count int               The number of worker Nodes that the NodePool should contain (default 1)
   -i, --nodepool-id string           The unique K8s Node Pool Id (required)


### PR DESCRIPTION
## What does this fix or implement?

Fix disabling autoscaling on a Kubernetes node pool. Autoscaling is disabled when the min and max counts are `null`.

Previously this resulted in this error:

```
Error: 422 Unprocessable Entity {
  "httpStatus" : 422,
  "messages" : [ {
    "errorCode" : "110",
    "message" : "[(root).properties.autoScaling.minNodeCount] Attribute has to be greater than 0"
  } ]
}
```

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Sonar Cloud Scan
- [x] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
