### PR TITLE
fix: fallback to IONOS_CONFIG_FILE if not found at --config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v6.9.1] – July 2025
 
 ### Fixed
+- Fixed a bug where the fallback to IONOS_CONFIG_FILE and ~/.ionos/config was not working correctly
 - Fixed a bug where config overrides were ignored for certain CloudAPI commands
 
 
@@ -52,7 +53,7 @@
 
 ### Changed
 
-- Changed (subcommands) README broken link path to "For more information, see **SUBCOMMANDS** section for respective products." in Introduction and README.md file. 
+- Changed (subcommands) README broken link path to "For more information, see **SUBCOMMANDS** section for respective products." in Introduction and README.md file.
 - Changed **authentication precedence** and updated `whoami` to reflect:
   1. `IONOS_TOKEN` env var
   2. `IONOS_USERNAME` + `IONOS_PASSWORD` env vars

--- a/commands/cfg/location.go
+++ b/commands/cfg/location.go
@@ -18,12 +18,14 @@ func LocationCmd() *core.Command {
 		PreCmdRun: core.NoPreRun,
 		CmdRun: func(c *core.CommandConfig) error {
 			cl, authErr := client.Get()
-			path := config.GetConfigFilePath()
-			if authErr == nil && cl != nil && cl.Config == nil {
+			var path string
+			if authErr == nil && cl != nil && cl.ConfigPath != "" {
 				path = cl.ConfigPath
+			} else {
+				path = config.GetConfigFilePath()
 			}
 
-			_, err := fmt.Fprintf(c.Command.Command.OutOrStdout(), path)
+			_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), path)
 			return err
 		},
 		InitClient: false,

--- a/commands/cfg/location.go
+++ b/commands/cfg/location.go
@@ -25,7 +25,7 @@ func LocationCmd() *core.Command {
 				path = config.GetConfigFilePath()
 			}
 
-			_, err := fmt.Fprintln(c.Command.Command.OutOrStdout(), path)
+			_, err := fmt.Fprintf(c.Command.Command.OutOrStdout(), path)
 			return err
 		},
 		InitClient: false,

--- a/internal/client/config_integration.go
+++ b/internal/client/config_integration.go
@@ -22,7 +22,7 @@ type ConfigSource struct {
 
 // retrieveConfigFile returns the first successful config or a fatal error.
 // If no config is found, ConfigSource.Config will be nil and Path will be the
-// default flag value (for backwards‐compat).
+// default flag value (for backwards-compat).
 func retrieveConfigFile() (ConfigSource, error) {
 	loaders := []func() (ConfigSource, error){
 		loadFromFlag,
@@ -44,7 +44,6 @@ func retrieveConfigFile() (ConfigSource, error) {
 		// not found -> try next
 	}
 
-	fmt.Println("none found: printing default")
 	// none found -> return nil config, default flag path
 	return ConfigSource{nil, viper.GetString(constants.ArgConfig)}, nil
 }

--- a/internal/client/config_integration.go
+++ b/internal/client/config_integration.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cfg "github.com/ionos-cloud/ionosctl/v6/internal/config"
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/ionos-cloud/sdk-go-bundle/shared/fileconfiguration"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigSource holds a loaded FileConfig (or nil) plus the path it came from.
+type ConfigSource struct {
+	Config *fileconfiguration.FileConfig
+	Path   string
+}
+
+// retrieveConfigFile returns the first successful config or a fatal error.
+// If no config is found, ConfigSource.Config will be nil and Path will be the
+// default flag value (for backwards‐compat).
+func retrieveConfigFile() (ConfigSource, error) {
+	loaders := []func() (ConfigSource, error){
+		loadFromFlag,
+		loadFromEnvVar,
+		loadFromJSONMigration,
+		loadFromSDKDefault,
+	}
+
+	for _, load := range loaders {
+		src, err := load()
+		if err != nil {
+			// I/O or parse error: stop immediately
+			return ConfigSource{}, err
+		}
+		if src.Config != nil {
+			// found a valid config; return it
+			return src, nil
+		}
+		// not found -> try next
+	}
+
+	fmt.Println("none found: printing default")
+	// none found -> return nil config, default flag path
+	return ConfigSource{nil, viper.GetString(constants.ArgConfig)}, nil
+}
+
+// loadFromFlag tries --config; if empty or missing -> (nil, ""), nil;
+// on I/O/parse error -> err; on success -> (*FileConfig, path), nil.
+func loadFromFlag() (ConfigSource, error) {
+	path := viper.GetString(constants.ArgConfig)
+	if path == "" {
+		return ConfigSource{}, nil
+	}
+	return tryLoad(path, "--config")
+}
+
+// loadFromEnvVar tries IONOS_CONFIG_FILE; same semantics as loadFromFlag.
+func loadFromEnvVar() (ConfigSource, error) {
+	path := os.Getenv(shared.IonosFilePathEnvVar)
+	if path == "" {
+		return ConfigSource{}, nil
+	}
+	return tryLoad(path, fmt.Sprintf("env %s", shared.IonosFilePathEnvVar))
+}
+
+// loadFromJSONMigration migrates legacy config.json (if present next to --config path).
+// On success returns the new YAML config; on any error returns err.
+func loadFromJSONMigration() (ConfigSource, error) {
+	yamlPath := viper.GetString(constants.ArgConfig)
+	if yamlPath == "" {
+		return ConfigSource{}, nil
+	}
+	jsonPath := filepath.Join(filepath.Dir(yamlPath), "config.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		return ConfigSource{}, nil
+	}
+
+	migrated, err := cfg.MigrateFromJSON(jsonPath)
+	if err != nil {
+		return ConfigSource{}, fmt.Errorf("failed migrating %q to YAML: %w", jsonPath, err)
+	}
+	if migrated == nil {
+		return ConfigSource{}, nil
+	}
+
+	out, _ := yaml.Marshal(migrated)
+	if err := os.WriteFile(yamlPath, out, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Warning: could not write migrated config to %s: %v\n",
+			yamlPath, err)
+	}
+	return ConfigSource{migrated, yamlPath}, nil
+}
+
+// loadFromSDKDefault tries the SDK default path (~/.ionos/config).
+func loadFromSDKDefault() (ConfigSource, error) {
+	defaultPath, err := fileconfiguration.DefaultConfigFileName()
+	if err != nil {
+		return ConfigSource{}, fmt.Errorf("could not determine default config path: %w", err)
+	}
+	return tryLoad(defaultPath, "SDK default")
+}
+
+// tryLoad loads a FileConfig from the given path.
+// If the file does not exist, it returns a nil FileConfig and the path.
+// If the file exists but cannot be loaded, it returns an error.
+// If the file is loaded successfully, it returns the FileConfig and the path.
+func tryLoad(path, sourceDesc string) (ConfigSource, error) {
+	cfg, err := fileconfiguration.New(path)
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			return ConfigSource{nil, path}, nil
+		}
+		return ConfigSource{}, fmt.Errorf("%s: failed loading %q: %w", sourceDesc, path, err)
+	}
+	return ConfigSource{cfg, path}, nil
+}

