### PR TITLE
fix: version flag completions, remove '-w' for maria, hide '-w' for mongo

### DIFF
--- a/commands/dbaas/mariadb/cluster/create.go
+++ b/commands/dbaas/mariadb/cluster/create.go
@@ -130,7 +130,7 @@ func Create() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagName, constants.FlagNameShort, "", "The name of your cluster", core.RequiredFlagOption())
 	cmd.AddStringFlag(constants.FlagVersion, "", "10.6", "The MariaDB version of your cluster", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagInstances, func(cmdCobra *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagVersion, func(cmdCobra *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"10.6", "10.11"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
@@ -162,7 +162,7 @@ func Create() *core.Command {
 		"Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. "+
 			"Defaults to a random day during Mon-Fri, during the hours 10:00-16:00")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagMaintenanceDay, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return append(workingDaysOfWeek, "Satuday", "Sunday"), cobra.ShellCompDirectiveNoFileComp
+		return append(workingDaysOfWeek, "Saturday", "Sunday"), cobra.ShellCompDirectiveNoFileComp
 	})
 	// Connections
 	cmd.AddStringFlag(constants.FlagDatacenterId, "", "", "The datacenter to which your cluster will be connected. Must be in the same location as the cluster", core.RequiredFlagOption())
@@ -179,10 +179,6 @@ func Create() *core.Command {
 	// credentials / DBUser
 	cmd.AddStringFlag(constants.ArgUser, "", "", "The initial username", core.RequiredFlagOption())
 	cmd.AddStringFlag(constants.ArgPassword, "", "", "The password", core.RequiredFlagOption())
-
-	// Misc
-	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request to be executed")
-	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request [seconds]")
 
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false

--- a/commands/dbaas/mongo/cluster/create.go
+++ b/commands/dbaas/mongo/cluster/create.go
@@ -271,7 +271,7 @@ func ClusterCreateCmd() *core.Command {
 		"Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. "+
 			"Defaults to a random day during Mon-Fri, during the hours 10:00-16:00")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagMaintenanceDay, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return append(workingDaysOfWeek, "Satuday", "Sunday"), cobra.ShellCompDirectiveNoFileComp
+		return append(workingDaysOfWeek, "Saturday", "Sunday"), cobra.ShellCompDirectiveNoFileComp
 	})
 	// Enterprise-specific
 	cmd.AddInt32Flag(constants.FlagCores, "", 1, "The total number of cores for the Server, e.g. 4. (required and only settable for enterprise edition)")
@@ -316,10 +316,6 @@ func ClusterCreateCmd() *core.Command {
 	// Biconnector
 	cmd.AddStringFlag(flagBiconnector, "", "", "BI Connector host & port. The MongoDB Connector for Business Intelligence allows you to query a MongoDB database using SQL commands. Example: r1.m-abcdefgh1234.mongodb.de-fra.ionos.com:27015")
 	cmd.AddBoolFlag(flagBiconnectorEnabled, "", true, fmt.Sprintf("Enable or disable the biconnector. To disable it, use --%s=false", flagBiconnectorEnabled))
-
-	// Misc
-	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request to be executed")
-	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request [seconds]")
 
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false

--- a/commands/dbaas/mongo/cluster/create.go
+++ b/commands/dbaas/mongo/cluster/create.go
@@ -317,6 +317,15 @@ func ClusterCreateCmd() *core.Command {
 	cmd.AddStringFlag(flagBiconnector, "", "", "BI Connector host & port. The MongoDB Connector for Business Intelligence allows you to query a MongoDB database using SQL commands. Example: r1.m-abcdefgh1234.mongodb.de-fra.ionos.com:27015")
 	cmd.AddBoolFlag(flagBiconnectorEnabled, "", true, fmt.Sprintf("Enable or disable the biconnector. To disable it, use --%s=false", flagBiconnectorEnabled))
 
+	// Misc
+	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request to be executed")
+	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request [seconds]")
+
+	// They do nothing... but we can't outright remove them in case some user already uses them in their scripts
+	// would cause ('unknown flag: -w')
+	cmd.Command.Flags().MarkHidden(constants.ArgWaitForRequest)
+	cmd.Command.Flags().MarkHidden(constants.ArgTimeout)
+
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false
 

--- a/commands/dbaas/mongo/cluster/update.go
+++ b/commands/dbaas/mongo/cluster/update.go
@@ -220,6 +220,11 @@ func ClusterUpdateCmd() *core.Command {
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request [seconds]")
 
+	// They do nothing... but we can't outright remove them in case some user already uses them in their scripts
+	// would cause ('unknown flag: -w')
+	cmd.Command.Flags().MarkHidden(constants.ArgWaitForRequest)
+	cmd.Command.Flags().MarkHidden(constants.ArgTimeout)
+
 	cmd.Command.SilenceUsage = true
 
 	return cmd

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
@@ -57,11 +57,9 @@ Create DBaaS MariaDB clusters
   -q, --quiet                     Quiet output
       --ram string                RAM size. e.g.: --ram 4GB. Minimum of 4GB. The maximum RAM size is determined by your contract limit (default "4GB")
       --storage-size string       The size of the Storage in GB. e.g.: --size 10 or --size 10GB. The maximum Volume size is determined by your contract limit (default "10")
-  -t, --timeout int               Timeout option for Request [seconds] (default 60)
       --user string               The initial username (required)
   -v, --verbose                   Print step-by-step process when running command
       --version string            The MariaDB version of your cluster (required) (default "10.6")
-  -w, --wait-for-request          Wait for the Request to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -64,11 +64,9 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --storage-size string       Custom Storage: Minimum of 5GB, Greater performance for values greater than 100 GB. (only settable for enterprise edition) (default "5GB")
       --storage-type string       Custom Storage Type. (only settable for enterprise edition) (default "\"SSD Standard\"")
       --template string           The ID of a Mongo Template, or a word contained in the name of one. Templates specify the number of cores, storage size, and memory. Business editions default to XS template. Playground editions default to playground template.
-  -t, --timeout int               Timeout option for Request [seconds] (default 60)
       --type string               Cluster Type. Required for enterprise clusters. Not required (inferred) if using --shards or --instances. Can be one of: replicaset, sharded-cluster (default "replicaset")
   -v, --verbose                   Print step-by-step process when running command
       --version string            The MongoDB version of your cluster (required) (default "6.0")
-  -w, --wait-for-request          Wait for the Request to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
@@ -62,9 +62,7 @@ Update a Mongo Cluster by ID
       --shards int32              The total number of shards in the sharded_cluster cluster. Setting this flag is only possible for enterprise clusters and infers a sharded_cluster type. Possible values: 2 - 32. (required for sharded_cluster enterprise clusters) (default 1)
       --storage-size string       Custom Storage: Greater performance for values greater than 100 GB. (required and only settable for enterprise edition)
       --storage-type string       Custom Storage Type. (only settable for enterprise edition) (default "\"SSD Standard\"")
-  -t, --timeout int               Timeout option for Request [seconds] (default 60)
   -v, --verbose                   Print step-by-step process when running command
-  -w, --wait-for-request          Wait for the Request to be executed
 ```
 
 ## Examples


### PR DESCRIPTION
Removes `--wait-for-request` as this does nothing. We can't implement this 'as is' because CloudAPI Requests API does not register these requests.

Hides `--wait-for-request` for mongo commands for the same reason, but do not remove it as this might be used by users in scripts (and removing it outright would cause 'unknown flag: -w'

Fixes completions for `--version` flag

Fixes misspelled 'Satuday' -> 'Saturday' for maintenance day completions