### PR TITLE
fix: version if installed via 'go install'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,20 @@
 
 ## Upcoming
 
-## Changed
+### Changed
 - Changed help text order to match terminal reading patterns: command-specific information moved lower, global/general help moved higher.
 
 
 ### Fixed
 - Kubernetes node pool auto scaling can be disabled by setting `--min-node-count` and `--max-node-count` to 0.
+- Fixed missing version in `ionosctl version` output when installed via 'go install'.
 
 ## [v6.7.4] (January 2024)
 
 ### Added
 - Added `version` resource for Dataplatform API, with `list` and `latest` subcommands
 - Added support for Container-Registry Vulnerabilities
-  - New `--vulnerability-scanning` flag added to `registry create` and `registry update` commands 
+  - New `--vulnerability-scanning` flag added to `registry create` and `registry update` commands
   - New `artifacts` and `vulnerabilities` commands under `container-registry`
   - `repository` command functionality will eventually be moved to `repository delete`. For the time being, both commands are available.
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns"
 	vm_autoscaling "github.com/ionos-cloud/ionosctl/v6/commands/vm-autoscaling"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/jsontabwriter"
+	"github.com/ionos-cloud/ionosctl/v6/internal/version"
 
 	certificates "github.com/ionos-cloud/ionosctl/v6/commands/certmanager"
 	cloudapiv6 "github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6"
