### PR TITLE
feat: regional APIs tab-complete default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [v6.8.0] (January 2025)
 
 ### Added
+- Added support for `vpn` commands
+- Added support for `kafka` commands
 - Added `--ttl` flag for creating tokens. You can specify the time-to-live for the token i.e. `--ttl 1h30m`
+- Added a default location for Regional APIs when tab-completing
 
 ## [v6.7.9] (December 2024)
 

--- a/commands/cdn/distribution/delete.go
+++ b/commands/cdn/distribution/delete.go
@@ -47,7 +47,7 @@ func Delete() *core.Command {
 			return completer.DistributionsProperty(func(r cdn.Distribution) string {
 				return *r.Id
 			})
-		}, constants.CDNApiRegionalURL),
+		}, constants.CDNApiRegionalURL, constants.CDNLocations),
 	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all records if set", core.RequiredFlagOption())
 

--- a/commands/cdn/distribution/get.go
+++ b/commands/cdn/distribution/get.go
@@ -59,7 +59,7 @@ func FindByID() *core.Command {
 			return completer.DistributionsProperty(func(r cdn.Distribution) string {
 				return *r.Id
 			})
-		}, constants.CDNApiRegionalURL),
+		}, constants.CDNApiRegionalURL, constants.CDNLocations),
 	)
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false

--- a/commands/cdn/distribution/routingrules/routing_rules.go
+++ b/commands/cdn/distribution/routingrules/routing_rules.go
@@ -85,7 +85,7 @@ func GetDistributionRoutingRules() *core.Command {
 			return completer.DistributionsProperty(func(r cdn.Distribution) string {
 				return *r.Id
 			})
-		}, constants.CDNApiRegionalURL),
+		}, constants.CDNApiRegionalURL, constants.CDNLocations),
 	)
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false

--- a/commands/cdn/distribution/update.go
+++ b/commands/cdn/distribution/update.go
@@ -54,7 +54,7 @@ func Update() *core.Command {
 			return completer.DistributionsProperty(func(r cdn.Distribution) string {
 				return *r.Id
 			})
-		}, constants.CDNApiRegionalURL),
+		}, constants.CDNApiRegionalURL, constants.CDNLocations),
 	)
 	cmd.Command.SilenceUsage = true
 	cmd.Command.Flags().SortFlags = false

--- a/commands/dbaas/mariadb/backup/get.go
+++ b/commands/dbaas/mariadb/backup/get.go
@@ -58,7 +58,7 @@ func Get() *core.Command {
 					}
 					return *c.Id + "\t" + fmt.Sprintf("(%d MiB)", *c.Properties.Size)
 				})
-			}, constants.MariaDBApiRegionalURL),
+			}, constants.MariaDBApiRegionalURL, constants.MariaDBLocations),
 	)
 	return cmd
 }

--- a/commands/dbaas/mariadb/backup/list.go
+++ b/commands/dbaas/mariadb/backup/list.go
@@ -67,7 +67,7 @@ func List() *core.Command {
 					}
 					return *c.Id
 				})
-			}, constants.MariaDBApiRegionalURL),
+			}, constants.MariaDBApiRegionalURL, constants.MariaDBLocations),
 	)
 	cmd.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, 0, constants.DescMaxResults)
 	cmd.AddInt32Flag(constants.FlagOffset, "", 0, "Skip a certain number of results")

