### PR TITLE
test: add BATS server volume test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Upcoming
 
 ### Fixed
+- Fixed a bug with 'nic create' not creating the LAN when missing and instead returning a 404
+
+## [v6.7.6] (April 2024)
+
+### Fixed
 - Fixed a bug for `image upload` where using a custom `--ftp-url` and no `--location` would silently fail the operation
 
 ### Added

--- a/test/bats/cloudapi/volume.bats
+++ b/test/bats/cloudapi/volume.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+# tags: server, volume, image, console
+
+BATS_LIBS_PATH="${LIBS_PATH:-../libs}" # fallback to relative path if not set
+load "${BATS_LIBS_PATH}/bats-assert/load"
+load "${BATS_LIBS_PATH}/bats-support/load"
+load '../setup.bats'
+
+setup_file() {
+    mkdir -p /tmp/bats_test
+
+    ssh-keygen -t rsa -b 4096 -N "" -f /tmp/bats_test/id_rsa
+
+    uuid_v4_regex='^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+    ip_regex='^([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?$'
+}
+
+# Creating a temp user allows us to simply delete all datacenters if something fails
+# Prevents deletion of unrelated resources
+@test "Create temporary user with relevant permissions" {
+    echo "$(randStr 16)@$(randStr 8).ionosctl.test" | tr '[:upper:]' '[:lower:]' > /tmp/bats_test/email
+    echo "$(randStr 12)" > /tmp/bats_test/password
+
+    run ionosctl user create --first-name "random-$(randStr 4)" --last-name "last-$(randStr 4)" \
+     --email "$(cat /tmp/bats_test/email)" --password "$(cat /tmp/bats_test/password)" -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/user_id
+
+    run ionosctl group create --name "test-volumes-$(randStr 4)" \
+     --create-dc --create-nic --reserve-ip -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/group_id
+
+    run ionosctl group user add --user-id "$(cat /tmp/bats_test/user_id)" \
+     --group-id "$(cat /tmp/bats_test/group_id)" -o json 2> /dev/null
+    assert_success
+}
+
+@test "Create Datacenter" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    run ionosctl datacenter create --name "volumes-test-$(randStr 8)" --location "es/vit" -w -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/datacenter_id
+    sleep 5
+}
+
+@test "Create Server" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    # CPU-Family should be selected correctly by default
+    run ionosctl server create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --name "bats-test-$(randStr 8)" \
+     --cores 1 --ram 4GB -w -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/server_id
+}
+
+@test "Make servers accessible via NIC and attach IP. Verify LAN is created" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    run ionosctl ipblock create --location "es/vit" --size 1 --name "bats-test-$(randStr 8)" -w -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.properties.ips[0]' > /tmp/bats_test/ip
+
+    run ionosctl nic create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" \
+     --name "bats-test-$(randStr 8)" --ips "$(cat /tmp/bats_test/ip)" -w -o json 2> /dev/null
+    assert_success
+    sleep 5
+
+    # A LAN is created by default
+    run ionosctl lan list --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+     --no-headers --cols LanId
+    assert_success
+    assert_output "1"
+}
+
+@test "Attach a volume with an HDD image" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    # Find a suitable image
+    run ionosctl image list -F imageAliases=ubuntu:20 -F location="es/vit" -F imageType=hdd --cols ImageId --no-headers
+    assert_success
+    echo "$output" | head -n 1 > /tmp/bats_test/image_id
+
+    run ionosctl volume create --type "SSD Premium" --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+     --name "bats-test-$(randStr 8)" --size 50 --image-id "$(cat /tmp/bats_test/image_id)" \
+     --ssh-key-paths /tmp/bats_test/id_rsa.pub -w -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/volume_id
+
+    run ionosctl volume attach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_id)" -w
+    assert_success
+}
+
+@test "Server Console is accessible" {
+    run ionosctl server console get --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+     --server-id "$(cat /tmp/bats_test/server_id)" --no-headers
+    assert_success
+    # Use curl to fetch the HTML content of the URL
+    run curl "$output"
+    assert_success
+    assert_output --partial "<title>Remote Console</title>"
+}
+
+@test "ssh into the server" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    run ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/bats_test/id_rsa \
+     root@"$(cat /tmp/bats_test/ip)" "echo 'SSH into the server successful'"
+    assert_success
+}
+
+@test "Delete Server" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    run ionosctl server delete \
+     --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" -f
+    assert_success
+}
+
+@test "Delete Datacenter" {
+    export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+    export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+    run ionosctl datacenter delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" -f
+    assert_success
+}
+
+#teardown_file() {
+#    # use a temporary subshell to switch to the temp user
+#    (
+#        # Overwrite IONOS_USERNAME and IONOS_PASSWORD with values from temporary files
+#        export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+#        export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+#
+#        # Execute commands using the temporary user
+#        ionosctl ipblock delete -af
+#        ionosctl datacenter delete -af
+#    )
+#
+#    # original IONOS_USERNAME IONOS_PASSWORD are restored
+#    ionosctl user delete --user-id "$(cat /tmp/bats_test/user_id)" -f
+#    ionosctl group delete --group-id "$(cat /tmp/bats_test/group_id)" -f
+#
+#    rm -rf /tmp/bats_test
+#}

