### PR TITLE
fix: Fix error message on failed tokens API call

### DIFF
--- a/commands/cfg/login.go
+++ b/commands/cfg/login.go
@@ -110,7 +110,7 @@ func RunLoginUser(c *core.CommandConfig) error {
 	if validCredentials {
 		ls, _, errTokens := client.NewClientFromCfgData(data).AuthClient.TokensApi.TokensGet(context.Background()).Execute()
 		if errTokens != nil {
-			return fmt.Errorf("failed retrieving current tokens: %w", err)
+			return fmt.Errorf("failed retrieving current tokens: %w", errTokens)
 		}
 		msgActiveTokens := fmt.Sprintf("Note: Your account has %d active tokens. ", len(*ls.Tokens))
 		msg.WriteString(msgActiveTokens)


### PR DESCRIPTION
## What does this fix or implement?

I saw a workflow that failed with the following error message:

```
Error: failed retrieving current tokens: %!w(<nil>)
```

This is because the error wasn't wrapped correctly.

## Checklist

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
