### PR TITLE
fix: get overrides where missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## [v6.9.1] – July 2025
+
+### Fixed
+- Fixed a bug where config overrides were ignored for certain CloudAPI commands
+
+
 ## [v6.9.0] – July 2025
 
 > [!WARNING]

--- a/commands/cloudapi-v6/backupunit.go
+++ b/commands/cloudapi-v6/backupunit.go
@@ -210,7 +210,7 @@ Required values to run command:
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for BackupUnit deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return backupUnitCmd
+	return core.WithConfigOverride(backupUnitCmd, "compute", "")
 }
 
 func PreRunBackupUnitList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/firewallrule.go
+++ b/commands/cloudapi-v6/firewallrule.go
@@ -297,7 +297,7 @@ Required values to run command:
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for Firewall Rule deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, "", cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return firewallRuleCmd
+	return core.WithConfigOverride(firewallRuleCmd, "compute", "")
 }
 
 func PreRunFirewallRuleList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/flowlog.go
+++ b/commands/cloudapi-v6/flowlog.go
@@ -222,7 +222,7 @@ Required values to run command:
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for FlowLog deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return flowLogCmd
+	return core.WithConfigOverride(flowLogCmd, "compute", "")
 }
 
 func PreRunFlowLogList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/ipconsumer.go
+++ b/commands/cloudapi-v6/ipconsumer.go
@@ -62,7 +62,7 @@ func IpconsumerCmd() *core.Command {
 	listResources.AddInt32Flag(constants.FlagMaxResults, constants.FlagMaxResultsShort, cloudapiv6.DefaultMaxResults, constants.DescMaxResults)
 	listResources.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultListDepth, cloudapiv6.ArgDepthDescription)
 
