### PR TITLE
enhancement: restructure help template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ go.work
 # Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
+.idea/copilot
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+## Changed
+- Changed help text order to match terminal reading patterns: command-specific information moved lower, global/general help moved higher.
+
+
 ### Fixed
 - Kubernetes node pool auto scaling can be disabled by setting `--min-node-count` and `--max-node-count` to 0.
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/cfg"
@@ -264,56 +263,50 @@ func addCommands() {
 }
 
 const (
-	availableCommands = `{{if .HasAvailableSubCommands}}
+	availableCommands = `{{- if .HasAvailableSubCommands}}
 AVAILABLE COMMANDS:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short | trimTrailingWhitespaces}}{{end}}{{end}}{{end}}`
+  {{rpad .Name .NamePadding }} {{.Short | trim}}{{end}}{{end}}{{print "\n"}}{{end}}`
 
-	seeAlso = `{{if .HasHelpSubCommands}}
+	seeAlso = `{{- if .HasHelpSubCommands}}
 SEE ALSO:
-{{.Annotations.SeeAlsos | trimTrailingWhitespaces}}{{end}}`
+{{.Annotations.SeeAlsos | trim}}{{print "\n"}}{{end}}`
 
-	additionalHelpTopics = `{{if .HasHelpSubCommands}}
+	additionalHelpTopics = `{{- if .HasHelpSubCommands}}
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short | trimTrailingWhitespaces}}{{end}}{{end}}{{end}}`
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short | trim}}{{end}}{{end}}{{print "\n"}}{{end}}`
 
-	localFlags = `{{if .HasAvailableLocalFlags}}
+	localFlags = `{{- if .HasAvailableLocalFlags}}
 FLAGS:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}`
+{{.LocalFlags.FlagUsages}}{{end}}`
 
-	globalFlags = `{{if .HasAvailableInheritedFlags}}
+	globalFlags = `{{- if .HasAvailableInheritedFlags}}
 GLOBAL FLAGS:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}`
+{{.InheritedFlags.FlagUsages}}{{end}}`
 
-	usage = `{{if .Runnable}}
+	usage = `{{- if .Runnable}}
 USAGE:
-  {{.UseLine | trimTrailingWhitespaces}}{{end}}`
+  {{.UseLine | trim}}{{print "\n"}}{{end}}`
 
-	aliases = `{{if gt (len .Aliases) 0}}
+	aliases = `{{- if gt (len .Aliases) 0}}
 ALIASES:
-  {{.NameAndAliases | trimTrailingWhitespaces}}{{end}}`
+  {{.NameAndAliases | trim}}{{print "\n"}}{{end}}`
 
-	examples = `{{if .HasExample}}
+	examples = `{{- if .HasExample}}
 EXAMPLES:
-{{.Example | trimTrailingWhitespaces}}{{end}}`
+{{.Example | trim}}{{print "\n"}}{{end}}`
 
-	moreInfo = `{{if .HasAvailableSubCommands}}
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}`
+	moreInfo = `{{- if .HasAvailableSubCommands}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{print "\n"}}{{end}}`
 )
 
-var helpTemplate = func() string {
-	result := strings.Join([]string{
-		seeAlso,
-		additionalHelpTopics,
-		globalFlags,
-		localFlags,
-		aliases,
-		examples,
-		usage,
-		availableCommands,
-		moreInfo,
-	}, "\n")
-
-	// Use a regular expression to replace any occurrence of more than one newline with a single newline
-	re := regexp.MustCompile(`\n{2,}`)
-	return re.ReplaceAllString(result, "\n")
-}()
+var helpTemplate = strings.Join([]string{
+	seeAlso,
+	additionalHelpTopics,
+	globalFlags,
+	localFlags,
+	aliases,
+	examples,
+	usage,
+	availableCommands,
+	moreInfo,
+}, "")


### PR DESCRIPTION
Reorders the Help Template such that current command related  functionalities are printed last, similar to how `kubectl` does it. Basically in CLIs the read order is bottom-to-top, so this new order should reflect that.

This should get rid of the "ping-pong" style scrolling that users have to do to find information for that command (i.e. scrolling up to examples, down to flags, up to usage, etc.). This was also most noticeable in commands with available subcommands, where users commonly had to scroll up to see these subcommands.

Also, now a developer can just re-order the templates more easily, they don't depend on each other for newlines, indents, trims, etc. and manage the whitespaces around them by themself, as well as the if-conditions are reworked to be included in that specific section. 

## `ionosctl datacenter` before:
```
The sub-commands of `ionosctl datacenter` allow you to create, list, get, update and delete Data Centers.

USAGE: 
  ionosctl datacenter [command]

ALIASES:
  datacenter, d, dc, vdc

AVAILABLE COMMANDS:
  create      Create a Data Center
  delete      Delete a Data Center
  get         Get a Data Center
  list        List Data Centers
  update      Update a Data Center

FLAGS:
      --cols strings   Set of columns to be printed on output 
                       Available columns: [DatacenterId Name Location State Description Version Features CpuFamily SecAuthProtection IPv6CidrBlock] (default [DatacenterId,Name,Location,CpuFamily,IPv6CidrBlock,State])

GLOBAL FLAGS:
  -u, --api-url string   Override default host url (default "https://api.ionos.com")
  -c, --config string    Configuration file used for authentication (default "/home/avirtopeanu/.config/ionosctl/config.json")
  -f, --force            Force command to execute without user input
  -h, --help             Print usage
      --no-headers       Don't print table headers when table output is used
  -o, --output string    Desired output format [text|json|api-json] (default "text")
  -q, --quiet            Quiet output
  -v, --verbose          Print step-by-step process when running command

Use "ionosctl datacenter [command] --help" for more information about a command.
```

