### PR TITLE
fix: json-properties flag not working on k8s nodepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## [v6.8.0]
+## [v6.8.0] (???)
+
+### Added
 - Added support for CDN operations
+
+### Fixed
+- Removed Viper binding for `json-properties` and `json-properties-example` (fixes [463](https://github.com/ionos-cloud/ionosctl/issues/463))
 
 ## [v6.7.8] (October 2024)
 

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -150,9 +150,10 @@ Required values to run a command (for Private Kubernetes Cluster):
 			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			if viper.IsSet(constants.FlagJsonProperties) {
+			if c.Command.Command.Flags().Changed(constants.FlagJsonProperties) {
 				return RunK8sNodePoolCreateFromJSON(c, nodepoolViaJsonPropertiesFlag)
 			}
+
 			return RunK8sNodePoolCreate(c)
 		},
 		InitClient: true,

--- a/internal/core/command_runner.go
+++ b/internal/core/command_runner.go
@@ -26,13 +26,11 @@ func NewCommandWithJsonProperties(ctx context.Context, parent *Command, jsonExam
 
 	cmd.Command.Flags().String(constants.FlagJsonProperties, "",
 		"Path to a JSON file containing the desired properties. Overrides any other properties set.")
-	viper.BindPFlag(constants.FlagJsonProperties, cmd.Command.Flags().Lookup(constants.FlagJsonProperties))
 
 	if jsonExample != "" {
 		cmd.Command.Flags().Bool(constants.FlagJsonPropertiesExample, false,
 			fmt.Sprintf("If set, prints a complete JSON which could be used for --%s "+
 				"and exits. Hint: Pipe me to a .json file", constants.FlagJsonProperties))
-		viper.BindPFlag(constants.FlagJsonPropertiesExample, cmd.Command.Flags().Lookup(constants.FlagJsonPropertiesExample))
 	}
 
 	return cmd

--- a/test/bats/cloudapi/k8s.bats
+++ b/test/bats/cloudapi/k8s.bats
@@ -12,6 +12,8 @@ location="es/vit"
 setup_file() {
     uuid_v4_regex='^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
     ip_regex='^([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?$'
+
+    mkdir -p /tmp/bats_test
 }
 
 @test "Create K8s Nodepool" {
@@ -21,6 +23,8 @@ setup_file() {
     [ -n "$datacenter_id" ] || fail "$datacenter_id is empty"
     assert_regex "$datacenter_id" "$uuid_v4_regex"
 
+    echo $datacenter_id >> /tmp/bats_test/datacenter_id
+
     cluster_id=$(find_or_create_resource \
         "ionosctl k8s cluster list -F public=true,state=available -M 1 -o json 2> /dev/null | jq -r '.items[] | .id'" \
         "ionosctl k8s cluster create --name \"CLI-Test-$(randStr 8)\" -o json 2> /dev/null | jq -r '.id'")
@@ -29,12 +33,20 @@ setup_file() {
 
     sleep 120
 
+    # Use retry_until to check if the cluster is in "active" state
+    retry_until "ionosctl k8s cluster get --cluster-id $cluster_id -o json 2> /dev/null | jq -r '.metadata.state'" \
+        "[[ \$output == \"ACTIVE\" ]]" 10 60
+
+    echo $cluster_id >> /tmp/bats_test/cluster_id
+
     echo "Trying to create k8s nodepool in cluster $cluster_id and datacenter $datacenter_id"
     run ionosctl k8s nodepool create --name "CLI-Test-$(randStr 8)" --cluster-id "$cluster_id" --datacenter-id "$datacenter_id" -o json 2> /dev/null -W -t 600
     assert_success
     nodepool_id=$(echo "$output" | jq -r '.id')
     assert_regex "nodepool_id" "$uuid_v4_regex"
     echo "created k8s nodepool $nodepool_id"
+
+    echo $nodepool_id >> /tmp/bats_test/nodepool_id
 
     run ionosctl k8s node list --cluster-id "$cluster_id" --nodepool-id "$nodepool_id" --cols PublicIP --no-headers
     assert_success
@@ -47,10 +59,16 @@ setup_file() {
 }
 
 teardown_file() {
+    datacenter_id=$(cat /tmp/bats_test/datacenter_id)
+    cluster_id=$(cat /tmp/bats_test/cluster_id)
+    nodepool_id=$(cat /tmp/bats_test/nodepool_id)
+
     echo "cleaning up datacenter $datacenter_id and k8s resources $cluster_id ; $nodepool_id"
     retry_command run ionosctl k8s nodepool delete --cluster-id "$cluster_id" --nodepool-id "$nodepool_id" -f -w -t 1200
     sleep 30
     retry_command run ionosctl k8s cluster delete --cluster-id "$cluster_id" -f -w -t 1200
     sleep 30
     retry_command run ionosctl datacenter delete --datacenter_id "$datacenter_id" -f -w -t 1200
+
+    rm -rf /tmp/bats_test
 }


### PR DESCRIPTION
## What does this fix or implement?
`json-properties` flag not working on k8s nodepool as reported in https://github.com/ionos-cloud/ionosctl/issues/463. 
Fixed by removing Viper binding for it and `json-properties-example`.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
