### PR TITLE
feat: add funcs for easier regional API integration

### DIFF
--- a/commands/cdn/completer/completer.go
+++ b/commands/cdn/completer/completer.go
@@ -2,6 +2,7 @@ package completer
 
 import (
 	"context"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	cdn "github.com/ionos-cloud/sdk-go-cdn"

--- a/commands/cdn/distribution/create.go
+++ b/commands/cdn/distribution/create.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
@@ -11,7 +13,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/uuidgen"
 	cdn "github.com/ionos-cloud/sdk-go-cdn"
 	"github.com/spf13/viper"
-	"os"
 )
 
 func Create() *core.Command {

--- a/commands/cdn/distribution/delete.go
+++ b/commands/cdn/distribution/delete.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"

--- a/commands/cdn/distribution/get.go
+++ b/commands/cdn/distribution/get.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
 	cdn "github.com/ionos-cloud/sdk-go-cdn"
 	"github.com/spf13/cobra"

--- a/commands/cdn/distribution/list.go
+++ b/commands/cdn/distribution/list.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"

--- a/commands/cdn/distribution/routingrules/routing_rules.go
+++ b/commands/cdn/distribution/routingrules/routing_rules.go
@@ -3,6 +3,7 @@ package routingrules
 import (
 	"context"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"

--- a/commands/cdn/distribution/update.go
+++ b/commands/cdn/distribution/update.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 	"fmt"
+
 	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
 	"github.com/spf13/cobra"
 

--- a/commands/dns/completer/completer.go
+++ b/commands/dns/completer/completer.go
@@ -5,22 +5,14 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/completions"
-	"github.com/ionos-cloud/ionosctl/v6/internal/config"
-	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/json2table"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/json2table/jsonpaths"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 
-	"github.com/ionos-cloud/sdk-go-dns"
-	"github.com/spf13/viper"
+	ionoscloud "github.com/ionos-cloud/sdk-go-dns"
 )
 
 func SecondaryZonesIDs() []string {
-	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
-		viper.Set(constants.ArgServerUrl, "")
-	}
-
 	secondaryZones, _, err := client.Must().DnsClient.SecondaryZonesApi.SecondaryzonesGet(context.Background()).Execute()
 	if err != nil {
 		return nil
@@ -38,11 +30,6 @@ func SecondaryZonesIDs() []string {
 
 // Zones returns all zones matching the given filters
 func Zones(fs ...Filter) (ionoscloud.ZoneReadList, error) {
-	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
-		viper.Set(constants.ArgServerUrl, "")
-	}
-
 	req := client.Must().DnsClient.ZonesApi.ZonesGet(context.Background())
 
 	for _, f := range fs {

--- a/commands/dns/dns.go
+++ b/commands/dns/dns.go
@@ -7,6 +7,7 @@ import (
 	reverse_record "github.com/ionos-cloud/ionosctl/v6/commands/dns/reverse-record"
 	secondary_zones "github.com/ionos-cloud/ionosctl/v6/commands/dns/secondary-zones"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/zone"
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/spf13/cobra"
 )
@@ -26,5 +27,5 @@ func Root() *core.Command {
 	cmd.AddCommand(dnssec.Root())
 	cmd.AddCommand(secondary_zones.Root())
 
-	return core.WithRegionalFlags(cmd, "https://dns.%s.ionos.com", []string{"de/fra"})
+	return core.WithRegionalFlags(cmd, constants.DNSApiURL, []string{"de/fra"})
 }

--- a/commands/dns/dns.go
+++ b/commands/dns/dns.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func DNSCommand() *core.Command {
+func Root() *core.Command {
 	cmd := &core.Command{
 		Command: &cobra.Command{
 			Use:              "dns",
@@ -26,5 +26,5 @@ func DNSCommand() *core.Command {
 	cmd.AddCommand(dnssec.Root())
 	cmd.AddCommand(secondary_zones.Root())
 
-	return cmd
+	return core.WithRegionalFlags(cmd, "https://dns.%s.ionos.com", []string{"de/fra"})
 }

--- a/commands/dns/record/list.go
+++ b/commands/dns/record/list.go
@@ -72,12 +72,8 @@ ionosctl dns r list --zone ZONE_ID`,
 	cmd.AddInt32Flag(constants.FlagOffset, "", 0, "The first element (of the total list of elements) to include in the response. Use together with limit for pagination")
 	cmd.AddInt32Flag(constants.FlagMaxResults, "", 0, constants.DescMaxResults)
 
-	cmd.Command.Flags().String(constants.FlagSecondaryZone, "", "The name or ID of the secondary zone to fetch records from")
-	_ = cmd.Command.RegisterFlagCompletionFunc(
-		constants.FlagSecondaryZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completer.SecondaryZonesIDs(), cobra.ShellCompDirectiveNoFileComp
-		},
-	)
+	cmd.AddStringFlag(constants.FlagSecondaryZone, "", "", "The name or ID of the secondary zone to fetch records from",
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiURL, constants.DNSApiLocations))
 
 	cmd.Command.PersistentFlags().StringSlice(
 		constants.ArgCols, nil,

--- a/commands/dns/record/record.go
+++ b/commands/dns/record/record.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/utils"
-	"github.com/ionos-cloud/ionosctl/v6/internal/config"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/tabheaders"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
@@ -57,11 +56,6 @@ func RecordsProperty[V any](f func(dns.RecordRead) V, fs ...Filter) []V {
 
 // Records returns all records matching the given filters
 func Records(fs ...Filter) (dns.RecordReadList, error) {
-	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
-		viper.Set(constants.ArgServerUrl, "")
-	}
-
 	req := client.Must().DnsClient.RecordsApi.RecordsGet(context.Background())
 
 	for _, f := range fs {

--- a/commands/dns/reverse-record/reverse-record.go
+++ b/commands/dns/reverse-record/reverse-record.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/gofrs/uuid/v5"
-	"github.com/ionos-cloud/ionosctl/v6/internal/config"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/tabheaders"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
@@ -55,11 +54,6 @@ func RecordsProperty[V any](f func(dns.ReverseRecordRead) V, fs ...Filter) []V {
 
 // Records returns all records matching the given filters
 func Records(fs ...Filter) (dns.ReverseRecordsReadList, error) {
-	// Hack to enforce the dns-level flag default for API URL on the completions too
-	if url := config.GetServerUrl(); url == constants.DefaultApiURL {
-		viper.Set(constants.ArgServerUrl, "")
-	}
-
 	req := client.Must().DnsClient.ReverseRecordsApi.ReverserecordsGet(context.Background())
 
 	for _, f := range fs {

--- a/commands/root.go
+++ b/commands/root.go
@@ -224,7 +224,7 @@ func addCommands() {
 		return command
 	}
 
-	rootCmd.AddCommand(dns.DNSCommand())
+	rootCmd.AddCommand(dns.Root())
 	// Logging Service
 	rootCmd.AddCommand(
 		funcChangeDefaultApiUrl(

--- a/commands/root.go
+++ b/commands/root.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"fmt"
-	"github.com/ionos-cloud/ionosctl/v6/commands/cdn"
 	"os"
 	"strings"
+
+	"github.com/ionos-cloud/ionosctl/v6/commands/cdn"
 
 	certificates "github.com/ionos-cloud/ionosctl/v6/commands/certmanager"
 	"github.com/ionos-cloud/ionosctl/v6/commands/cfg"
@@ -220,30 +221,10 @@ func addCommands() {
 
 	// DNS ---
 	funcChangeDefaultApiUrl := func(command *core.Command, newDefault string) *core.Command {
-		// For some reason, this line only changes the help text
-		command.Command.PersistentFlags().StringP(
-			constants.ArgServerUrl, constants.ArgServerUrlShort, newDefault, "Override default host url",
-		)
-
-		// We should still run the original PersistentPreRun
-		originalPreRun := command.Command.PersistentPreRun
-
-		// If unset, manually set the flag to the new default. SIDE EFFECT: Now, this flag will always be considered "set", within DNS sub commands. Can't find a better alternative
-		command.Command.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-			if originalPreRun != nil {
-				originalPreRun(cmd, args)
-			}
-
-			setVal := newDefault
-			if val, _ := cmd.Flags().GetString(constants.ArgServerUrl); val != "" {
-				setVal = val
-			}
-			viper.Set(constants.ArgServerUrl, setVal)
-		}
 		return command
 	}
 
-	rootCmd.AddCommand(funcChangeDefaultApiUrl(dns.DNSCommand(), constants.DefaultDnsApiURL))
+	rootCmd.AddCommand(dns.DNSCommand())
 	// Logging Service
 	rootCmd.AddCommand(
 		funcChangeDefaultApiUrl(

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+
 	cdn "github.com/ionos-cloud/sdk-go-cdn"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/die"
@@ -23,22 +22,20 @@ var FieldsWithSensitiveDataInConfigFile = []string{
 // GetServerUrl returns the server URL the SDK should use, with support for layered fallbacks.
 func GetServerUrl() string {
 	viper.AutomaticEnv()
-	if flagVal := viper.GetString(constants.ArgServerUrl); viper.IsSet(constants.ArgServerUrl) {
-		// 1. Above all, use global flag val
-		if !strings.Contains(flagVal, constants.DefaultDnsApiURL) && !strings.Contains(
-			flagVal, constants.DefaultLoggingServiceApiURL,
-		) {
-			// Workaround for changing the default for dns namepsace and still allowing this to be customized via env var / cfg
-			return flagVal
-		}
+	if val := viper.GetString(constants.ArgServerUrl); viper.IsSet(constants.ArgServerUrl) {
+		// 1. Prefer flag values
+		fmt.Println("using flag val: ", val)
+		return val
 	}
-	if envVal := viper.GetString(constants.EnvServerUrl); viper.IsSet(constants.EnvServerUrl) {
+	if val := viper.GetString(constants.EnvServerUrl); viper.IsSet(constants.EnvServerUrl) {
+		fmt.Println("using env val: ", val)
 		// 2. Fallback to non-empty env vars
-		return envVal
+		return val
 	}
-	if cfgVal := viper.GetString(constants.CfgServerUrl); viper.IsSet(constants.CfgServerUrl) {
+	if val := viper.GetString(constants.CfgServerUrl); viper.IsSet(constants.CfgServerUrl) {
+		fmt.Println("using cfg val: ", val)
 		// 3. Fallback to non-empty cfg field
-		return cfgVal
+		return val
 	}
 	// 4. Return empty string. SDKs should handle it, per docs
 	return ""

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -139,12 +139,17 @@ const (
 // Defaults
 const (
 	DefaultApiURL               = "https://api.ionos.com"
+	DNSApiURL                   = "https://dns.%s.ionos.com"
 	DefaultLoggingServiceApiURL = "logging.de-txl.ionos.com"
 	DefaultConfigFileName       = "/config.json"
 	DefaultOutputFormat         = "text"
 	DefaultWait                 = false
 	DefaultTimeoutSeconds       = int(60)
 	DefaultParentIndex          = int(1)
+)
+
+var (
+	DNSApiLocations = []string{"de/fra"}
 )
 
 // enum values. TODO: ideally i'd like these handled by the SDK

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -139,7 +139,6 @@ const (
 // Defaults
 const (
 	DefaultApiURL               = "https://api.ionos.com"
-	DefaultDnsApiURL            = "dns.de-fra.ionos.com"
 	DefaultLoggingServiceApiURL = "logging.de-txl.ionos.com"
 	DefaultConfigFileName       = "/config.json"
 	DefaultOutputFormat         = "text"

--- a/internal/core/flag.go
+++ b/internal/core/flag.go
@@ -9,42 +9,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	RequiredFlagsAnnotation   = "RequiredFlags"
-	DeprecatedFlagsAnnotation = "DeprecatedFlags"
-)
-
 var (
 	flagNamePrintF     = "%s --%s %s"
 	flagNameBoolPrintF = "%s --%s"
 	requiredFlagErr    = errors.New("error checking required flags on command")
 )
-
-type FlagOptionFunc func(cmd *Command, flagName string)
-
-func DeprecatedFlagOption(help string) FlagOptionFunc {
-	return func(cmd *Command, flagName string) {
-		cmd.Command.Flag(flagName).Deprecated = help
-		// For documentation purposes, add flag to command Annotation
-		if len(cmd.Command.Annotations) > 0 {
-			cmd.Command.Annotations[DeprecatedFlagsAnnotation] = fmt.Sprintf(flagNamePrintF, cmd.Command.Annotations[DeprecatedFlagsAnnotation], flagName, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))
-		} else {
-			cmd.Command.Annotations = map[string]string{DeprecatedFlagsAnnotation: fmt.Sprintf(flagNamePrintF, cmd.Command.Annotations[DeprecatedFlagsAnnotation], flagName, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))}
-		}
-	}
-}
-
-func RequiredFlagOption() FlagOptionFunc {
-	return func(cmd *Command, flagName string) {
-		cmd.Command.Flag(flagName).Usage = fmt.Sprintf("%s (required)", cmd.Command.Flag(flagName).Usage)
-		// For documentation purposes, add flag to command Annotation
-		if len(cmd.Command.Annotations) > 0 {
-			cmd.Command.Annotations[RequiredFlagsAnnotation] = fmt.Sprintf(flagNamePrintF, cmd.Command.Annotations[RequiredFlagsAnnotation], flagName, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))
-		} else {
-			cmd.Command.Annotations = map[string]string{RequiredFlagsAnnotation: fmt.Sprintf(flagNamePrintF, cmd.Command.Annotations[RequiredFlagsAnnotation], flagName, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))}
-		}
-	}
-}
 
 // FlagAsVariable takes a flag name and returns it as a screaming camel case
 //


### PR DESCRIPTION
Make it easier to add support for APIs with different URLs for multiple locations.

Adds a decorator `WithRegionalURLs` which takes a command and adds `location` flag, and also modifies the behaviour of api-url flag

Adds a flag option `WithCompletion` which allows us to inject this location behaviour modifier before any completion logic 