### PR TITLE
fix: goreleaser builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ modules.xml
 
 # Contains built binaries
 builds/
+dist/
 
 # direnv config
 .envrc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,8 @@ builds:
       - -trimpath
       - -mod=vendor
     ldflags:
-      - "-X github.com/ionos-cloud/ionosctl/v6/commands.Version={{ .Version }}"
-      - "-X github.com/ionos-cloud/ionosctl/v6/commands.Label=release"
+      - "-X github.com/ionos-cloud/ionosctl/v6/internal/version.Version={{ .Version }}"
+      - "-X github.com/ionos-cloud/ionosctl/v6/internal/version.Label=release"
     goos:
       - windows
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,20 +42,19 @@ archives:
       - CHANGELOG.md
     wrap_in_directory: false
 
-scoop:
-#  folder: Scoops
-  bucket:
-    owner: ionos-cloud
-    name: scoop-bucket
-  homepage: https://github.com/ionos-cloud/ionosctl
-  description: IonosCTL is a tool to help you manage your Ionos Cloud resources directly from your terminal.
-  license: Apache-2.0
+scoops:
+  - repository:
+      owner: ionos-cloud
+      name: scoop-bucket
+    homepage: https://github.com/ionos-cloud/ionosctl
+    description: IonosCTL is a tool to help you manage your Ionos Cloud resources directly from your terminal.
+    license: Apache-2.0
 
 brews:
   - name: ionosctl
     ids:
       - ionosctl
-    tap:
+    repository:
       owner: ionos-cloud
       name: homebrew-ionos-cloud
     folder: Formula
@@ -92,4 +91,4 @@ changelog:
       - '^dep:'
       - '^deps:'
       - '^dependencies:'
-  skip: false
+  disable: false


### PR DESCRIPTION
## What does this fix or implement?

Relese binaries had the version `unknown` because the ldflags were not set correctly.
The Github action also printed out some deprecation warnings.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
