### PR TITLE
fix: 404 on backupunit wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed not being able to use snapshot IDs for --image-id
+- Fixed 404 when waiting for backupunits to be ready
 
 ## [v6.8.0] (January 2025)
 

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
 	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/query"
-	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/waiter"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/json2table/jsonpaths"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/jsontabwriter"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/tabheaders"
 	"github.com/ionos-cloud/ionosctl/v6/internal/request"
-	"github.com/ionos-cloud/ionosctl/v6/internal/waitfor"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	cloudapiv6 "github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6"
 	"github.com/ionos-cloud/ionosctl/v6/services/cloudapi-v6/resources"
@@ -145,7 +143,9 @@ Required values to run a command:
 	create.AddStringFlag(cloudapiv6.ArgName, cloudapiv6.ArgNameShort, "", "Alphanumeric name you want to assign to the BackupUnit", core.RequiredFlagOption())
 	create.AddStringFlag(cloudapiv6.ArgEmail, cloudapiv6.ArgEmailShort, "", "The e-mail address you want to assign to the BackupUnit", core.RequiredFlagOption())
 	create.AddStringFlag(cloudapiv6.ArgPassword, cloudapiv6.ArgPasswordShort, "", "Alphanumeric password you want to assign to the BackupUnit", core.RequiredFlagOption())
-	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit creation to be executed")
+	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit creation to be executed")
+	create.Command.Flags().MarkHidden(constants.ArgWaitForRequest) // Backupunit resources are not tracked by /requests endpoint yet - but keep the flag for backward compatibility
 	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit creation [seconds]")
 	create.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultCreateDepth, cloudapiv6.ArgDepthDescription)
 
@@ -174,7 +174,9 @@ Required values to run command:
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit update to be executed")
+	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit update to be executed")
+	update.Command.Flags().MarkHidden(constants.ArgWaitForRequest) // Backupunit resources are not tracked by /requests endpoint yet - but keep the flag for backward compatibility
 	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit update [seconds]")
 	update.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultUpdateDepth, cloudapiv6.ArgDepthDescription)
 
@@ -201,7 +203,9 @@ Required values to run command:
 	_ = deleteCmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgBackupUnitId, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completer.BackupUnitsIds(), cobra.ShellCompDirectiveNoFileComp
 	})
-	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for BackupUnit deletion to be executed")
+	deleteCmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait,
+		"Wait for the Request for BackupUnit deletion to be executed")
+	deleteCmd.Command.Flags().MarkHidden(constants.ArgWaitForRequest) // Backupunit resources are not tracked by /requests endpoint yet - but keep the flag for backward compatibility
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all BackupUnits.")
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
@@ -355,9 +359,11 @@ func RunBackupUnitCreate(c *core.CommandConfig) error {
 		return err
 	}
 
-	if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
-		return err
-	}
+	// Backupunit resources are not tracked by /requests endpoint.
+	// They are always returned in AVAILABLE state. But we keep the flag for backward-compatibility.
+	// if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
+	// 	return err
+	// }
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput(backupUnitNote))
 
@@ -388,9 +394,11 @@ func RunBackupUnitUpdate(c *core.CommandConfig) error {
 		return err
 	}
 
-	if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
-		return err
-	}
+	// Backupunit resources are not tracked by /requests endpoint.
+	// They are always returned in AVAILABLE state. But we keep the flag for backward-compatibility.
+	// if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
+	// 	return err
+	// }
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
 
@@ -434,9 +442,11 @@ func RunBackupUnitDelete(c *core.CommandConfig) error {
 		return err
 	}
 
-	if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
-		return err
-	}
+	// Backupunit resources are not tracked by /requests endpoint.
+	// They are always returned in AVAILABLE state. But we keep the flag for backward-compatibility.
+	// if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
+	// 	return err
+	// }
 
 	fmt.Fprintf(c.Command.Command.OutOrStdout(), jsontabwriter.GenerateLogOutput("Backup Unit successfully deleted"))
 
@@ -530,10 +540,12 @@ func DeleteAllBackupUnits(c *core.CommandConfig) error {
 
 		fmt.Fprintf(c.Command.Command.ErrOrStderr(), jsontabwriter.GenerateLogOutput(constants.MessageDeletingAll, c.Resource, *id))
 
-		if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
-			multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
-			continue
-		}
+		// Backupunit resources are not tracked by /requests endpoint.
+		// They are always returned in AVAILABLE state. But we keep the flag for backward-compatibility.
+		// if err = waitfor.WaitForRequest(c, waiter.RequestInterrogator, request.GetId(resp)); err != nil {
+		// 	multiErr = errors.Join(multiErr, fmt.Errorf(constants.ErrWaitDeleteAll, c.Resource, *id, err))
+		// 	continue
+		// }
 	}
 
 	if multiErr != nil {

--- a/commands/cloudapi-v6/backupunit_test.go
+++ b/commands/cloudapi-v6/backupunit_test.go
@@ -423,7 +423,7 @@ func TestRunBackupUnitUpdateWaitErr(t *testing.T) {
 		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitNew, &testResponse, nil)
 		// Note: in #487 we no longer expect a status check when using -w , as backupunits are not registered on /requests
 		err := RunBackupUnitUpdate(cfg)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/commands/cloudapi-v6/backupunit_test.go
+++ b/commands/cloudapi-v6/backupunit_test.go
@@ -370,7 +370,7 @@ func TestRunBackupUnitCreateWaitErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitVar)
 		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Create(backupUnitTest, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitTest, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
+		// Note: in #487 we no longer expect a status check when using -w , as backupunits are not registered on /requests
 		err := RunBackupUnitCreate(cfg)
 		assert.NoError(t, err)
 	})