@@ -24,8 +25,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-const CLIVersionDev = "DEV"
 
 var (
 	// RootCmd is the root level command that all other commands attach to
@@ -44,12 +43,6 @@ var (
 	NoHeaders bool
 
 	cfgFile string
-
-	Version string
-	// Label - If label is not set, the version will be: DEV
-	// If label is set as `release`, it will show the version released
-	Label     string
-	GitCommit string
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -84,12 +77,7 @@ func init() {
 	rootCmd.Command.SetUsageTemplate(helpTemplate)
 	rootCmd.Command.SetHelpCommand(helpCommand)
 
-	// Init version
-	if Label == "release" {
-		rootCmd.Command.Version = "v" + strings.TrimLeft(Version, "v ")
-	} else {
-		rootCmd.Command.Version = fmt.Sprintf("%s-%s", CLIVersionDev, GitCommit)
-	}
+	rootCmd.Command.Version = version.Get() // Send the current version to Cobra
 	viper.Set(constants.CLIHttpUserAgent, fmt.Sprintf("ionosctl/%v", rootCmd.Command.Version))
 
 	// Here you will define your flags and configuration settings.

--- a/commands/shell.go
+++ b/commands/shell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elk-language/go-prompt"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	"github.com/ionos-cloud/ionosctl/v6/internal/version"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionoscloudsdk/comptplus"
 	"github.com/spf13/cobra"
@@ -118,7 +119,7 @@ Ctrl + L\tClear the screen`,
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			fmt.Printf("ionosctl v%s\n", Version)
+			fmt.Printf("ionosctl v%s\n", version.Get())
 			fmt.Println("Warning: We recommend keeping usage of this interactive shell to non-production critical applications.")
 			fmt.Println("   - DANGER:\tCertain commands that require user input may freeze the shell!")
 			fmt.Println("   - NOTE:\tCommands such as 'delete' that require user confirmation will always fail and will instead ask for '--force' to be set.")

--- a/commands/shell.go
+++ b/commands/shell.go
@@ -119,7 +119,7 @@ Ctrl + L\tClear the screen`,
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			fmt.Printf("ionosctl v%s\n", version.Get())
+			fmt.Printf("ionosctl %s\n", version.Get())
 			fmt.Println("Warning: We recommend keeping usage of this interactive shell to non-production critical applications.")
 			fmt.Println("   - DANGER:\tCertain commands that require user input may freeze the shell!")
 			fmt.Println("   - NOTE:\tCommands such as 'delete' that require user confirmation will always fail and will instead ask for '--force' to be set.")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,7 +26,7 @@ func Get() string {
 		if len(versionParts) >= 3 {
 			versionOrHash := versionParts[2]
 			if isSemanticVersion(versionOrHash) {
-				return versionOrHash
+				return "v" + strings.TrimLeft(versionOrHash, "v ")
 			}
 			if len(versionOrHash) > 7 {
 				versionOrHash = versionOrHash[:7]

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,6 +23,11 @@ var (
 )
 
 // Get returns the current CLI version, preferring the value set via ldflags
+// Examples:
+//   - v1.0.0
+//   - DEV-abcdef1
+//   - DEV-abcdef1+ (if installed via `make install` with uncommitted changes)
+//   - unknown
 func Get(options ...Option) string {
 	cfg := Config{
 		ReadBuildInfo: debug.ReadBuildInfo, // Default fetcher

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+// Variables sent at link time via ldflags
+var (
+	Version   string
+	GitCommit string
+	Label     string
+)
+
+// Get returns the current CLI version, preferring the value set via ldflags
+func Get() string {
+	if Version != "" || GitCommit != "" {
+		return getVersionViaLdFlags()
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		return info.Main.Version
+	}
+
+	return "unknown"
+}
+
+func getVersionViaLdFlags() string {
+	if Label == "release" {
+		return "v" + strings.TrimLeft(Version, "v ")
+	}
+	return fmt.Sprintf("DEV-%s", GitCommit)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 	"runtime/debug"
 	"strings"
 )
@@ -23,14 +24,16 @@ func Get() string {
 	if ok {
 		versionParts := strings.Split(info.Main.Version, "-")
 		if len(versionParts) >= 3 {
-			commitHash := versionParts[2]
-			if len(commitHash) > 7 {
-				commitHash = commitHash[:7]
+			versionOrHash := versionParts[2]
+			if isSemanticVersion(versionOrHash) {
+				return versionOrHash
 			}
-			return fmt.Sprintf("DEV-%s", commitHash)
+			if len(versionOrHash) > 7 {
+				versionOrHash = versionOrHash[:7]
+			}
+			return fmt.Sprintf("DEV-%s", versionOrHash)
 		}
 	}
-
 	return "unknown"
 }
 
@@ -39,4 +42,10 @@ func getVersionViaLdFlags() string {
 		return "v" + strings.TrimLeft(Version, "v ")
 	}
 	return fmt.Sprintf("DEV-%s", GitCommit)
+}
+
+func isSemanticVersion(version string) bool {
+	semanticVersionPattern := `^v\d+\.\d+\.\d+$`
+	matched, _ := regexp.MatchString(semanticVersionPattern, version)
+	return matched
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -22,6 +22,13 @@ func Get() string {
 
 	info, ok := debug.ReadBuildInfo()
 	if ok {
+		// If installed via a known tag using `go install`, return the version directly
+		if isSemanticVersion(info.Main.Version) {
+			return "v" + strings.TrimLeft(info.Main.Version, "v ")
+		}
+
+		// Installed via `go install` with a commit hash, return a dev version
+		// Example: v0.0.0-20210101000000-abcdef123456 -> DEV-abcdef1
 		versionParts := strings.Split(info.Main.Version, "-")
 		if len(versionParts) >= 3 {
 			versionOrHash := versionParts[2]

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,14 @@ func Get() string {
 
 	info, ok := debug.ReadBuildInfo()
 	if ok {
-		return info.Main.Version
+		versionParts := strings.Split(info.Main.Version, "-")
+		if len(versionParts) >= 3 {
+			commitHash := versionParts[2]
+			if len(commitHash) > 7 {
+				commitHash = commitHash[:7]
+			}
+			return fmt.Sprintf("DEV-%s", commitHash)
+		}
 	}
 
 	return "unknown"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,109 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func()
+		fetcher         BuildInfoFetcher
+		expectedVersion string
+	}{
+		{
+			name: "ldflags version and release label",
+			setup: func() {
+				Version = "1.0.0"
+				GitCommit = "abc123"
+				Label = "release"
+			},
+			expectedVersion: "v1.0.0",
+		},
+		{
+			name: "ldflags GitCommit only",
+			setup: func() {
+				Version = ""
+				GitCommit = "def456"
+				Label = ""
+			},
+			expectedVersion: "DEV-def456",
+		},
+		{
+			name: "ldflags GitCommit modified files",
+			setup: func() {
+				Version = ""
+				GitCommit = "def456+"
+				Label = ""
+			},
+			expectedVersion: "DEV-def456+",
+		},
+		{
+			name: "semantic version from build info",
+			setup: func() {
+				Version = ""
+				GitCommit = ""
+				Label = ""
+			},
+			fetcher: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{
+					Main: debug.Module{
+						Version: "v2.0.0",
+					},
+				}, true
+			},
+			expectedVersion: "v2.0.0",
+		},
+		{
+			name: "commit hash from build info",
+			setup: func() {
+				Version = ""
+				GitCommit = ""
+				Label = ""
+			},
+			fetcher: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{
+					Main: debug.Module{
+						Version: "v0.0.0-20210101000000-abcdef123456",
+					},
+				}, true
+			},
+			expectedVersion: "DEV-abcdef1",
+		},
+		{
+			name: "unknown version",
+			setup: func() {
+				Version = ""
+				GitCommit = ""
+				Label = ""
+			},
+			fetcher: func() (*debug.BuildInfo, bool) {
+				return nil, false
+			},
+			expectedVersion: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer func() {
+				Version = ""
+				GitCommit = ""
+				Label = ""
+			}()
+
+			var got string
+			if tc.fetcher != nil {
+				got = Get(WithFetcher(tc.fetcher))
+			} else {
+				got = Get()
+			}
+
+			if got != tc.expectedVersion {
+				t.Errorf("expected version %q, got %q", tc.expectedVersion, got)
+			}
+		})
+	}
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -15,10 +15,10 @@ if [ "${RELEASE_BUILD:-}" = "true" ]; then
   label="release"
 fi
 
-ldflags_base="-X github.com/ionos-cloud/ionosctl/v6/commands.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/v6/commands.GitCommit=${GIT_COMMIT}"
+ldflags_base="-X github.com/ionos-cloud/ionosctl/v6/internal/version.Version=${VERSION} -X github.com/ionos-cloud/ionosctl/v6/internal/version.GitCommit=${GIT_COMMIT}"
 ldflags="${ldflags_base}"
 if [ -n "${label}" ]; then
-  ldflags="${ldflags} -X github.com/ionos-cloud/ionosctl/v6/commands.Label=${label}"
+  ldflags="${ldflags} -X github.com/ionos-cloud/ionosctl/v6/internal/version.Label=${label}"
 fi
 
 echo "VERSION: ${VERSION}"


### PR DESCRIPTION
Moves versioning logic to a new `version` pkg.

Use `buildinfo` to get version, since this is empty if installed via `go install`.

## `ionosctl version` before
```
 % go install github.com/ionos-cloud/ionosctl/v6@(some-commit)
go: downloading github.com/ionos-cloud/ionosctl/v6 v...

 % ionosctl version
DEV-
```

## `ionosctl version` after
```
 % go install github.com/ionos-cloud/ionosctl/v6@67c7f98                                     
go: downloading github.com/ionos-cloud/ionosctl/v6 v6.7.5-0.20240301130018-67c7f986faf0

 % i version
DEV-67c7f98
```

## `ionosctl version` installed via build script (before & after - no change - ldflags are used)

```
 % i version
DEV-67c7f98
```