-	return resourceCmd
+	return core.WithConfigOverride(resourceCmd, "compute", "")
 }
 
 func RunIpConsumersList(c *core.CommandConfig) error {

--- a/commands/cloudapi-v6/k8s_cluster.go
+++ b/commands/cloudapi-v6/k8s_cluster.go
@@ -43,7 +43,8 @@ func K8sCmd() *core.Command {
 	k8sCmd.AddCommand(K8sNodePoolCmd())
 	k8sCmd.AddCommand(K8sNodeCmd())
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func K8sClusterCmd() *core.Command {
@@ -225,7 +226,8 @@ Required values to run command:
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.K8sTimeoutSeconds, "Timeout option for waiting for Request [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func PreRunK8sClusterList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/k8s_kubeconfig.go
+++ b/commands/cloudapi-v6/k8s_kubeconfig.go
@@ -45,7 +45,8 @@ func K8sKubeconfigCmd() *core.Command {
 		return completer.K8sClustersIds(), cobra.ShellCompDirectiveNoFileComp
 	})
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func RunK8sKubeconfigGet(c *core.CommandConfig) error {

--- a/commands/cloudapi-v6/k8s_node.go
+++ b/commands/cloudapi-v6/k8s_node.go
@@ -187,7 +187,8 @@ Required values to run command:
 	deleteCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Delete all the Kubernetes Nodes within an existing Kubernetes NodePool in a Cluster.")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func PreRunK8sNodesList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/k8s_nodepool.go
+++ b/commands/cloudapi-v6/k8s_nodepool.go
@@ -305,7 +305,8 @@ Required values to run command:
 
 	k8sCmd.AddCommand(K8sNodePoolLanCmd())
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func RunK8sNodePoolCreateFromJSON(c *core.CommandConfig, propertiesFromJson ionoscloud.KubernetesNodePoolForPost) error {

--- a/commands/cloudapi-v6/k8s_nodepool_lan.go
+++ b/commands/cloudapi-v6/k8s_nodepool_lan.go
@@ -142,7 +142,8 @@ Required values to run command:
 	removeCmd.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Remove all FK8s Nodepool Lans.")
 	removeCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func PreRunK8sClusterNodePoolLanIds(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/k8s_version.go
+++ b/commands/cloudapi-v6/k8s_version.go
@@ -55,7 +55,8 @@ func K8sVersionCmd() *core.Command {
 		InitClient: true,
 	})
 
-	return k8sCmd
+	return core.WithConfigOverride(k8sCmd, "compute", "")
+
 }
 
 func RunK8sVersionList(c *core.CommandConfig) error {

--- a/commands/cloudapi-v6/s3key.go
+++ b/commands/cloudapi-v6/s3key.go
@@ -187,7 +187,7 @@ Required values to run command:
 	deleteCmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for User S3Key deletion [seconds]")
 	deleteCmd.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultDeleteDepth, cloudapiv6.ArgDepthDescription)
 
-	return s3keyCmd
+	return core.WithConfigOverride(s3keyCmd, "compute", "")
 }
 
 func PreRunUserKeyIds(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/server.go
+++ b/commands/cloudapi-v6/server.go
@@ -534,7 +534,7 @@ Required values to run command:
 	serverCmd.AddCommand(ServerVolumeCmd())
 	serverCmd.AddCommand(ServerCdromCmd())
 
-	return serverCmd
+	return core.WithConfigOverride(serverCmd, "compute", "")
 }
 
 func PreRunServerList(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/targetgroup.go
+++ b/commands/cloudapi-v6/targetgroup.go
@@ -218,7 +218,7 @@ Required values to run command:
 
 	targetGroupCmd.AddCommand(TargetGroupTargetCmd())
 
-	return targetGroupCmd
+	return core.WithConfigOverride(targetGroupCmd, "compute", "")
 }
 
 func PreRunTargetGroupId(c *core.PreCommandConfig) error {

--- a/commands/cloudapi-v6/template.go
+++ b/commands/cloudapi-v6/template.go
@@ -84,6 +84,7 @@ func TemplateCmd() *core.Command {
 		return completer.TemplatesIds(), cobra.ShellCompDirectiveNoFileComp
 	})
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+
 	return core.WithConfigOverride(templateCmd, "compute", "")
 }
 

--- a/commands/cloudapi-v6/token.go
+++ b/commands/cloudapi-v6/token.go
@@ -54,6 +54,7 @@ func ServerTokenCmd() *core.Command {
 		return completer.ServersIds(viper.GetString(core.GetFlagName(get.NS, cloudapiv6.ArgDataCenterId))), cobra.ShellCompDirectiveNoFileComp
 	})
 	get.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultGetDepth, cloudapiv6.ArgDepthDescription)
+
 	return core.WithConfigOverride(tokenCmd, "compute", "")
 }
 

--- a/commands/cloudapi-v6/volume.go
+++ b/commands/cloudapi-v6/volume.go
@@ -1042,7 +1042,7 @@ Required values to run command:
 	detachVolume.AddBoolFlag(cloudapiv6.ArgAll, cloudapiv6.ArgAllShort, false, "Detach all Volumes.")
 	detachVolume.AddInt32Flag(cloudapiv6.ArgDepth, cloudapiv6.ArgDepthShort, cloudapiv6.DefaultMiscDepth, cloudapiv6.ArgDepthDescription)
 
