### PR TITLE
Fix: allow usage of snapshots for volumes as --image-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v6.8.1] (???)
+
+### Fixed
+
+- Fixed not being able to use snapshot IDs for --image-id
+
 ## [v6.8.0] (January 2025)
 
 ### Added

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -216,7 +216,7 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "[CUBE Server] The Image Alias to use instead of Image Id for the Direct Attached Storage")
 	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "[CUBE Server] The Image Id or snapshot Id to be used as for the Direct Attached Storage")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+		imageIds := completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
 			// Completer for HDD images that are in the same location as the datacenter
 			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
 				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
@@ -225,7 +225,11 @@ You can wait for the Request to be executed using ` + "`" + `--wait-for-request`
 			}
 
 			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
-		}), cobra.ShellCompDirectiveNoFileComp
+		})
+
+		snapshotIds := completer.SnapshotIds()
+
+		return append(imageIds, snapshotIds...), cobra.ShellCompDirectiveNoFileComp
 	})
 	create.AddStringFlag(constants.ArgPassword, constants.ArgPasswordShort, "", "[CUBE Server] Initial image password to be set for installed OS. Works with public Images only. Not modifiable. Password rules allows all characters from a-z, A-Z, 0-9")
 	create.AddStringSliceFlag(cloudapiv6.ArgSshKeyPaths, cloudapiv6.ArgSshKeyPathsShort, []string{""}, "[CUBE Server] Absolute paths for the SSH Keys of the Direct Attached Storage")
@@ -559,36 +563,47 @@ func PreRunServerCreate(c *core.PreCommandConfig) error {
 		return err
 	}
 
-	// If either image ID or alias is set, we'll need to modify the required flags.
-	if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) || viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)) {
+	imageIdFlag := core.GetFlagName(c.NS, cloudapiv6.ArgImageId)
+	imageAliasFlag := core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)
+
+	// Check if image ID or alias is set
+	if viper.IsSet(imageIdFlag) || viper.IsSet(imageAliasFlag) {
 		imageRequiredFlags := make([][]string, 0)
 
-		// If image-alias is set, it's a public image. Otherwise, we need to check.
-		if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageAlias)) {
-			// Directly append public image flags.
+		if viper.IsSet(imageAliasFlag) {
+			// Handle public image alias
 			for _, baseFlagSet := range baseRequiredFlags {
 				imageRequiredFlags = append(imageRequiredFlags,
 					append(baseFlagSet, cloudapiv6.ArgImageAlias, cloudapiv6.ArgPassword),
 					append(baseFlagSet, cloudapiv6.ArgImageAlias, cloudapiv6.ArgSshKeyPaths),
 				)
 			}
-		} else if viper.IsSet(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)) {
-			// is image public or private?
-			img, _, err := client.Must().CloudClient.ImagesApi.ImagesFindById(context.Background(),
-				viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId))).Execute()
-			if err != nil {
-				return fmt.Errorf("failed getting image %s: %w", viper.GetString(core.GetFlagName(c.NS, cloudapiv6.ArgImageId)), err)
+		} else if viper.IsSet(imageIdFlag) {
+			// Check if the image ID corresponds to an image or snapshot
+			img, _, imgErr := client.Must().CloudClient.ImagesApi.ImagesFindById(context.Background(),
+				viper.GetString(imageIdFlag)).Execute()
+			if imgErr != nil {
+				// Try to fetch as a snapshot if image fetch fails
+				_, _, snapshotErr := client.Must().CloudClient.SnapshotsApi.SnapshotsFindById(context.Background(),
+					viper.GetString(imageIdFlag)).Execute()
+				if snapshotErr != nil {
+					return fmt.Errorf("failed getting image or snapshot %s: %w", viper.GetString(imageIdFlag), imgErr)
+				}
+
+				// If it's a snapshot, no additional checks are required
+				return nil
 			}
 
+			// If it's an image, determine if it is public or private
 			for _, baseFlagSet := range baseRequiredFlags {
-				if *img.Properties.Public {
-					// For public images, password or SSH key is required.
+				if img.Properties != nil && img.Properties.Public != nil && *img.Properties.Public {
+					// For public images, require password or SSH key
 					imageRequiredFlags = append(imageRequiredFlags,
 						append(baseFlagSet, cloudapiv6.ArgImageId, cloudapiv6.ArgPassword),
 						append(baseFlagSet, cloudapiv6.ArgImageId, cloudapiv6.ArgSshKeyPaths),
 					)
 				} else {
-					// For private images, no additional flags beyond image ID are required.
+					// For private images, only the image ID is required
 					imageRequiredFlags = append(imageRequiredFlags,
 						append(baseFlagSet, cloudapiv6.ArgImageId),
 					)

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -160,7 +160,7 @@ Required values to run command:
 	})
 	create.AddUUIDFlag(cloudapiv6.ArgImageId, "", "", "The Image Id or Snapshot Id to be used as template for the new Volume. A password or SSH Key need to be set")
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgImageId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
+		imageIds := completer.ImageIds(func(r ionoscloud.ApiImagesGetRequest) ionoscloud.ApiImagesGetRequest {
 			// Completer for HDD images that are in the same location as the datacenter
 			chosenDc, _, err := client.Must().CloudClient.DataCentersApi.DatacentersFindById(context.Background(),
 				viper.GetString(core.GetFlagName(create.NS, cloudapiv6.ArgDataCenterId))).Execute()
@@ -169,7 +169,11 @@ Required values to run command:
 			}
 
 			return r.Filter("location", *chosenDc.Properties.Location).Filter("imageType", "HDD")
-		}), cobra.ShellCompDirectiveNoFileComp
+		})
+
+		snapshotIds := completer.SnapshotIds()
+
+		return append(imageIds, snapshotIds...), cobra.ShellCompDirectiveNoFileComp
 	})
 
 	create.AddStringFlag(cloudapiv6.ArgImageAlias, cloudapiv6.ArgImageAliasShort, "", "The Image Alias to set instead of Image Id. A password or SSH Key need to be set")