@@ -421,7 +421,7 @@ func TestRunBackupUnitUpdateWaitErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgPassword), testBackupUnitNewVar)
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgEmail), testBackupUnitNewVar)
 		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Update(testBackupUnitVar, backupUnitProperties, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&backupUnitNew, &testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, testRequestErr)
+		// Note: in #487 we no longer expect a status check when using -w , as backupunits are not registered on /requests
 		err := RunBackupUnitUpdate(cfg)
 		assert.Error(t, err)
 	})
@@ -564,7 +564,7 @@ func TestRunBackupUnitDeleteWaitErr(t *testing.T) {
 		viper.Set(core.GetFlagName(cfg.NS, cloudapiv6.ArgBackupUnitId), testBackupUnitVar)
 		viper.Set(core.GetFlagName(cfg.NS, constants.ArgWaitForRequest), true)
 		rm.CloudApiV6Mocks.BackupUnit.EXPECT().Delete(testBackupUnitVar, gomock.AssignableToTypeOf(testQueryParamOther)).Return(&testResponse, nil)
-		rm.CloudApiV6Mocks.Request.EXPECT().GetStatus(testRequestIdVar).Return(&testRequestStatus, nil, nil)
+		// Note: in #487 we no longer expect a status check when using -w , as backupunits are not registered on /requests
 		err := RunBackupUnitDelete(cfg)
 		assert.NoError(t, err)
 	})

--- a/docs/subcommands/Managed-Backup/create.md
+++ b/docs/subcommands/Managed-Backup/create.md
@@ -44,22 +44,21 @@ Required values to run a command:
 ## Options
 
 ```text
-  -u, --api-url string     Override default host url (default "https://api.ionos.com")
-      --cols strings       Set of columns to be printed on output 
-                           Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])
-  -c, --config string      Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
-  -D, --depth int32        Controls the detail depth of the response objects. Max depth is 10.
-  -e, --email string       The e-mail address you want to assign to the BackupUnit (required)
-  -f, --force              Force command to execute without user input
-  -h, --help               Print usage
-  -n, --name string        Alphanumeric name you want to assign to the BackupUnit (required)
-      --no-headers         Don't print table headers when table output is used
-  -o, --output string      Desired output format [text|json|api-json] (default "text")
-  -p, --password string    Alphanumeric password you want to assign to the BackupUnit (required)
-  -q, --quiet              Quiet output
-  -t, --timeout int        Timeout option for Request for BackupUnit creation [seconds] (default 60)
-  -v, --verbose            Print step-by-step process when running command
-  -w, --wait-for-request   Wait for the Request for BackupUnit creation to be executed
+  -u, --api-url string    Override default host url (default "https://api.ionos.com")
+      --cols strings      Set of columns to be printed on output 
+                          Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])
+  -c, --config string     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.json")
+  -D, --depth int32       Controls the detail depth of the response objects. Max depth is 10.
+  -e, --email string      The e-mail address you want to assign to the BackupUnit (required)
+  -f, --force             Force command to execute without user input
+  -h, --help              Print usage
+  -n, --name string       Alphanumeric name you want to assign to the BackupUnit (required)
+      --no-headers        Don't print table headers when table output is used
+  -o, --output string     Desired output format [text|json|api-json] (default "text")
+  -p, --password string   Alphanumeric password you want to assign to the BackupUnit (required)
+  -q, --quiet             Quiet output
+  -t, --timeout int       Timeout option for Request for BackupUnit creation [seconds] (default 60)
+  -v, --verbose           Print step-by-step process when running command
 ```
 
 ## Examples

--- a/docs/subcommands/Managed-Backup/delete.md
+++ b/docs/subcommands/Managed-Backup/delete.md
@@ -49,7 +49,6 @@ Required values to run command:
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for BackupUnit deletion [seconds] (default 60)
   -v, --verbose                Print step-by-step process when running command
-  -w, --wait-for-request       Wait for the Request for BackupUnit deletion to be executed
 ```
 
 ## Examples

--- a/docs/subcommands/Managed-Backup/update.md
+++ b/docs/subcommands/Managed-Backup/update.md
@@ -50,7 +50,6 @@ Required values to run command:
   -q, --quiet                  Quiet output
   -t, --timeout int            Timeout option for Request for BackupUnit update [seconds] (default 60)
   -v, --verbose                Print step-by-step process when running command
-  -w, --wait-for-request       Wait for the Request for BackupUnit update to be executed
 ```
 
 ## Examples

--- a/test/bats/cloudapi/volume.bats
+++ b/test/bats/cloudapi/volume.bats
@@ -150,7 +150,7 @@ setup_file() {
     export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
     run ionosctl backupunit create --name "bats$(randStr 6)" --email "$(cat /tmp/bats_test/email)" \
-     --password "$(cat /tmp/bats_test/password)" -o json 2> /dev/null
+     --password "$(cat /tmp/bats_test/password)" -w -t 300 -o json 2> /dev/null
     assert_success
     assert_regex "$output" "$uuid_v4_regex"
     echo "$output" | jq -r '.id' > /tmp/bats_test/backupunit_id


### PR DESCRIPTION
Backupunit resources are not tracked on `/requests` endpoint leading to a 404 if -w is  set

Hide `-w` flag and remove its behaviour, but keep it for backward compatibility - this means we won't throw errors if `-w` is set, but setting it will do nothing