-	return serverVolumeCmd
+	return core.WithConfigOverride(serverVolumeCmd, "compute", "")
 }
 
 func PreRunServerVolumeList(c *core.PreCommandConfig) error {

--- a/docs/subcommands/Compute Engine/firewallrule/create.md
+++ b/docs/subcommands/Compute Engine/firewallrule/create.md
@@ -42,7 +42,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FirewallRuleId Name Protocol SourceMac SourceIP DestinationIP PortRangeStart PortRangeEnd IcmpCode IcmpType Direction IPVersion State] (default [FirewallRuleId,Name,Protocol,PortRangeStart,PortRangeEnd,Direction,IPVersion,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/firewallrule/delete.md
+++ b/docs/subcommands/Compute Engine/firewallrule/delete.md
@@ -41,7 +41,7 @@ Required values to run command:
 
 ```text
   -a, --all                      Delete all the Firewalls.
-  -u, --api-url string           Override default host url (default "https://api.ionos.com")
+  -u, --api-url string           Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings             Set of columns to be printed on output 
                                  Available columns: [FirewallRuleId Name Protocol SourceMac SourceIP DestinationIP PortRangeStart PortRangeEnd IcmpCode IcmpType Direction IPVersion State] (default [FirewallRuleId,Name,Protocol,PortRangeStart,PortRangeEnd,Direction,IPVersion,State])
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/firewallrule/get.md
+++ b/docs/subcommands/Compute Engine/firewallrule/get.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string           Override default host url (default "https://api.ionos.com")
+  -u, --api-url string           Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings             Set of columns to be printed on output 
                                  Available columns: [FirewallRuleId Name Protocol SourceMac SourceIP DestinationIP PortRangeStart PortRangeEnd IcmpCode IcmpType Direction IPVersion State] (default [FirewallRuleId,Name,Protocol,PortRangeStart,PortRangeEnd,Direction,IPVersion,State])
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/firewallrule/list.md
+++ b/docs/subcommands/Compute Engine/firewallrule/list.md
@@ -42,7 +42,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FirewallRuleId Name Protocol SourceMac SourceIP DestinationIP PortRangeStart PortRangeEnd IcmpCode IcmpType Direction IPVersion State] (default [FirewallRuleId,Name,Protocol,PortRangeStart,PortRangeEnd,Direction,IPVersion,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/firewallrule/update.md
+++ b/docs/subcommands/Compute Engine/firewallrule/update.md
@@ -40,7 +40,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string           Override default host url (default "https://api.ionos.com")
+  -u, --api-url string           Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings             Set of columns to be printed on output 
                                  Available columns: [FirewallRuleId Name Protocol SourceMac SourceIP DestinationIP PortRangeStart PortRangeEnd IcmpCode IcmpType Direction IPVersion State] (default [FirewallRuleId,Name,Protocol,PortRangeStart,PortRangeEnd,Direction,IPVersion,State])
   -c, --config string            Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/flowlog/create.md
+++ b/docs/subcommands/Compute Engine/flowlog/create.md
@@ -43,7 +43,7 @@ Required values to run command:
 
 ```text
   -a, --action string          Specifies the traffic Action pattern (default "ALL")
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FlowLogId Name Action Direction Bucket State] (default [FlowLogId,Name,Action,Direction,Bucket,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/flowlog/delete.md
+++ b/docs/subcommands/Compute Engine/flowlog/delete.md
@@ -41,7 +41,7 @@ Required values to run command:
 
 ```text
   -a, --all                    Delete all Flowlogs.
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FlowLogId Name Action Direction Bucket State] (default [FlowLogId,Name,Action,Direction,Bucket,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/flowlog/get.md
+++ b/docs/subcommands/Compute Engine/flowlog/get.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FlowLogId Name Action Direction Bucket State] (default [FlowLogId,Name,Action,Direction,Bucket,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/flowlog/list.md
+++ b/docs/subcommands/Compute Engine/flowlog/list.md
@@ -42,7 +42,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [FlowLogId Name Action Direction Bucket State] (default [FlowLogId,Name,Action,Direction,Bucket,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/ipconsumer/list.md
+++ b/docs/subcommands/Compute Engine/ipconsumer/list.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [Ip Mac NicId ServerId ServerName DatacenterId DatacenterName K8sNodePoolId K8sClusterId] (default [Ip,NicId,ServerId,DatacenterId,K8sNodePoolId,K8sClusterId])
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/create.md
+++ b/docs/subcommands/Compute Engine/server/create.md
@@ -75,7 +75,7 @@ You can wait for the Request to be executed using `--wait-for-request` option. Y
 ## Options
 
 ```text
-  -u, --api-url string             Override default host url (default "https://api.ionos.com")
+  -u, --api-url string             Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -z, --availability-zone string   Availability zone of the Server (default "AUTO")
       --bus string                 [CUBE Server] The bus type of the Direct Attached Storage (default "VIRTIO")
       --cols strings               Set of columns to be printed on output 

--- a/docs/subcommands/Compute Engine/server/delete.md
+++ b/docs/subcommands/Compute Engine/server/delete.md
@@ -41,7 +41,7 @@ Required values to run command:
 
 ```text
   -a, --all                    Delete all Servers form a virtual Datacenter.
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/get.md
+++ b/docs/subcommands/Compute Engine/server/get.md
@@ -36,7 +36,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/list.md
+++ b/docs/subcommands/Compute Engine/server/list.md
@@ -41,7 +41,7 @@ Required values to run command:
 
 ```text
   -a, --all                    List all resources without the need of specifying parent ID name.
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/reboot.md
+++ b/docs/subcommands/Compute Engine/server/reboot.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/resume.md
+++ b/docs/subcommands/Compute Engine/server/resume.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/start.md
+++ b/docs/subcommands/Compute Engine/server/start.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/stop.md
+++ b/docs/subcommands/Compute Engine/server/stop.md
@@ -38,7 +38,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/suspend.md
+++ b/docs/subcommands/Compute Engine/server/suspend.md
@@ -32,7 +32,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [ServerId DatacenterId Name AvailabilityZone Cores Ram CpuFamily VmState State TemplateId Type BootCdromId BootVolumeId] (default [ServerId,Name,Type,AvailabilityZone,Cores,Ram,CpuFamily,VmState,State])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/update.md
+++ b/docs/subcommands/Compute Engine/server/update.md
@@ -47,7 +47,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string             Override default host url (default "https://api.ionos.com")
+  -u, --api-url string             Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -z, --availability-zone string   Availability zone of the Server
       --cdrom-id string            The unique Cdrom Id for the BootCdrom. The Cdrom needs to be already attached to the Server
       --cols strings               Set of columns to be printed on output 

--- a/docs/subcommands/Compute Engine/server/volume/attach.md
+++ b/docs/subcommands/Compute Engine/server/volume/attach.md
@@ -45,7 +45,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [VolumeId Name Size Type LicenceType State Image Bus AvailabilityZone BackupunitId DeviceNumber UserData BootServerId DatacenterId] (default [VolumeId,Name,Size,Type,LicenceType,State,Image])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/volume/detach.md
+++ b/docs/subcommands/Compute Engine/server/volume/detach.md
@@ -46,7 +46,7 @@ Required values to run command:
 
 ```text
   -a, --all                    Detach all Volumes.
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [VolumeId Name Size Type LicenceType State Image Bus AvailabilityZone BackupunitId DeviceNumber UserData BootServerId DatacenterId] (default [VolumeId,Name,Size,Type,LicenceType,State,Image])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/volume/get.md
+++ b/docs/subcommands/Compute Engine/server/volume/get.md
@@ -43,7 +43,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [VolumeId Name Size Type LicenceType State Image Bus AvailabilityZone BackupunitId DeviceNumber UserData BootServerId DatacenterId] (default [VolumeId,Name,Size,Type,LicenceType,State,Image])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/server/volume/list.md
+++ b/docs/subcommands/Compute Engine/server/volume/list.md
@@ -47,7 +47,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings           Set of columns to be printed on output 
                                Available columns: [VolumeId Name Size Type LicenceType State Image Bus AvailabilityZone BackupunitId DeviceNumber UserData BootServerId DatacenterId] (default [VolumeId,Name,Size,Type,LicenceType,State,Image])
   -c, --config string          Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/targetgroup/create.md
+++ b/docs/subcommands/Compute Engine/targetgroup/create.md
@@ -34,7 +34,7 @@ You can wait for the Request to be executed using `--wait-for-request` or `-w` o
 
 ```text
       --algorithm string     Balancing algorithm. (default "ROUND_ROBIN")
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --check-interval int   [Health Check] The interval in milliseconds between consecutive health checks; default is 2000. (default 2000)
       --check-timeout int    [Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established. (default 2000)
       --cols strings         Set of columns to be printed on output 

--- a/docs/subcommands/Compute Engine/targetgroup/delete.md
+++ b/docs/subcommands/Compute Engine/targetgroup/delete.md
@@ -36,7 +36,7 @@ Required values to run command:
 
 ```text
   -a, --all                     Delete all Target Groups
-  -u, --api-url string          Override default host url (default "https://api.ionos.com")
+  -u, --api-url string          Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings            Set of columns to be printed on output 
                                 Available columns: [TargetGroupId Name Algorithm Protocol CheckTimeout CheckInterval Retries Path Method MatchType Response Regex Negate State] (default [TargetGroupId,Name,Algorithm,Protocol,CheckTimeout,CheckInterval,State])
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/targetgroup/get.md
+++ b/docs/subcommands/Compute Engine/targetgroup/get.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string          Override default host url (default "https://api.ionos.com")
+  -u, --api-url string          Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings            Set of columns to be printed on output 
                                 Available columns: [TargetGroupId Name Algorithm Protocol CheckTimeout CheckInterval Retries Path Method MatchType Response Regex Negate State] (default [TargetGroupId,Name,Algorithm,Protocol,CheckTimeout,CheckInterval,State])
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/targetgroup/list.md
+++ b/docs/subcommands/Compute Engine/targetgroup/list.md
@@ -31,7 +31,7 @@ Use this command to get a list of Target Groups.
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [TargetGroupId Name Algorithm Protocol CheckTimeout CheckInterval Retries Path Method MatchType Response Regex Negate State] (default [TargetGroupId,Name,Algorithm,Protocol,CheckTimeout,CheckInterval,State])
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Compute Engine/targetgroup/update.md
+++ b/docs/subcommands/Compute Engine/targetgroup/update.md
@@ -38,7 +38,7 @@ Required values to run command:
 
 ```text
       --algorithm string        Balancing algorithm. (default "ROUND_ROBIN")
-  -u, --api-url string          Override default host url (default "https://api.ionos.com")
+  -u, --api-url string          Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --check-interval int      [Health Check] The interval in milliseconds between consecutive health checks; default is 2000. (default 2000)
       --check-timeout int       [Health Check] The maximum time in milliseconds to wait for a target to respond to a check. For target VMs with 'Check Interval' set, the lesser of the two  values is used once the TCP connection is established. (default 2000)
       --cols strings            Set of columns to be printed on output 

--- a/docs/subcommands/Managed-Backup/create.md
+++ b/docs/subcommands/Managed-Backup/create.md
@@ -44,7 +44,7 @@ Required values to run a command:
 ## Options
 
 ```text
-  -u, --api-url string    Override default host url (default "https://api.ionos.com")
+  -u, --api-url string    Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings      Set of columns to be printed on output 
                           Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])
   -c, --config string     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Managed-Backup/delete.md
+++ b/docs/subcommands/Managed-Backup/delete.md
@@ -36,7 +36,7 @@ Required values to run command:
 
 ```text
   -a, --all                    Delete all BackupUnits.
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --backupunit-id string   The unique BackupUnit Id (required)
       --cols strings           Set of columns to be printed on output 
                                Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])

--- a/docs/subcommands/Managed-Backup/get.md
+++ b/docs/subcommands/Managed-Backup/get.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --backupunit-id string   The unique BackupUnit Id (required)
       --cols strings           Set of columns to be printed on output 
                                Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])

