### PR TITLE
fix: mongo return early if no snapshots

### DIFF
--- a/commands/dbaas/mongo/snapshot/list.go
+++ b/commands/dbaas/mongo/snapshot/list.go
@@ -43,6 +43,10 @@ func SnapshotsListCmd() *core.Command {
 				return err
 			}
 
+			if len(snapshots.Items) == 0 {
+				return nil // SDK-Bundle changes the return type of Items from empty slice to nil
+			}
+
 			cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
 
 			out, err := jsontabwriter.GenerateOutput("items", jsonpaths.DbaasMongoSnapshot, snapshots,


### PR DESCRIPTION
After #472 , listing snapshots causes an error if there are no snapshots to list

Fixes this bug by returning early.

Did not add to changelog as this bug hadn't been released yet