--- a/test/bats/cloudapi/snapshot.bats
+++ b/test/bats/cloudapi/snapshot.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+# tags: snapshot, volume, server, datacenter, cube, template
+
+BATS_LIBS_PATH="${LIBS_PATH:-../libs}" # fallback to relative path if not set
+load "${BATS_LIBS_PATH}/bats-assert/load"
+load "${BATS_LIBS_PATH}/bats-support/load"
+load '../setup.bats'
+
+setup_file() {
+    rm -rf /tmp/bats_test
+    mkdir -p /tmp/bats_test
+
+    ssh-keygen -t rsa -b 4096 -N "" -f /tmp/bats_test/id_rsa
+
+    uuid_v4_regex='^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+}
+
+setup() {
+    if [[ -f /tmp/bats_test/email ]] && [[ -f /tmp/bats_test/password ]]; then
+        export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+        export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+    fi
+}
+
+@test "Create temporary sub-user with relevant permissions" {
+    echo "$(randStr 16)@$(randStr 8).ionosctl.test" | tr '[:upper:]' '[:lower:]' > /tmp/bats_test/email
+    echo "$(randStr 12)" > /tmp/bats_test/password
+
+    run ionosctl user create --first-name "test-user-$(randStr 4)" --last-name "test-last-$(randStr 4)" \
+        --email "$(cat /tmp/bats_test/email)" --password "$(cat /tmp/bats_test/password)" -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/user_id
+
+    run ionosctl group create --name "test-group-$(randStr 4)" \
+        --create-dc --create-nic --create-backup --create-snapshot --reserve-ip \
+        -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/group_id
+
+    sleep 10
+
+    run ionosctl group user add --user-id "$(cat /tmp/bats_test/user_id)" \
+        --group-id "$(cat /tmp/bats_test/group_id)" -o json 2> /dev/null
+    assert_success
+}
+
+@test "Is temp user" {
+    run ionosctl whoami
+    assert_success
+    assert_output "$(cat /tmp/bats_test/email)"
+}
+
+
+@test "Get and verify XS template" {
+    run ionosctl template list -F name=XS -o json 2> /dev/null
+    assert_success
+    xs_output="$output"
+    echo "$xs_output" | jq -r '.items[0].id' > /tmp/bats_test/template_id
+
+    run ionosctl template get --template-id "$(cat /tmp/bats_test/template_id)" --cols Ram --no-headers
+    assert_success
+    assert_output "$(echo "$xs_output" | jq -r '.items[0].properties.ram')"
+
+    run ionosctl template get --template-id "$(cat /tmp/bats_test/template_id)" --cols Cores --no-headers
+    assert_success
+    assert_output "$(echo "$xs_output" | jq -r '.items[0].properties.cores')"
+}
+
+@test "Create Datacenter" {
+    run ionosctl datacenter create --name "snapshot-test-dc-$(randStr 8)" --location "de/txl" -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/datacenter_id
+    sleep 5
+}
+
+@test "Create Volume" {
+    run ionosctl volume create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --size 10 --type "HDD" -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/volume_id
+}
+
+@test "Create Snapshot from Volume" {
+    run ionosctl snapshot create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --volume-id "$(cat /tmp/bats_test/volume_id)" --name "snapshot-test-$(randStr 8)" -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/snapshot_id
+}
+
+@test "Create Volume from Snapshot" {
+    run ionosctl volume create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --image-id "$(cat /tmp/bats_test/snapshot_id)" --size 10 --type "HDD" -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/volume_from_snapshot_id
+}
+
+@test "Create Server" {
+    run ionosctl server create --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --name "snapshot-test-server-$(randStr 8)" --cores 2 --ram 4096 -w -t 300 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/server_id
+}
+
+@test "Attach Volume to Server" {
+    run ionosctl server volume attach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_from_snapshot_id)" \
+        -w -t 300 -o json 2> /dev/null
+    assert_success
+}
+
+@test "Detach Volume from Server" {
+    run ionosctl server volume detach --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --server-id "$(cat /tmp/bats_test/server_id)" --volume-id "$(cat /tmp/bats_test/volume_from_snapshot_id)" -w -t 300 -f
+    assert_success
+}
+
+@test "Create CUBE Server using Snapshot" {
+    run ionosctl server create --type CUBE --template-id "$(cat /tmp/bats_test/template_id)" \
+        --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" --image-id "$(cat /tmp/bats_test/snapshot_id)" \
+        -w -t 400 -o json 2> /dev/null
+    assert_success
+    echo "$output" | jq -r '.id' > /tmp/bats_test/cube_server_id
+    assert_equal "$(echo "$output" | jq -r '.properties.type')" "CUBE"
+
+    run ionosctl server get --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --server-id "$(cat /tmp/bats_test/cube_server_id)" --no-headers --cols Type
+    assert_success
+    assert_output -p "CUBE"
+}
+
+@test "Detach and Cleanup" {
+    run ionosctl server delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --server-id "$(cat /tmp/bats_test/cube_server_id)" -w -t 300 -f
+    assert_success
+
+    run ionosctl volume delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" \
+        --volume-id "$(cat /tmp/bats_test/volume_id)" -w -t 300 -f
+    assert_success
+
+    run ionosctl snapshot delete --snapshot-id "$(cat /tmp/bats_test/snapshot_id)" -f
+    assert_success
+
+    run ionosctl datacenter delete --datacenter-id "$(cat /tmp/bats_test/datacenter_id)" -w -t 300 -f
+    assert_success
+}
+
+teardown_file() {
+    (
+        export IONOS_USERNAME="$(cat /tmp/bats_test/email)"
+        export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
+
+        ionosctl datacenter delete -af
+        ionosctl snapshot delete -af
+    )
+
+    ionosctl user delete --user-id "$(cat /tmp/bats_test/user_id)" -f
+    ionosctl group delete --group-id "$(cat /tmp/bats_test/group_id)" -f
+
+    rm -rf /tmp/bats_test
+}


### PR DESCRIPTION
Allow usage of snapshots for --image-id flag on volume and CUBE creation.

Adds a step to the BATS Volume test to test this scenario