--- a/docs/subcommands/Managed-Backup/get/sso/url.md
+++ b/docs/subcommands/Managed-Backup/get/sso/url.md
@@ -29,7 +29,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --backupunit-id string   The unique BackupUnit Id (required)
       --cols strings           Set of columns to be printed on output 
                                Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])

--- a/docs/subcommands/Managed-Backup/list.md
+++ b/docs/subcommands/Managed-Backup/list.md
@@ -36,7 +36,7 @@ Available Filters:
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Managed-Backup/update.md
+++ b/docs/subcommands/Managed-Backup/update.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string         Override default host url (default "https://api.ionos.com")
+  -u, --api-url string         Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --backupunit-id string   The unique BackupUnit Id (required)
       --cols strings           Set of columns to be printed on output 
                                Available columns: [BackupUnitId Name Email State] (default [BackupUnitId,Name,Email,State])

--- a/docs/subcommands/Managed-Kubernetes/cluster/create.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/create.md
@@ -34,7 +34,7 @@ You can wait for the Cluster to be in "ACTIVE" state using `--wait-for-state` fl
 
 ```text
       --api-subnets strings     Access to the K8s API server is restricted to these CIDRs. Cluster-internal traffic is not affected by this restriction. If no allowlist is specified, access is not restricted. If an IP without subnet mask is provided, the default value will be used: 32 for IPv4 and 128 for IPv6
-  -u, --api-url string          Override default host url (default "https://api.ionos.com")
+  -u, --api-url string          Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings            Set of columns to be printed on output 
                                 Available columns: [ClusterId Name K8sVersion State MaintenanceWindow Public Location NatGatewayIp NodeSubnet AvailableUpgradeVersions ViableNodePoolVersions S3Bucket ApiSubnetAllowList] (default [ClusterId,Name,K8sVersion,State,MaintenanceWindow,Public,Location])
   -c, --config string           Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Managed-Kubernetes/cluster/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/delete.md
@@ -38,7 +38,7 @@ Required values to run command:
 
 ```text
   -a, --all                 Delete all the Kubernetes clusters.
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --cluster-id string   The unique K8s Cluster Id (required)
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ClusterId Name K8sVersion State MaintenanceWindow Public Location NatGatewayIp NodeSubnet AvailableUpgradeVersions ViableNodePoolVersions S3Bucket ApiSubnetAllowList] (default [ClusterId,Name,K8sVersion,State,MaintenanceWindow,Public,Location])