--- a/test/bats/cloudapi/volume.bats
+++ b/test/bats/cloudapi/volume.bats
@@ -44,7 +44,7 @@ setup_file() {
 
     # NOTE: In this test suite we also create a CUBE Server. Cubes can only work with INTEL_SKYLAKE family
     # If you want to change the location, make sure it supports INTEL_SKYLAKE!
-    run ionosctl datacenter create --name "volumes-test-$(randStr 8)" --location "es/vit" -w -o json 2> /dev/null
+    run ionosctl datacenter create --name "volumes-test-$(randStr 8)" --location "es/vit" -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/datacenter_id
     sleep 5
@@ -56,7 +56,7 @@ setup_file() {
 
     # CPU-Family should be selected correctly by default
     run ionosctl server create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --name "bats-test-$(randStr 8)" \
-     --cores 1 --ram 4GB -w -o json 2> /dev/null
+     --cores 1 --ram 4GB -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/server_id
 }
@@ -66,16 +66,16 @@ setup_file() {
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
     run ionosctl lan create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --name "bats-test-$(randStr 8)" \
-     --public -w -o json 2> /dev/null
+     --public -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/lan_id
 
-    run ionosctl ipblock create --location "es/vit" --size 1 --name "bats-test-$(randStr 8)" -w -o json 2> /dev/null
+    run ionosctl ipblock create --location "es/vit" --size 1 --name "bats-test-$(randStr 8)" -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.properties.ips[0]' > /tmp/bats_test/ip
     echo "$output" | jq -r '.id' > /tmp/bats_test/ipblock_id
     run ionosctl nic create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" \
-     --lan-id "$(cat /tmp/bats_test/lan_id)" --name "bats-test-$(randStr 8)" --ips "$(cat /tmp/bats_test/ip)" -w -o json 2> /dev/null
+     --lan-id "$(cat /tmp/bats_test/lan_id)" --name "bats-test-$(randStr 8)" --ips "$(cat /tmp/bats_test/ip)" -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/nic_id
     sleep 5
@@ -83,7 +83,7 @@ setup_file() {
 
 @test "Creating a nic with a non-existent LAN ID will create a LAN" {
     run ionosctl nic create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" \
-     --lan-id 123 -w -o json 2> /dev/null
+     --lan-id 123 -w -t 300 -o json 2> /dev/null
     assert_success
     sleep 5
 
@@ -111,7 +111,7 @@ setup_file() {
     echo "$output" | jq -r '.id' > /tmp/bats_test/volume_id
 
     run ionosctl server volume attach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_id)" -t 300 -w
+     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_id)" -t 600 -w
     assert_success
 }
 
@@ -125,14 +125,14 @@ setup_file() {
     echo "$output" | head -n 1 > /tmp/bats_test/iso_image_id
 
     run ionosctl server cdrom attach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --cdrom-id "$(cat /tmp/bats_test/iso_image_id)" --server-id "$(cat /tmp/bats_test/server_id)" -w -o json 2> /dev/null
+     --cdrom-id "$(cat /tmp/bats_test/iso_image_id)" --server-id "$(cat /tmp/bats_test/server_id)" -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/cdrom_id
 }
 
 @test "Attach a volume with a backupunit public image" {
     run ionosctl backupunit create --name "bats$(randStr 6)" --email "$(cat /tmp/bats_test/email)" \
-     --password "$(cat /tmp/bats_test/password)" -w -o json 2> /dev/null
+     --password "$(cat /tmp/bats_test/password)" -w -t 300 -o json 2> /dev/null
     assert_success
     echo "$output" | jq -r '.id' > /tmp/bats_test/backupunit_id
 
@@ -190,15 +190,15 @@ setup_file() {
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
     run ionosctl server volume detach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/backup_volume_id)" -w -f
+     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/backup_volume_id)" -w -t 300 -f
     assert_success
 
     run ionosctl server volume detach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_id)" -w -f
+     --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_id)" -w -t 300 -f
     assert_success
 
     run ionosctl server cdrom detach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --server-id "$(cat /tmp/bats_test/server_id)" --cdrom-id "$(cat /tmp/bats_test/cdrom_id)" -w -f
