### PR TITLE
enhancement: logged in as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [v6.8.1] (???)
+## [v6.8.2] (March 2025)
+
+### Changed
+- Changed login message to include the username you have logged in as, if possible.
+
+
+## [v6.8.1] (February 2025)
 
 ### Added
 

--- a/commands/cfg/login.go
+++ b/commands/cfg/login.go
@@ -122,9 +122,11 @@ func RunLoginUser(c *core.CommandConfig) error {
 		if errTokens == nil {
 			msg.WriteString(fmt.Sprintf(" • Your account has %d active tokens.\n", len(ls.Tokens)))
 		}
+		if errLoggedInAs == nil || errTokens == nil {
+			msg.WriteString("\n")
+		}
 	}
-
-	msg.WriteString(fmt.Sprintf("\nConfig file updated successfully. Created the following fields in your config file:\n"))
+	msg.WriteString(fmt.Sprintf("Config file updated successfully. Created the following fields in your config file:\n"))
 	for k := range data {
 		msg.WriteString(fmt.Sprintf(" • %s\n", strings.TrimPrefix(k, "userdata.")))
 	}


### PR DESCRIPTION
Changes the login message to include the username you have logged in as, if possible.

Logging in will now still succeed if we cannot retrieve the number of tokens, but instead we will simply not print this information if we fail to retrieve it.


New:
```
 % i login --user $IONOS_USERNAME --password $IONOS_PASSWORD
Config file [...]/config.json already exists. Do you want to replace it? [y/n]: y
Note:                                    (note: not printed if both of the next two notes are empty)
 • Logged in as [...]                    (note: not printed if there is an error getting the username)
 • Your account has 8 active tokens.     (note: not printed if there is an error getting the number of tokens)

Config file updated successfully. Created the following fields in your config file:
 • token
```

```
 % i login --token BAD_TOKEN --skip-verify 
Config file updated successfully. Created the following fields in your config file:
 • token
```


Old:
```
 % i login --user $IONOS_USERNAME --password $IONOS_PASSWORD     
Config file [...]/config.json already exists. Do you want to replace it? [y/n]: y
Note: Your account has 9 active tokens. Config file updated successfully. Created the following fields in your config file:
 • token
```