## `ionosctl datacenter` after:
```
The sub-commands of `ionosctl datacenter` allow you to create, list, get, update and delete Data Centers.


GLOBAL FLAGS:
  -u, --api-url string   Override default host url (default "https://api.ionos.com")
  -c, --config string    Configuration file used for authentication (default "/home/avirtopeanu/.config/ionosctl/config.json")
  -f, --force            Force command to execute without user input
  -h, --help             Print usage
      --no-headers       Don't print table headers when table output is used
  -o, --output string    Desired output format [text|json|api-json] (default "text")
  -q, --quiet            Quiet output
  -v, --verbose          Print step-by-step process when running command

FLAGS:
      --cols strings   Set of columns to be printed on output 
                       Available columns: [DatacenterId Name Location State Description Version Features CpuFamily SecAuthProtection IPv6CidrBlock] (default [DatacenterId,Name,Location,CpuFamily,IPv6CidrBlock,State])

ALIASES:
  datacenter, d, dc, vdc

AVAILABLE COMMANDS:
  create      Create a Data Center
  delete      Delete a Data Center
  get         Get a Data Center
  list        List Data Centers
  update      Update a Data Center

Use "ionosctl datacenter [command] --help" for more information about a command.
```

## `ionosctl datacenter create --help` before:
```
 % i dc create --help 
Use this command to create a Virtual Data Center. You can specify the name, description or location for the object.

Virtual Data Centers are the foundation of the IONOS platform. VDCs act as logical containers for all other objects you will be creating, e.g. servers. You can provision as many Data Centers as you want. Data Centers have their own private network and are logically segmented from each other to create isolation.

You can wait for the Request to be executed using `--wait-for-request` option.

USAGE: 
  ionosctl datacenter create [flags]

ALIASES:
  create, c

EXAMPLES:
ionosctl datacenter create --name NAME --location LOCATION_ID
ionosctl datacenter create --name NAME --location LOCATION_ID --wait-for-request

FLAGS:
  -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
  -d, --description string   Description of the Data Center
  -l, --location string      Location for the Data Center (default "de/txl")
  -n, --name string          Name of the Data Center (default "Unnamed Data Center")
  -t, --timeout int          Timeout option for Request for Data Center creation [seconds] (default 60)
  -w, --wait-for-request     Wait for the Request for Data Center creation to be executed

GLOBAL FLAGS:
  -u, --api-url string   Override default host url (default "https://api.ionos.com")
      --cols strings     Set of columns to be printed on output 
                         Available columns: [DatacenterId Name Location State Description Version Features CpuFamily SecAuthProtection IPv6CidrBlock] (default [DatacenterId,Name,Location,CpuFamily,IPv6CidrBlock,State])
  -c, --config string    Configuration file used for authentication (default "/home/avirtopeanu/.config/ionosctl/config.json")
  -f, --force            Force command to execute without user input
  -h, --help             Print usage
      --no-headers       Don't print table headers when table output is used
  -o, --output string    Desired output format [text|json|api-json] (default "text")
  -q, --quiet            Quiet output
  -v, --verbose          Print step-by-step process when running command
```

## `ionosctl datacenter create --help` after:
```
 % i dc create --help
Use this command to create a Virtual Data Center. You can specify the name, description or location for the object.

Virtual Data Centers are the foundation of the IONOS platform. VDCs act as logical containers for all other objects you will be creating, e.g. servers. You can provision as many Data Centers as you want. Data Centers have their own private network and are logically segmented from each other to create isolation.

You can wait for the Request to be executed using `--wait-for-request` option.


GLOBAL FLAGS:
  -u, --api-url string   Override default host url (default "https://api.ionos.com")
      --cols strings     Set of columns to be printed on output 
                         Available columns: [DatacenterId Name Location State Description Version Features CpuFamily SecAuthProtection IPv6CidrBlock] (default [DatacenterId,Name,Location,CpuFamily,IPv6CidrBlock,State])
  -c, --config string    Configuration file used for authentication (default "/home/avirtopeanu/.config/ionosctl/config.json")
  -f, --force            Force command to execute without user input
  -h, --help             Print usage
      --no-headers       Don't print table headers when table output is used
  -o, --output string    Desired output format [text|json|api-json] (default "text")
  -q, --quiet            Quiet output
  -v, --verbose          Print step-by-step process when running command

FLAGS:
  -D, --depth int32          Controls the detail depth of the response objects. Max depth is 10.
  -d, --description string   Description of the Data Center
  -l, --location string      Location for the Data Center (default "de/txl")
  -n, --name string          Name of the Data Center (default "Unnamed Data Center")
  -t, --timeout int          Timeout option for Request for Data Center creation [seconds] (default 60)
  -w, --wait-for-request     Wait for the Request for Data Center creation to be executed

ALIASES:
  create, c

EXAMPLES:
ionosctl datacenter create --name NAME --location LOCATION_ID
ionosctl datacenter create --name NAME --location LOCATION_ID --wait-for-request

USAGE:
  ionosctl datacenter create [flags]
```
