### PR TITLE
fix: auto imports scoped to vendor

### DIFF
--- a/.idea/ionosctl.iml
+++ b/.idea/ionosctl.iml
@@ -11,7 +11,6 @@
   </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <content url="file://$MODULE_DIR$/vendor" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>


### PR DESCRIPTION
fixes the automatic goland imports scoped to 'vendor' dir