--- a/docs/subcommands/Managed-Kubernetes/cluster/get.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/get.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --cluster-id string   The unique K8s Cluster Id (required)
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ClusterId Name K8sVersion State MaintenanceWindow Public Location NatGatewayIp NodeSubnet AvailableUpgradeVersions ViableNodePoolVersions S3Bucket ApiSubnetAllowList] (default [ClusterId,Name,K8sVersion,State,MaintenanceWindow,Public,Location])

--- a/docs/subcommands/Managed-Kubernetes/cluster/list.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/list.md
@@ -36,7 +36,7 @@ Available Filters:
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cols strings        Set of columns to be printed on output 
                             Available columns: [ClusterId Name K8sVersion State MaintenanceWindow Public Location NatGatewayIp NodeSubnet AvailableUpgradeVersions ViableNodePoolVersions S3Bucket ApiSubnetAllowList] (default [ClusterId,Name,K8sVersion,State,MaintenanceWindow,Public,Location])
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/Managed-Kubernetes/cluster/update.md
+++ b/docs/subcommands/Managed-Kubernetes/cluster/update.md
@@ -38,7 +38,7 @@ Required values to run command:
 
 ```text
       --api-subnets strings       Access to the K8s API server is restricted to these CIDRs. Cluster-internal traffic is not affected by this restriction. If no allowlist is specified, access is not restricted. If an IP without subnet mask is provided, the default value will be used: 32 for IPv4 and 128 for IPv6. This will overwrite the existing ones
-  -u, --api-url string            Override default host url (default "https://api.ionos.com")
+  -u, --api-url string            Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -i, --cluster-id string         The unique K8s Cluster Id (required)
       --cols strings              Set of columns to be printed on output 
                                   Available columns: [ClusterId Name K8sVersion State MaintenanceWindow Public Location NatGatewayIp NodeSubnet AvailableUpgradeVersions ViableNodePoolVersions S3Bucket ApiSubnetAllowList] (default [ClusterId,Name,K8sVersion,State,MaintenanceWindow,Public,Location])

--- a/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
+++ b/docs/subcommands/Managed-Kubernetes/kubeconfig/get.md
@@ -35,7 +35,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string   The unique K8s Cluster Id (required)
   -c, --config string       Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")
   -D, --depth int32         Controls the detail depth of the response objects. Max depth is 10.

--- a/docs/subcommands/Managed-Kubernetes/node/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/node/delete.md
@@ -38,7 +38,7 @@ Required values to run command:
 
 ```text
   -a, --all                  Delete all the Kubernetes Nodes within an existing Kubernetes NodePool in a Cluster.
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodeId Name K8sVersion PublicIP PrivateIP State] (default [NodeId,Name,K8sVersion,PublicIP,PrivateIP,State])

