### PR TITLE
fix: change test parameter

### DIFF
--- a/test/bats/apigateway/apigateway.bats
+++ b/test/bats/apigateway/apigateway.bats
@@ -173,10 +173,10 @@ setup() {
     gateway_id=$(cat /tmp/bats_test/gateway_id)
 
     # Get Gateway (JSON output)
-    run ionosctl apigateway gateway update --gateway-id "$gateway_id" --logs true -o json 2> /dev/null
+    run ionosctl apigateway gateway update --gateway-id "$gateway_id" --name example -o json 2> /dev/null
     assert_success
     assert_output -p "\"status\": \"PROVISIONING\""
-    assert_output -p "\"logs\": true"
+    assert_output -p "\"name\": \"example\""
 }
 
 @test "Update ApiGateway Route" {


### PR DESCRIPTION
- Fix API error when updating API Gateway. 

- Replaced --logs true in "run ionosctl apigateway gateway update --gateway-id "$gateway_id" --logs true -o json 2> /dev/null" because it caused the following error: 

"Error: 422 Unprocessable Entity: {"httpStatus":422,"messages":[{"errorCode":"Validation","message":"in order to enable the logs you need to enable the central logging first"}]}"