### PR TITLE
remove: trivy license scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
-          scanners: vuln,secret,license
+          scanners: vuln,secret
           skip-dirs: vendor
           format: table
           output: trivy-report.txt


### PR DESCRIPTION
removes trivy workflow license scanning, as this was being too noisy.