### PR TITLE
test: cleanup dns reverse records, secondary-zones

### DIFF
--- a/test/bats/dns/dns.bats
+++ b/test/bats/dns/dns.bats
@@ -253,6 +253,9 @@ teardown_file() {
         export IONOS_PASSWORD="$(cat /tmp/bats_test/password)"
 
         ionosctl dns zone delete -af
+        ionosctl dns record delete -af
+        ionosctl dns secondary-zone delete -af
+        ionosctl dns reverse-record delete -af
     )
 
     ionosctl user delete --user-id "$(cat /tmp/bats_test/user_id)" -f


### PR DESCRIPTION
adds a clean up to DNS records, reverse-records, secondary-zones at the end of the BATS Test.