### PR TITLE
feat: allow mongodb version to be updated

### DIFF
--- a/commands/dbaas/mongo/cluster/create.go
+++ b/commands/dbaas/mongo/cluster/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/fake"
 	cloudapiv6completer "github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
+	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/completer"
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/mongo/templates"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
@@ -243,7 +244,11 @@ func ClusterCreateCmd() *core.Command {
 	})
 
 	cmd.AddStringFlag(constants.FlagName, constants.FlagNameShort, "", "The name of your cluster", core.RequiredFlagOption())
-	cmd.AddStringFlag(constants.FlagVersion, "", "6.0", "The MongoDB version of your cluster", core.RequiredFlagOption())
+	cmd.AddStringFlag(constants.FlagVersion, "", "7.0", "The MongoDB version of your cluster", core.RequiredFlagOption())
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completer.MongoDBVersions(), cobra.ShellCompDirectiveNoFileComp
+	})
+
 	cmd.AddStringFlag(constants.FlagLocation, constants.FlagLocationShort, "", "The physical location where the cluster will be created. (defaults to the location of the connected datacenter)")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagLocation, func(cmdCobra *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cloudapiv6completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp

--- a/commands/dbaas/mongo/cluster/update.go
+++ b/commands/dbaas/mongo/cluster/update.go
@@ -54,6 +54,9 @@ func ClusterUpdateCmd() *core.Command {
 				}
 			}
 
+			if fn := core.GetFlagName(c.NS, constants.FlagVersion); viper.IsSet(fn) {
+				cluster.MongoDBVersion = pointer.From(viper.GetString(fn))
+			}
 			if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
 				cluster.DisplayName = pointer.From(viper.GetString(fn))
 			}
@@ -168,6 +171,10 @@ func ClusterUpdateCmd() *core.Command {
 	})
 	cmd.AddInt32Flag(constants.FlagShards, "", 1, "The total number of shards in the sharded_cluster cluster. Setting this flag is only possible for enterprise clusters and infers a sharded_cluster type. Possible values: 2 - 32. (required for sharded_cluster enterprise clusters)")
 
+	cmd.AddStringFlag(constants.FlagVersion, "", "", "The MongoDB version of your cluster.")
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completer.MongoClusterVersions(viper.GetString(core.GetFlagName(ClusterUpdateCmd().NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
+	})
 	// Maintenance
 	cmd.AddStringFlag(constants.FlagMaintenanceTime, "", "", "Time for the Maintenance. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagMaintenanceTime, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/commands/dbaas/mongo/cluster/update.go
+++ b/commands/dbaas/mongo/cluster/update.go
@@ -172,8 +172,8 @@ func ClusterUpdateCmd() *core.Command {
 	cmd.AddInt32Flag(constants.FlagShards, "", 1, "The total number of shards in the sharded_cluster cluster. Setting this flag is only possible for enterprise clusters and infers a sharded_cluster type. Possible values: 2 - 32. (required for sharded_cluster enterprise clusters)")
 
 	cmd.AddStringFlag(constants.FlagVersion, "", "", "The MongoDB version of your cluster.")
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.MongoClusterVersions(viper.GetString(core.GetFlagName(ClusterUpdateCmd().NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagVersion, func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completer.MongoClusterVersions(viper.GetString(core.GetFlagName(cmd.NS, constants.FlagClusterId))), cobra.ShellCompDirectiveNoFileComp
 	})
 	// Maintenance
 	cmd.AddStringFlag(constants.FlagMaintenanceTime, "", "", "Time for the Maintenance. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59")

--- a/commands/dbaas/mongo/completer/ids.go
+++ b/commands/dbaas/mongo/completer/ids.go
@@ -67,3 +67,23 @@ func MongoTemplateIds() []string {
 		return t.GetId()
 	})
 }
+
+func MongoDBVersions() []string {
+	ls, _, err := client.Must().MongoClient.MetadataApi.VersionsGet(context.Background()).Execute()
+	if err != nil {
+		return nil
+	}
+	return functional.Map(ls.GetData(), func(t sdkgo.MongoDBVersionListData) string {
+		return *t.Name
+	})
+}
+
+func MongoClusterVersions(clusterid string) []string {
+	ls, _, err := client.Must().MongoClient.ClustersApi.ClustersVersionsGet(context.Background(), clusterid).Execute()
+	if err != nil {
+		return nil
+	}
+	return functional.Map(ls.GetData(), func(t sdkgo.MongoDBVersionListData) string {
+		return *t.Name
+	})
+}

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/create.md
@@ -66,7 +66,7 @@ Create DBaaS Mongo Replicaset or Sharded Clusters for your chosen edition
       --template string           The ID of a Mongo Template, or a word contained in the name of one. Templates specify the number of cores, storage size, and memory. Business editions default to XS template. Playground editions default to playground template.
       --type string               Cluster Type. Required for enterprise clusters. Not required (inferred) if using --shards or --instances. Can be one of: replicaset, sharded-cluster (default "replicaset")
   -v, --verbose                   Print step-by-step process when running command
-      --version string            The MongoDB version of your cluster (required) (default "6.0")
+      --version string            The MongoDB version of your cluster (required) (default "7.0")
 ```
 
 ## Examples

--- a/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mongo/cluster/update.md
@@ -63,6 +63,7 @@ Update a Mongo Cluster by ID
       --storage-size string       Custom Storage: Greater performance for values greater than 100 GB. (required and only settable for enterprise edition)
       --storage-type string       Custom Storage Type. (only settable for enterprise edition) (default "\"SSD Standard\"")
   -v, --verbose                   Print step-by-step process when running command
+      --version string            The MongoDB version of your cluster.
 ```
 
 ## Examples


### PR DESCRIPTION
## What does this fix or implement?

This adds the `--version` parameter to the `ionosctl dbaas mongo cluster update` command which allows to upgrade the MongoDB version used by a cluster. It also pulls the available MongoDB versions for completions.

This also increases the default version for new MongoDB clusters (from "6.0" to "7.0", since the former is close to EOL)

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