--- a/docs/subcommands/Managed-Kubernetes/node/get.md
+++ b/docs/subcommands/Managed-Kubernetes/node/get.md
@@ -37,7 +37,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodeId Name K8sVersion PublicIP PrivateIP State] (default [NodeId,Name,K8sVersion,PublicIP,PrivateIP,State])

--- a/docs/subcommands/Managed-Kubernetes/node/list.md
+++ b/docs/subcommands/Managed-Kubernetes/node/list.md
@@ -41,7 +41,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodeId Name K8sVersion PublicIP PrivateIP State] (default [NodeId,Name,K8sVersion,PublicIP,PrivateIP,State])

--- a/docs/subcommands/Managed-Kubernetes/node/recreate.md
+++ b/docs/subcommands/Managed-Kubernetes/node/recreate.md
@@ -39,7 +39,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodeId Name K8sVersion PublicIP PrivateIP State] (default [NodeId,Name,K8sVersion,PublicIP,PrivateIP,State])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/create.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/create.md
@@ -46,7 +46,7 @@ Required values to run a command (for Private Kubernetes Cluster):
 
 ```text
   -A, --annotations stringToString   Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE (default [])
-  -u, --api-url string               Override default host url (default "https://api.ionos.com")
+  -u, --api-url string               Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -z, --availability-zone string     The compute Availability Zone in which the Node should exist (default "AUTO")
       --cluster-id string            The unique K8s Cluster Id (required)
       --cols strings                 Set of columns to be printed on output 

--- a/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/delete.md
@@ -37,7 +37,7 @@ Required values to run command:
 
 ```text
   -a, --all                  Delete all the Kubernetes Node Pools within an existing Kubernetes Nodepools.
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodePoolId Name K8sVersion DatacenterId NodeCount CpuFamily ServerType StorageType State LanIds CoresCount RamSize AvailabilityZone StorageSize MaintenanceWindow AutoScaling PublicIps AvailableUpgradeVersions Annotations Labels ClusterId] (default [NodePoolId,Name,K8sVersion,NodeCount,DatacenterId,State])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/get.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/get.md
@@ -36,7 +36,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodePoolId Name K8sVersion DatacenterId NodeCount CpuFamily ServerType StorageType State LanIds CoresCount RamSize AvailabilityZone StorageSize MaintenanceWindow AutoScaling PublicIps AvailableUpgradeVersions Annotations Labels ClusterId] (default [NodePoolId,Name,K8sVersion,NodeCount,DatacenterId,State])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/add.md
@@ -39,7 +39,7 @@ Required values to run a command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [LanId Dhcp RoutesNetwork RoutesGatewayIp] (default [LanId,Dhcp,RoutesNetwork,RoutesGatewayIp])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/list.md
@@ -36,7 +36,7 @@ Required values to run command:
 ## Options
 
 ```text
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [LanId Dhcp RoutesNetwork RoutesGatewayIp] (default [LanId,Dhcp,RoutesNetwork,RoutesGatewayIp])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/lan/remove.md
@@ -38,7 +38,7 @@ Required values to run command:
 
 ```text
   -a, --all                  Remove all FK8s Nodepool Lans.