--- a/commands/dbaas/mariadb/cluster/delete.go
+++ b/commands/dbaas/mariadb/cluster/delete.go
@@ -82,7 +82,7 @@ ionosctl db mar c d --all --name <name>`,
 					}
 					return *c.Id
 				})
-			}, constants.MariaDBApiRegionalURL),
+			}, constants.MariaDBApiRegionalURL, constants.MariaDBLocations),
 	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all mariadb clusters")
 	cmd.AddBoolFlag(constants.FlagName, "", false, "When deleting all clusters, filter the clusters by a name")

--- a/commands/dbaas/mariadb/cluster/get.go
+++ b/commands/dbaas/mariadb/cluster/get.go
@@ -59,7 +59,7 @@ func Get() *core.Command {
 					}
 					return *c.Id
 				})
-			}, constants.MariaDBApiRegionalURL),
+			}, constants.MariaDBApiRegionalURL, constants.MariaDBLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/dns/dnssec/create.go
+++ b/commands/dns/dnssec/create.go
@@ -94,14 +94,14 @@ func Create() *core.Command {
 		core.WithCompletion(
 			func() []string {
 				return []string{"1024", "2048", "4096"}
-			}, constants.DNSApiRegionalURL,
+			}, constants.DNSApiRegionalURL, constants.DNSLocations,
 		),
 	)
 	cmd.AddIntFlag(FlagZskBits, "", 1024, "Zone signing key length in bits. zskBits <= kskBits: [1024/2048/4096]",
 		core.WithCompletion(
 			func() []string {
 				return []string{"1024", "2048", "4096"}
-			}, constants.DNSApiRegionalURL,
+			}, constants.DNSApiRegionalURL, constants.DNSLocations,
 		),
 	)
 	cmd.AddSetFlag(FlagNsecMode, "", "NSEC", []string{"NSEC", "NSEC3"}, "NSEC mode.")
@@ -110,7 +110,7 @@ func Create() *core.Command {
 		core.WithCompletion(
 			func() []string {
 				return []string{"64", "72", "80", "88", "96", "104", "112", "120", "128"}
-			}, constants.DNSApiRegionalURL,
+			}, constants.DNSApiRegionalURL, constants.DNSLocations,
 		),
 	)
 	cmd.AddIntFlag(FlagValidity, "", 90, "Signature validity in days [90..365]")

--- a/commands/dns/dnssec/create.go
+++ b/commands/dns/dnssec/create.go
@@ -87,7 +87,7 @@ func Create() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 	cmd.AddStringFlag(FlagAlgorithm, "", "RSASHA256", "Algorithm used to generate signing keys (both Key Signing Keys and Zone Signing Keys)")
 	cmd.AddIntFlag(FlagKskBits, "", 1024, "Key signing key length in bits. kskBits >= zskBits: [1024/2048/4096]",

--- a/commands/dns/dnssec/delete.go
+++ b/commands/dns/dnssec/delete.go
@@ -51,7 +51,7 @@ func Delete() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/dns/dnssec/get.go
+++ b/commands/dns/dnssec/get.go
@@ -66,7 +66,7 @@ ionosctl dns keys list --zone ZONE --cols PubKey --no-headers`,
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/dns/reverse-record/delete.go
+++ b/commands/dns/reverse-record/delete.go
@@ -47,7 +47,7 @@ func Delete() *core.Command {
 			return RecordsProperty(func(read ionoscloud.ReverseRecordRead) string {
 				return *read.Properties.Ip
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all records if set", core.RequiredFlagOption())

--- a/commands/dns/reverse-record/get.go
+++ b/commands/dns/reverse-record/get.go
@@ -61,7 +61,7 @@ func Get() *core.Command {
 			return RecordsProperty(func(read ionoscloud.ReverseRecordRead) string {
 				return *read.Properties.Ip
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/dns/reverse-record/list.go
+++ b/commands/dns/reverse-record/list.go
@@ -49,7 +49,7 @@ func List() *core.Command {
 			return RecordsProperty(func(t dns.ReverseRecordRead) string {
 				return *t.Properties.Ip
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 	cmd.AddInt32Flag(constants.FlagOffset, "", 0, "The first element (of the total list of elements) to include in the response. Use together with limit for pagination")
 	cmd.AddInt32Flag(constants.FlagMaxResults, "", 0, constants.DescMaxResults)

--- a/commands/dns/reverse-record/update.go
+++ b/commands/dns/reverse-record/update.go
@@ -74,7 +74,7 @@ func Update() *core.Command {
 			return RecordsProperty(func(read ionoscloud.ReverseRecordRead) string {
 				return *read.Properties.Ip
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagIp, "", "", "The new IP", core.WithCompletionE(
@@ -90,7 +90,7 @@ func Update() *core.Command {
 				}
 			}
 			return ips, nil
-		}, ""),
+		}, "", nil),
 	)
 	cmd.AddStringFlag(constants.FlagName, "", "", "The new record name")
 	cmd.AddStringFlag(constants.FlagDescription, "", "", "The new description of the record")

--- a/commands/dns/secondary-zones/delete.go
+++ b/commands/dns/secondary-zones/delete.go
@@ -51,7 +51,7 @@ func deleteCmd() *core.Command {
 	c.Command.Flags().BoolP(constants.ArgAll, constants.ArgAllShort, false, "Delete all secondary zones")
 
 	c.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", constants.DescZone,
-		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL),
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/secondary-zones/get.go
+++ b/commands/dns/secondary-zones/get.go
@@ -51,7 +51,7 @@ func getCmd() *core.Command {
 	)
 
 	c.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", constants.DescZone,
-		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL),
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/secondary-zones/transfer/get.go
+++ b/commands/dns/secondary-zones/transfer/get.go
@@ -51,7 +51,7 @@ func getCmd() *core.Command {
 	)
 
 	c.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", constants.DescZone,
-		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL),
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/secondary-zones/transfer/start.go
+++ b/commands/dns/secondary-zones/transfer/start.go
@@ -41,7 +41,7 @@ func startCmd() *core.Command {
 	)
 
 	c.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", constants.DescZone,
-		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL),
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/secondary-zones/update.go
+++ b/commands/dns/secondary-zones/update.go
@@ -83,7 +83,7 @@ func updateCmd() *core.Command {
 	c.Command.Flags().StringSlice(constants.FlagPrimaryIPs, []string{}, "Primary DNS server IP addresses")
 
 	c.AddStringFlag(constants.FlagZone, constants.FlagZoneShort, "", constants.DescZone,
-		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL),
+		core.WithCompletion(completer.SecondaryZonesIDs, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/zone/delete.go
+++ b/commands/dns/zone/delete.go
@@ -61,7 +61,7 @@ func ZonesDeleteCmd() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all zones. Required or -%s", constants.FlagZoneShort))

--- a/commands/dns/zone/file/get.go
+++ b/commands/dns/zone/file/get.go
@@ -41,7 +41,7 @@ func getCmd() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	c.Command.SilenceUsage = true

--- a/commands/dns/zone/file/update.go
+++ b/commands/dns/zone/file/update.go
@@ -53,7 +53,7 @@ func updateCmd() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 	c.Command.Flags().String(constants.FlagZoneFile, "", "Path to the zone file")
 

--- a/commands/dns/zone/get.go
+++ b/commands/dns/zone/get.go
@@ -62,7 +62,7 @@ func ZonesFindByIdCmd() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/dns/zone/update.go
+++ b/commands/dns/zone/update.go
@@ -78,7 +78,7 @@ func ZonesPutCmd() *core.Command {
 			return completer.ZonesProperty(func(t dns.ZoneRead) string {
 				return *t.Properties.ZoneName
 			})
-		}, constants.DNSApiRegionalURL),
+		}, constants.DNSApiRegionalURL, constants.DNSLocations),
 	)
 	cmd.AddStringFlag(constants.FlagName, constants.FlagNameShort, "", "The new name of the DNS zone, e.g. foo.com")
 	cmd.AddStringFlag(constants.FlagDescription, "", "", "The new description of the DNS zone")

--- a/commands/kafka/cluster/delete.go
+++ b/commands/kafka/cluster/delete.go
@@ -56,7 +56,7 @@ func Delete() *core.Command {
 						return *k.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 

--- a/commands/kafka/cluster/get.go
+++ b/commands/kafka/cluster/get.go
@@ -67,7 +67,7 @@ func FindByID() *core.Command {
 						return *k.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 

--- a/commands/kafka/topic/create.go
+++ b/commands/kafka/topic/create.go
@@ -79,7 +79,7 @@ func createCmd() *core.Command {
 						return *read.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 

--- a/commands/kafka/topic/delete.go
+++ b/commands/kafka/topic/delete.go
@@ -74,7 +74,7 @@ func deleteCmd() *core.Command {
 						return *read.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 	cmd.AddStringFlag(
@@ -82,7 +82,7 @@ func deleteCmd() *core.Command {
 		core.WithCompletion(
 			func() []string {
 				return completer.Topics(cmd.Command.Flag(constants.FlagClusterId).Value.String())
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Delete all topics")

--- a/commands/kafka/topic/get.go
+++ b/commands/kafka/topic/get.go
@@ -63,7 +63,7 @@ func getCmd() *core.Command {
 						return *read.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 	cmd.AddStringFlag(
@@ -71,7 +71,7 @@ func getCmd() *core.Command {
 		core.WithCompletion(
 			func() []string {
 				return completer.Topics(cmd.Command.Flag(constants.FlagClusterId).Value.String())
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 

--- a/commands/kafka/topic/list.go
+++ b/commands/kafka/topic/list.go
@@ -66,7 +66,7 @@ ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID`,
 						return *read.Id
 					},
 				)
-			}, constants.KafkaApiRegionalURL,
+			}, constants.KafkaApiRegionalURL, constants.KafkaLocations,
 		),
 	)
 

--- a/commands/logging-service/logging-service.go
+++ b/commands/logging-service/logging-service.go
@@ -22,5 +22,5 @@ func Root() *core.Command {
 	cmd.AddCommand(pipeline.PipelineCmd())
 	cmd.AddCommand(logs.LogsCmd())
 
-	return core.WithRegionalFlags(cmd, constants.LoggingApiRegionalURL, constants.LoggingAPILocations)
+	return core.WithRegionalFlags(cmd, constants.LoggingApiRegionalURL, constants.LoggingLocations)
 }

--- a/commands/logging-service/logs/add.go
+++ b/commands/logging-service/logs/add.go
@@ -31,7 +31,7 @@ func LogsAddCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	cmd.AddStringFlag(

--- a/commands/logging-service/logs/get.go
+++ b/commands/logging-service/logs/get.go
@@ -31,7 +31,7 @@ func LogsGetCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	cmd.AddStringFlag(

--- a/commands/logging-service/logs/get.go
+++ b/commands/logging-service/logs/get.go
@@ -41,7 +41,7 @@ func LogsGetCmd() *core.Command {
 			return completer.LoggingServiceLogTags(
 				viper.GetString(core.GetFlagName(cmd.NS, constants.FlagLoggingPipelineId)),
 			)
-		}, constants.LoggingApiRegionalURL),
+		}, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/logs/list.go
+++ b/commands/logging-service/logs/list.go
@@ -29,7 +29,7 @@ func LogsListCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/logs/remove.go
+++ b/commands/logging-service/logs/remove.go
@@ -32,7 +32,7 @@ func LogsRemoveCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineLogTag, "", "", "The tag of the pipeline log that you want to delete",

--- a/commands/logging-service/logs/remove.go
+++ b/commands/logging-service/logs/remove.go
@@ -41,7 +41,7 @@ func LogsRemoveCmd() *core.Command {
 			return completer.LoggingServiceLogTags(
 				viper.GetString(core.GetFlagName(cmd.NS, constants.FlagLoggingPipelineId)),
 			)
-		}, constants.LoggingApiRegionalURL),
+		}, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/logs/update.go
+++ b/commands/logging-service/logs/update.go
@@ -29,7 +29,7 @@ func LogsUpdateCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineLogTag, "", "", "The tag of the pipeline log that you want to update",

--- a/commands/logging-service/logs/update.go
+++ b/commands/logging-service/logs/update.go
@@ -38,7 +38,7 @@ func LogsUpdateCmd() *core.Command {
 			return completer.LoggingServiceLogTags(
 				viper.GetString(core.GetFlagName(cmd.NS, constants.FlagLoggingPipelineId)),
 			)
-		}, constants.LoggingApiRegionalURL),
+		}, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	cmd.AddStringFlag(

--- a/commands/logging-service/pipeline/delete.go
+++ b/commands/logging-service/pipeline/delete.go
@@ -37,7 +37,7 @@ func PipelineDeleteCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline you want to delete", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/pipeline/get.go
+++ b/commands/logging-service/pipeline/get.go
@@ -27,7 +27,7 @@ func PipelineGetCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline you want to retrieve", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/pipeline/key.go
+++ b/commands/logging-service/pipeline/key.go
@@ -29,7 +29,7 @@ func PipelineKeyCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline you want to generate a key for", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/logging-service/pipeline/update.go
+++ b/commands/logging-service/pipeline/update.go
@@ -34,7 +34,7 @@ func PipelineUpdateCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline you want to delete", core.RequiredFlagOption(),
-		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL),
+		core.WithCompletion(completer.LoggingServicePipelineIds, constants.LoggingApiRegionalURL, constants.LoggingLocations),
 	)
 
 	return cmd

--- a/commands/vpn/ipsec/gateway/delete.go
+++ b/commands/vpn/ipsec/gateway/delete.go
@@ -53,7 +53,7 @@ func Delete() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all gateways. Required or --%s", constants.FlagGatewayID))

--- a/commands/vpn/ipsec/gateway/get.go
+++ b/commands/vpn/ipsec/gateway/get.go
@@ -54,7 +54,7 @@ func Get() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/vpn/ipsec/gateway/update.go
+++ b/commands/vpn/ipsec/gateway/update.go
@@ -117,7 +117,7 @@ func Update() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, constants.FlagNameShort, "", "Name of the IPSec Gateway", core.RequiredFlagOption())

--- a/commands/vpn/ipsec/tunnel/create.go
+++ b/commands/vpn/ipsec/tunnel/create.go
@@ -65,7 +65,7 @@ func Create() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, "", "", "Name of the IPSec Tunnel", core.RequiredFlagOption())

--- a/commands/vpn/ipsec/tunnel/delete.go
+++ b/commands/vpn/ipsec/tunnel/delete.go
@@ -56,14 +56,14 @@ func Delete() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagTunnelID, constants.FlagIdShort, "", "The ID of the IPSec Tunnel you want to delete",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			gatewayID := viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID))
 			return completer.TunnelIDs(gatewayID)
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all tunnels. Required or --%s", constants.FlagTunnelID))

--- a/commands/vpn/ipsec/tunnel/get.go
+++ b/commands/vpn/ipsec/tunnel/get.go
@@ -51,14 +51,14 @@ func Get() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagTunnelID, constants.FlagIdShort, "", "The ID of the IPSec Tunnel",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			gatewayID := viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID))
 			return completer.TunnelIDs(gatewayID)
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/vpn/ipsec/tunnel/list.go
+++ b/commands/vpn/ipsec/tunnel/list.go
@@ -57,7 +57,7 @@ func List() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, 0, constants.DescMaxResults)

--- a/commands/vpn/ipsec/tunnel/update.go
+++ b/commands/vpn/ipsec/tunnel/update.go
@@ -41,14 +41,14 @@ func Update() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the IPSec Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagTunnelID, constants.FlagIdShort, "", "The ID of the IPSec Tunnel",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			gatewayID := viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID))
 			return completer.TunnelIDs(gatewayID)
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, "", "", "Name of the IPSec Tunnel", core.RequiredFlagOption())

--- a/commands/vpn/wireguard/gateway/delete.go
+++ b/commands/vpn/wireguard/gateway/delete.go
@@ -53,7 +53,7 @@ func Delete() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all gateways. Required or --%s", constants.FlagGatewayID))

--- a/commands/vpn/wireguard/gateway/get.go
+++ b/commands/vpn/wireguard/gateway/get.go
@@ -54,7 +54,7 @@ func Get() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/vpn/wireguard/gateway/update.go
+++ b/commands/vpn/wireguard/gateway/update.go
@@ -149,7 +149,7 @@ func Update() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, constants.FlagNameShort, "", "Name of the WireGuard Gateway", core.RequiredFlagOption())

--- a/commands/vpn/wireguard/peer/create.go
+++ b/commands/vpn/wireguard/peer/create.go
@@ -82,7 +82,7 @@ func Create() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, "", "", "Name of the WireGuard Peer", core.RequiredFlagOption())

--- a/commands/vpn/wireguard/peer/delete.go
+++ b/commands/vpn/wireguard/peer/delete.go
@@ -56,13 +56,13 @@ func Delete() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagPeerID, constants.FlagIdShort, "", "The ID of the WireGuard Peer you want to delete",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			return completer.PeerIDs(viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID)))
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, fmt.Sprintf("Delete all peers. Required or --%s", constants.FlagPeerID))

--- a/commands/vpn/wireguard/peer/get.go
+++ b/commands/vpn/wireguard/peer/get.go
@@ -51,13 +51,13 @@ func Get() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagPeerID, constants.FlagIdShort, "", "The ID of the WireGuard Peer",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			return completer.PeerIDs(viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID)))
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.Command.SilenceUsage = true

--- a/commands/vpn/wireguard/peer/list.go
+++ b/commands/vpn/wireguard/peer/list.go
@@ -57,7 +57,7 @@ func List() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, constants.FlagIdShort, "", "The ID of the Wireguard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, 0, constants.DescMaxResults)
 	cmd.AddInt32Flag(constants.FlagOffset, "", 0, "Skip a certain number of results")

--- a/commands/vpn/wireguard/peer/update.go
+++ b/commands/vpn/wireguard/peer/update.go
@@ -86,13 +86,13 @@ func Update() *core.Command {
 
 	cmd.AddStringFlag(constants.FlagGatewayID, "", "", "The ID of the WireGuard Gateway",
 		core.RequiredFlagOption(),
-		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL),
+		core.WithCompletion(completer.GatewayIDs, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 	cmd.AddStringFlag(constants.FlagPeerID, constants.FlagIdShort, "", "The ID of the WireGuard Peer",
 		core.RequiredFlagOption(),
 		core.WithCompletion(func() []string {
 			return completer.PeerIDs(viper.GetString(core.GetFlagName(cmd.NS, constants.FlagGatewayID)))
-		}, constants.VPNApiRegionalURL),
+		}, constants.VPNApiRegionalURL, constants.VPNLocations),
 	)
 
 	cmd.AddStringFlag(constants.FlagName, "", "", "Name of the WireGuard Peer", core.RequiredFlagOption())

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
@@ -31,7 +31,7 @@ Create a IPSec Gateway
 ## Options
 
 ```text
-  -u, --api-url string         Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string         Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ID Name Description GatewayIP DatacenterId LanId ConnectionIPv4 ConnectionIPv6 Version Status]
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -42,7 +42,7 @@ Create a IPSec Gateway
       --gateway-ip string      The IP of an IPBlock in the same location as the provided datacenter (required)
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string        Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
@@ -32,14 +32,14 @@ Delete a gateway
 
 ```text
   -a, --all                 Delete all gateways. Required or --gateway-id
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description GatewayIP DatacenterId LanId ConnectionIPv4 ConnectionIPv6 Version Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
@@ -31,14 +31,14 @@ Find a gateway by ID
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description GatewayIP DatacenterId LanId ConnectionIPv4 ConnectionIPv6 Version Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
@@ -31,13 +31,13 @@ List IPSec Gateways
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description GatewayIP DatacenterId LanId ConnectionIPv4 ConnectionIPv6 Version Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -M, --max-results int32   The maximum number of elements to return
       --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
@@ -31,7 +31,7 @@ Update a IPSec Gateway
 ## Options
 
 ```text
-  -u, --api-url string         Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string         Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ID Name Description GatewayIP DatacenterId LanId ConnectionIPv4 ConnectionIPv6 Version Status]
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -43,7 +43,7 @@ Update a IPSec Gateway
       --gateway-ip string      The IP of an IPBlock in the same location as the provided datacenter (required)
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string        Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
   -o, --output string          Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
@@ -31,7 +31,7 @@ Create IPSec tunnels
 ## Options
 
 ```text
-  -u, --api-url string                    Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string                    Override default host URL (default "https://vpn.de-fra.ionos.com")
       --auth-method string                The authentication method for the IPSec tunnel. Valid values are PSK or RSA (required)
       --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
       --cols strings                      Set of columns to be printed on output 
@@ -52,7 +52,7 @@ Create IPSec tunnels
       --ike-lifetime int32                The phase lifetime in seconds
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
-  -l, --location string                   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string                   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
   -o, --output string                     Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
@@ -32,14 +32,14 @@ Remove a IPSec Tunnel
 
 ```text
   -a, --all                 Delete all tunnels. Required or --tunnel-id
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description RemoteHost AuthMethod PSKKey IKEDiffieHellmanGroup IKEEncryptionAlgorithm IKEIntegrityAlgorithm IKELifetime ESPDiffieHellmanGroup ESPEncryptionAlgorithm ESPIntegrityAlgorithm ESPLifetime CloudNetworkCIDRs PeerNetworkCIDRs Status StatusMessage]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
@@ -31,14 +31,14 @@ Find a tunnel by ID
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description RemoteHost AuthMethod PSKKey IKEDiffieHellmanGroup IKEEncryptionAlgorithm IKEIntegrityAlgorithm IKELifetime ESPDiffieHellmanGroup ESPEncryptionAlgorithm ESPIntegrityAlgorithm ESPLifetime CloudNetworkCIDRs PeerNetworkCIDRs Status StatusMessage]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
@@ -31,14 +31,14 @@ List IPSec Tunnels
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description RemoteHost AuthMethod PSKKey IKEDiffieHellmanGroup IKEEncryptionAlgorithm IKEIntegrityAlgorithm IKELifetime ESPDiffieHellmanGroup ESPEncryptionAlgorithm ESPIntegrityAlgorithm ESPLifetime CloudNetworkCIDRs PeerNetworkCIDRs Status StatusMessage]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -M, --max-results int32   The maximum number of elements to return
       --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
@@ -31,7 +31,7 @@ Update a IPSec Tunnel
 ## Options
 
 ```text
-  -u, --api-url string                    Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string                    Override default host URL (default "https://vpn.de-fra.ionos.com")
       --auth-method string                The authentication method for the IPSec tunnel. Valid values are PSK or RSA (required)
       --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
       --cols strings                      Set of columns to be printed on output 
@@ -52,7 +52,7 @@ Update a IPSec Tunnel
       --ike-lifetime int32                The phase lifetime in seconds
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
-  -l, --location string                   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string                   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
   -o, --output string                     Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
@@ -37,7 +37,7 @@ Create a WireGuard Gateway
 ## Options
 
 ```text
-  -u, --api-url string            Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string            Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings              Set of columns to be printed on output 
                                   Available columns: [ID Name PublicKey Description GatewayIP InterfaceIPv4 InterfaceIPv6 DatacenterId LanId ConnectionIPv4 ConnectionIPv6 InterfaceIP ListenPort Status]
   -c, --config string             Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -49,7 +49,7 @@ Create a WireGuard Gateway
   -h, --help                      Print usage
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string           Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
@@ -38,14 +38,14 @@ Delete a gateway
 
 ```text
   -a, --all                 Delete all gateways. Required or --gateway-id
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name PublicKey Description GatewayIP InterfaceIPv4 InterfaceIPv6 DatacenterId LanId ConnectionIPv4 ConnectionIPv6 InterfaceIP ListenPort Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
@@ -37,14 +37,14 @@ Find a gateway by ID
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name PublicKey Description GatewayIP InterfaceIPv4 InterfaceIPv6 DatacenterId LanId ConnectionIPv4 ConnectionIPv6 InterfaceIP ListenPort Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -q, --quiet               Quiet output

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
@@ -37,13 +37,13 @@ List WireGuard Gateways
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name PublicKey Description GatewayIP InterfaceIPv4 InterfaceIPv6 DatacenterId LanId ConnectionIPv4 ConnectionIPv6 InterfaceIP ListenPort Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -M, --max-results int32   The maximum number of elements to return
       --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
@@ -37,7 +37,7 @@ Update a WireGuard Gateway. Note: The private key MUST be provided again (or cha
 ## Options
 
 ```text
-  -u, --api-url string            Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string            Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings              Set of columns to be printed on output 
                                   Available columns: [ID Name PublicKey Description GatewayIP InterfaceIPv4 InterfaceIPv6 DatacenterId LanId ConnectionIPv4 ConnectionIPv6 InterfaceIP ListenPort Status]
   -c, --config string             Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -50,7 +50,7 @@ Update a WireGuard Gateway. Note: The private key MUST be provided again (or cha
   -h, --help                      Print usage
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string           Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
   -o, --output string             Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/wireguard/peer/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/create.md
@@ -37,7 +37,7 @@ Create WireGuard Peers. There is a limit to the total number of peers. Please re
 ## Options
 
 ```text
-  -u, --api-url string       Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string       Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings         Set of columns to be printed on output 
                              Available columns: [ID Name Description Host Port WhitelistIPs PublicKey Status]
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -47,7 +47,7 @@ Create WireGuard Peers. There is a limit to the total number of peers. Please re
   -h, --help                 Print usage
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
@@ -38,14 +38,14 @@ Remove a WireGuard Peer
 
 ```text
   -a, --all                 Delete all peers. Required or --peer-id
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description Host Port WhitelistIPs PublicKey Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -i, --peer-id string      The ID of the WireGuard Peer you want to delete (required)

--- a/docs/subcommands/VPN Gateway/wireguard/peer/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/get.md
@@ -37,14 +37,14 @@ Find a peer by ID
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description Host Port WhitelistIPs PublicKey Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
   -o, --output string       Desired output format [text|json|api-json] (default "text")
   -i, --peer-id string      The ID of the WireGuard Peer (required)

--- a/docs/subcommands/VPN Gateway/wireguard/peer/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/list.md
@@ -37,14 +37,14 @@ List WireGuard Peers
 ## Options
 
 ```text
-  -u, --api-url string      Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string      Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ID Name Description Host Port WhitelistIPs PublicKey Status]
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
   -f, --force               Force command to execute without user input
   -i, --gateway-id string   The ID of the Wireguard Gateway (required)
   -h, --help                Print usage
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -M, --max-results int32   The maximum number of elements to return
       --no-headers          Don't print table headers when table output is used
       --offset int32        Skip a certain number of results

--- a/docs/subcommands/VPN Gateway/wireguard/peer/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/update.md
@@ -37,7 +37,7 @@ Update a WireGuard Peer
 ## Options
 
 ```text
-  -u, --api-url string       Override default host URL (default "https://vpn.de-txl.ionos.com")
+  -u, --api-url string       Override default host URL (default "https://vpn.de-fra.ionos.com")
       --cols strings         Set of columns to be printed on output 
                              Available columns: [ID Name Description Host Port WhitelistIPs PublicKey Status]
   -c, --config string        Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
@@ -47,7 +47,7 @@ Update a WireGuard Peer
   -h, --help                 Print usage
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
+  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
   -o, --output string        Desired output format [text|json|api-json] (default "text")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -195,6 +195,7 @@ const (
 
 var (
 	DNSLocations     = []string{"de/fra"}
+	LoggingLocations = []string{"de/txl", "de/fra", "gb/lhr", "fr/par", "es/vit"}
 	CDNLocations     = []string{"de/fra"}
 	MariaDBLocations = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
 	VPNLocations     = []string{"de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci"}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -197,7 +197,7 @@ var (
 	DNSLocations     = []string{"de/fra"}
 	CDNLocations     = []string{"de/fra"}
 	MariaDBLocations = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
-	VPNLocations     = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci"}
+	VPNLocations     = []string{"de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci"}
 	KafkaLocations   = []string{
 		"de/fra", "de/txl",
 		// other locations not yet available. will be added in the future.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -194,12 +194,11 @@ const (
 )
 
 var (
-	DNSLocations        = []string{"de/fra"}
-	LoggingAPILocations = []string{"de/txl", "de/fra", "gb/lhr", "fr/par", "es/vit"}
-	CDNLocations        = []string{"de/fra"}
-	MariaDBLocations    = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
-	VPNLocations        = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci"}
-	KafkaLocations      = []string{
+	DNSLocations     = []string{"de/fra"}
+	CDNLocations     = []string{"de/fra"}
+	MariaDBLocations = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci"}
+	VPNLocations     = []string{"de/txl", "de/fra", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci"}
+	KafkaLocations   = []string{
 		"de/fra", "de/txl",
 		// other locations not yet available. will be added in the future.
 		// "es/vit", "gb/lhr", "us/ewr", "us/las", "us/mci", "fr/par",

--- a/internal/core/flag-option.go
+++ b/internal/core/flag-option.go
@@ -48,7 +48,7 @@ func RequiredFlagOption() FlagOptionFunc {
 // If the baseURL contains a placeholder and a location is provided, the location will be used to construct the URL
 func WithCompletionComplex(
 	completionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective),
-	baseURL string,
+	baseURL string, locations []string,
 ) FlagOptionFunc {
 	return func(cmdToRegister *Command, flagName string) {
 		cmdToRegister.Command.RegisterFlagCompletionFunc(flagName,
@@ -93,14 +93,14 @@ func WithCompletionComplex(
 // - WithCompletionE(completionFuncE, "api.ionos.com") for an API with a single endpoint
 //
 // - WithCompletionE(completionFuncE, "") to let the SDK choose the API endpoint
-func WithCompletionE(completionFunc func() ([]string, error), baseURL string) FlagOptionFunc {
+func WithCompletionE(completionFunc func() ([]string, error), baseURL string, locations []string) FlagOptionFunc {
 	return WithCompletionComplex(func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		results, err := completionFunc()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
 		return results, cobra.ShellCompDirectiveNoFileComp
-	}, baseURL)
+	}, baseURL, locations)
 }
 
 // WithCompletion is a FlagOptionFunc that allows for a completion function that returns a list of strings.
@@ -112,8 +112,8 @@ func WithCompletionE(completionFunc func() ([]string, error), baseURL string) Fl
 // - WithCompletion(completionFunc, "api.ionos.com") for an API with a single endpoint
 //
 // - WithCompletion(completionFunc, "") to let the SDKs choose the API endpoint
-func WithCompletion(completionFunc func() []string, baseURL string) FlagOptionFunc {
+func WithCompletion(completionFunc func() []string, baseURL string, locations []string) FlagOptionFunc {
 	return WithCompletionComplex(func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completionFunc(), cobra.ShellCompDirectiveNoFileComp
-	}, baseURL)
+	}, baseURL, locations)
 }


### PR DESCRIPTION
When tab-completing on regional APIs, use the first supported location on that API as the default (as is the case for creating resources on regional APIs) if no location is provided on the `--location` flag