--- a/internal/client/config_integration_test.go
+++ b/internal/client/config_integration_test.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
+)
+
+// writeMinimalYAML writes a bare-bones valid FileConfig YAML to path.
+func writeMinimalYAML(t *testing.T, path string) {
+	const yamlContent = `version: 1.0
+currentProfile: ""
+profiles: []
+environments: []
+`
+	if err := os.WriteFile(path, []byte(yamlContent), 0o600); err != nil {
+		t.Fatalf("failed to write %q: %v", path, err)
+	}
+}
+
+func TestRetrieveConfigFile_FlagOverridesEverything(t *testing.T) {
+	// prepare a temp config file
+	dir := t.TempDir()
+	flagCfg := filepath.Join(dir, "flag.yaml")
+	writeMinimalYAML(t, flagCfg)
+
+	// set the --config flag
+	viper.Set(constants.ArgConfig, flagCfg)
+	// ensure env var cannot interfere
+	t.Setenv(shared.IonosFilePathEnvVar, "")
+	// ensure no default exists
+	t.Setenv("HOME", dir) // no ~/.ionos/config
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.Path != flagCfg {
+		t.Errorf("expected Path %q, got %q", flagCfg, src.Path)
+	}
+	if src.Config == nil {
+		t.Errorf("expected Config non-nil when flag file exists")
+	}
+}
+
+func TestRetrieveConfigFile_EnvVarAsFallback(t *testing.T) {
+	// clear any --config flag
+	viper.Set(constants.ArgConfig, "")
+
+	// prepare env-pointed config
+	dir := t.TempDir()
+	envCfg := filepath.Join(dir, "env.yaml")
+	writeMinimalYAML(t, envCfg)
+
+	// set IONOS_CONFIG_FILE
+	t.Setenv(shared.IonosFilePathEnvVar, envCfg)
+	// clear any SDK default
+	t.Setenv("HOME", dir)
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.Path != envCfg {
+		t.Errorf("expected Path %q, got %q", envCfg, src.Path)
+	}
+	if src.Config == nil {
+		t.Errorf("expected Config non-nil when env file exists")
+	}
+}
+
+func TestRetrieveConfigFile_SDKDefault(t *testing.T) {
+	// clear flag + env
+	viper.Set(constants.ArgConfig, "")
+	t.Setenv(shared.IonosFilePathEnvVar, "")
+
+	// point HOME at a dir with a .ionos/config
+	home := t.TempDir()
+	dfltDir := filepath.Join(home, ".ionos")
+	if err := os.MkdirAll(dfltDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defaultCfg := filepath.Join(dfltDir, "config")
+	writeMinimalYAML(t, defaultCfg)
+	t.Setenv("HOME", home)
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.Path != defaultCfg {
+		t.Errorf("expected Path %q, got %q", defaultCfg, src.Path)
+	}
+	if src.Config == nil {
+		t.Errorf("expected Config non-nil when default exists")
+	}
+}
+
+func TestRetrieveConfigFile_NoneFound(t *testing.T) {
+	// clear everything
+	viper.Set(constants.ArgConfig, "")
+	t.Setenv(shared.IonosFilePathEnvVar, "")
+	// point HOME at empty dir
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// when nothing is found, Path should be whatever viper.ArgConfig says (here, empty)
+	if want, got := "", src.Path; want != got {
+		t.Errorf("expected empty Path, got %q", got)
+	}
+	if src.Config != nil {
+		t.Errorf("expected Config=nil when no file exists")
+	}
+}

--- a/internal/client/config_integration_test.go
+++ b/internal/client/config_integration_test.go
@@ -87,6 +87,8 @@ func TestRetrieveConfigFile_SDKDefault(t *testing.T) {
 	defaultCfg := filepath.Join(dfltDir, "config")
 	writeMinimalYAML(t, defaultCfg)
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 
 	src, err := retrieveConfigFile()
 	if err != nil {
@@ -107,6 +109,8 @@ func TestRetrieveConfigFile_NoneFound(t *testing.T) {
 	// point HOME at empty dir
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 
 	src, err := retrieveConfigFile()
 	if err != nil {


### PR DESCRIPTION
Refactor to use ConfigSource return type

After switching to the func-approach, the funcs were confounding "not found" errors and "incorrect config contents" errors which caused the bug. This is now fixed

Add tests covering each resolution path.