+     --server-id "$(cat /tmp/bats_test/server_id)" --cdrom-id "$(cat /tmp/bats_test/cdrom_id)" -w -t 300 -f
     assert_success
 }
 
@@ -220,7 +220,7 @@ setup_file() {
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
     run ionosctl server delete \
-     --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" -w -f
+     --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/server_id)" -w -t 300 -f
     assert_success
 }
 
@@ -253,7 +253,7 @@ setup_file() {
     export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
-    run ionosctl server delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/cube_server_id)" -f -w
+    run ionosctl server delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --server-id "$(cat /tmp/bats_test/cube_server_id)" -f -w -t 300
     assert_success
 }
 
@@ -266,7 +266,7 @@ setup_file() {
     assert_success
 
     run ionosctl volume delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
-     --volume-id "$(cat /tmp_bats_test/backup_volume_id)" -f -w -t 300
+     --volume-id "$(cat /tmp/bats_test/backup_volume_id)" -f -w -t 300
     assert_success
 
     # len of existing volumes should be 0
@@ -279,7 +279,7 @@ setup_file() {
     export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
-    run ionosctl datacenter delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" -f -w
+    run ionosctl datacenter delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" -f -w -t 300
     assert_success
 }
 
@@ -290,7 +290,7 @@ setup_file() {
     export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
-    run ionosctl ipblock delete -i "$(cat /tmp/bats_test/ipblock_id)" -f -w
+    run ionosctl ipblock delete -i "$(cat /tmp/bats_test/ipblock_id)" -f -w -t 300
     assert_success
 }
 

--- a/test/bats/cloudapi/volume.bats
+++ b/test/bats/cloudapi/volume.bats
@@ -268,11 +268,6 @@ setup_file() {
     run ionosctl volume delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
      --volume-id "$(cat /tmp/bats_test/backup_volume_id)" -f -w -t 300
     assert_success
-
-    # len of existing volumes should be 0
-    run ionosctl volume list --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --no-headers --cols Id | wc -l
-    assert_success
-    assert_equal "$output" 0
 }
 
 @test "Delete Datacenter" {

--- a/test/bats/setup.bats
+++ b/test/bats/setup.bats
@@ -14,6 +14,16 @@ randStr() {
     cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c "$size"
 }
 
+# Function to add padding to base64url encoded strings
+add_padding() {
+    local input=$1
+    local padded=$input
+    while [ $(( ${#padded} % 4 )) -ne 0 ]; do
+        padded="${padded}="
+    done
+    echo "$padded"
+}
+
 generate_ssh_key() {
     ssh_key_path="id_rsa_$(randStr 8)"
     ssh-keygen -t rsa -b 4096 -f "$ssh_key_path" -N "" >/dev/null 2>&1


### PR DESCRIPTION
Adds a BATS test suite for testing volume interactions with backupunits, servers, etc

Fixed a bug with NIC not creating the LAN when missing - returning a 404, and added a test case for this