-  -u, --api-url string       Override default host url (default "https://api.ionos.com")
+  -u, --api-url string       Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string    The unique K8s Cluster Id (required)
       --cols strings         Set of columns to be printed on output 
                              Available columns: [NodePoolId Name K8sVersion DatacenterId NodeCount CpuFamily ServerType StorageType State LanIds CoresCount RamSize AvailabilityZone StorageSize MaintenanceWindow AutoScaling PublicIps AvailableUpgradeVersions Annotations Labels ClusterId] (default [NodePoolId,Name,K8sVersion,NodeCount,DatacenterId,State])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/list.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/list.md
@@ -41,7 +41,7 @@ Required values to run command:
 
 ```text
   -a, --all                 List all resources without the need of specifying parent ID name.
-  -u, --api-url string      Override default host url (default "https://api.ionos.com")
+  -u, --api-url string      Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string   The unique K8s Cluster Id (required)
       --cols strings        Set of columns to be printed on output 
                             Available columns: [NodePoolId Name K8sVersion DatacenterId NodeCount CpuFamily ServerType StorageType State LanIds CoresCount RamSize AvailabilityZone StorageSize MaintenanceWindow AutoScaling PublicIps AvailableUpgradeVersions Annotations Labels ClusterId] (default [NodePoolId,Name,K8sVersion,NodeCount,DatacenterId,State])

--- a/docs/subcommands/Managed-Kubernetes/nodepool/update.md
+++ b/docs/subcommands/Managed-Kubernetes/nodepool/update.md
@@ -43,7 +43,7 @@ Required values to run command:
       --annotation-key string        Annotation key. Must be set together with --annotation-value (DEPRECATED: Use --labels, --annotations options instead!)
       --annotation-value string      Annotation value. Must be set together with --annotation-key (DEPRECATED: Use --labels, --annotations options instead!)
   -A, --annotations stringToString   Annotations to set on a NodePool. It will overwrite the existing annotations, if there are any. Use the following format: --annotations KEY=VALUE,KEY=VALUE (default [])
-  -u, --api-url string               Override default host url (default "https://api.ionos.com")
+  -u, --api-url string               Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
       --cluster-id string            The unique K8s Cluster Id (required)
       --cols strings                 Set of columns to be printed on output 
                                      Available columns: [NodePoolId Name K8sVersion DatacenterId NodeCount CpuFamily ServerType StorageType State LanIds CoresCount RamSize AvailabilityZone StorageSize MaintenanceWindow AutoScaling PublicIps AvailableUpgradeVersions Annotations Labels ClusterId] (default [NodePoolId,Name,K8sVersion,NodeCount,DatacenterId,State])

--- a/docs/subcommands/Managed-Kubernetes/version/get.md
+++ b/docs/subcommands/Managed-Kubernetes/version/get.md
@@ -31,7 +31,7 @@ Use this command to retrieve the current default Kubernetes version for Clusters
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage

--- a/docs/subcommands/Managed-Kubernetes/version/list.md
+++ b/docs/subcommands/Managed-Kubernetes/version/list.md
@@ -31,7 +31,7 @@ Use this command to retrieve all available Kubernetes versions.
 ## Options
 
 ```text
-  -u, --api-url string   Override default host url (default "https://api.ionos.com")
+  -u, --api-url string   Override default host URL. Preferred over the config file override 'compute' and env var 'IONOS_API_URL' (default "https://api.ionos.com")
   -c, --config string    Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")
   -f, --force            Force command to execute without user input
   -h, --help             Print usage


### PR DESCRIPTION
adds `core.WithConfigOhverride` to where it was missing from CloudAPI commands

Note: this adds the override parser even for sub-commands, where it will have no effect. (e.g. server volume, k8s subcommands etc)