### PR TITLE
test: fix intermittent UTC suffix failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,17 @@ utest:
 # `// +build integration` is still maintained for compatibility reasons
 # `go fmt` still maintains these lines, if one is removed. If it stops this behaviour, then we can remove them
 
+# run the go-based e2e tests
+.PHONY: itest
+itest:
+	@echo "--- Run unit tests and go-based integration tests ---"
+	@go test $(TEST_FLAGS) -tags=integration $(TEST_DIRS)
+
 .PHONY: test
 test:
-	@echo "--- Run bats-core, integration and unit tests ---"
+	@echo "--- Run bats-core tests ---"
 	@test/run.sh # bats-core tests and other
-	@go test $(TEST_FLAGS) -tags=integration $(TEST_DIRS)
+	@$(MAKE) itest # go-based tests (unit and integration)
 
 .PHONY: mocks
 mocks:
@@ -104,7 +110,8 @@ clean:
 help:
 	@echo "TARGETS: "
 	@echo " - utest:\tRun unit tests"
-	@echo " - test:\tRun integration and unit tests (CI Target)"
+	@echo " - itest:\tRun all go-based tests (unit, integration)"
+	@echo " - test:\tRuns bats-core tests, then runs all go-based tests (CI Target)"
 	@echo " - mocks:\tUpdate mocks. WARNING: Do not interrupt early!"
 	@echo " - gofmt:\tFormat code to adhere to gofmt [gofmt_check for checking only]"
 	@echo " - vendor:\tUpdate vendor dependencies. [vendor_check for checking only]"

--- a/commands/cfg/cfg_test.go
+++ b/commands/cfg/cfg_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/config"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	"github.com/ionos-cloud/ionosctl/v6/internal/utils"
 	"github.com/spf13/viper"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
@@ -296,11 +297,9 @@ func teardown() {
 
 	// Delete tokens generated since setup
 	for _, t := range *toks.Tokens {
-		strDate := *t.CreatedDate
-
-		date, err := time.Parse(time.RFC3339, strDate)
+		date, err := utils.ParseDate(*t.CreatedDate)
 		if err != nil {
-			panic(fmt.Errorf("they changed the date format: %w", err))
+			panic(fmt.Errorf("couldn't parse date %s: %w", *t.CreatedDate, err))
 		}
 
 		// Delete the token if it was created after setup

--- a/commands/cfg/cfg_test.go
+++ b/commands/cfg/cfg_test.go
@@ -296,10 +296,8 @@ func teardown() {
 
 	// Delete tokens generated since setup
 	for _, t := range *toks.Tokens {
-		strDate, ok := strings.CutSuffix(*t.CreatedDate, "[UTC]")
-		if !ok {
-			panic("they changed the date format: no more [UTC] suffix")
-		}
+		strDate := *t.CreatedDate
+
 		date, err := time.Parse(time.RFC3339, strDate)
 		if err != nil {
 			panic(fmt.Errorf("they changed the date format: %w", err))

--- a/commands/dns/dns_integration_test.go
+++ b/commands/dns/dns_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/record"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dns/utils"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	utils2 "github.com/ionos-cloud/ionosctl/v6/internal/utils"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	dns "github.com/ionos-cloud/sdk-go-dns"
 
@@ -226,11 +227,9 @@ func cleanupTokensCreatedAfterDate(taym time.Time) {
 
 	// Delete tokens generated since setup
 	for _, t := range *toks.Tokens {
-		strDate := *t.CreatedDate
-
-		date, err := time.Parse(time.RFC3339, strDate)
+		date, err := utils2.ParseDate(*t.CreatedDate)
 		if err != nil {
-			panic(fmt.Errorf("they changed the date format: %w", err))
+			panic(fmt.Errorf("couldn't parse date %s: %w", *t.CreatedDate, err))
 		}
 
 		// Delete the token if it was created after setup

--- a/commands/dns/dns_integration_test.go
+++ b/commands/dns/dns_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -227,10 +226,8 @@ func cleanupTokensCreatedAfterDate(taym time.Time) {
 
 	// Delete tokens generated since setup
 	for _, t := range *toks.Tokens {
-		strDate, ok := strings.CutSuffix(*t.CreatedDate, "[UTC]")
-		if !ok {
-			panic("they changed the date format: no more [UTC] suffix")
-		}
+		strDate := *t.CreatedDate
+
 		date, err := time.Parse(time.RFC3339, strDate)
 		if err != nil {
 			panic(fmt.Errorf("they changed the date format: %w", err))

--- a/commands/token/token_integration_test.go
+++ b/commands/token/token_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -82,10 +81,7 @@ func testCreateToken(t *testing.T) {
 	foundTokenViaSdk = nil
 
 	for _, tok := range *allTokens {
-		strDate, ok := strings.CutSuffix(*tok.CreatedDate, "[UTC]")
-		if !ok {
-			panic("they changed the time format: no more [UTC] suffix")
-		}
+		strDate := *tok.CreatedDate
 
 		date, err := time.Parse(time.RFC3339, strDate)
 		if err != nil {

--- a/commands/token/token_integration_test.go
+++ b/commands/token/token_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/commands/token"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/utils"
 	authservice "github.com/ionos-cloud/ionosctl/v6/services/auth-v1"
 	sdkgoauth "github.com/ionos-cloud/sdk-go-auth"
 	"github.com/spf13/viper"
@@ -81,11 +82,9 @@ func testCreateToken(t *testing.T) {
 	foundTokenViaSdk = nil
 
 	for _, tok := range *allTokens {
-		strDate := *tok.CreatedDate
-
-		date, err := time.Parse(time.RFC3339, strDate)
+		date, err := utils.ParseDate(*tok.CreatedDate)
 		if err != nil {
-			panic(fmt.Errorf("they changed the date format: %w", err))
+			panic(fmt.Errorf("couldn't parse date %s: %w", *tok.CreatedDate, err))
 		}
 
 		if date.After(tokFirstCreationTime) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -49,4 +51,16 @@ func ValidateIPv6CidrBlockAgainstParentCidrBlock(cidr string, expectedMask int, 
 	}
 
 	return nil
+}
+
+// ParseDate parses a date string in RFC3339 format
+// and returns a time.Time object
+// It also removes the [UTC] suffix if present
+func ParseDate(strDate string) (time.Time, error) {
+	strDate = strings.TrimSuffix(strDate, "[UTC]")
+	date, err := time.Parse(time.RFC3339, strDate)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("date is not a valid RFC3339: %w", err)
+	}
+	return date, nil
 }


### PR DESCRIPTION
Don't error out on [UTC] suffix removal in our tests, as now the API sometimes returns a valid RFC3339 string

It is possible that old objects retain [UTC] suffix while new ones don't have the suffix.

I've also modified the Makefile to make it easier to run tests locally while skipping the bats tests.