### PR TITLE
fix: add '-l' shorthand for '--location' for registry create

### DIFF
--- a/commands/container-registry/registry/post.go
+++ b/commands/container-registry/registry/post.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
@@ -28,7 +29,7 @@ func RegPostCmd() *core.Command {
 			Aliases:    []string{"c"},
 			ShortDesc:  "Create a registry",
 			LongDesc:   "Create a registry to hold container images or OCI compliant artifacts",
-			Example:    "ionosctl container-registry registry create",
+			Example:    "ionosctl container-registry registry create --name NAME --location de/txl",
 			PreCmdRun:  PreCmdPost,
 			CmdRun:     CmdPost,
 			InitClient: true,
@@ -45,13 +46,10 @@ func RegPostCmd() *core.Command {
 	cmd.AddStringFlag(
 		constants.FlagName, constants.FlagNameShort, "", "Specify the name of the registry", core.RequiredFlagOption(),
 	)
-	cmd.AddStringFlag(constants.FlagLocation, "", "", "Specify the location of the registry", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(
-		constants.FlagLocation,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return getLocForAutoComplete(), cobra.ShellCompDirectiveNoFileComp
-		},
-	)
+	cmd.AddStringFlag(constants.FlagLocation, constants.FlagLocationShort, "", "Specify the location of the registry", core.RequiredFlagOption())
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
+	})
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	hour := 10 + r.Intn(7) // Random hour 10-16

--- a/commands/container-registry/registry/post.go
+++ b/commands/container-registry/registry/post.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/ionos-cloud/ionosctl/v6/commands/cloudapi-v6/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
@@ -47,9 +46,12 @@ func RegPostCmd() *core.Command {
 		constants.FlagName, constants.FlagNameShort, "", "Specify the name of the registry", core.RequiredFlagOption(),
 	)
 	cmd.AddStringFlag(constants.FlagLocation, constants.FlagLocationShort, "", "Specify the location of the registry", core.RequiredFlagOption())
-	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagLocation, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return completer.LocationIds(), cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.Command.RegisterFlagCompletionFunc(
+		constants.FlagLocation,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getLocForAutoComplete(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	hour := 10 + r.Intn(7) // Random hour 10-16

--- a/docs/subcommands/Container-Registry/registry/create.md
+++ b/docs/subcommands/Container-Registry/registry/create.md
@@ -45,7 +45,7 @@ Create a registry to hold container images or OCI compliant artifacts
       --garbage-collection-schedule-days strings   Specify the garbage collection schedule days. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default Random (Mon-Fri 10:00-16:00))
       --garbage-collection-schedule-time string    Specify the garbage collection schedule time of day using RFC3339 format. i.e. "16:00:00Z". Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -h, --help                                       Print usage
-      --location string                            Specify the location of the registry (required)
+  -l, --location string                            Specify the location of the registry (required)
   -n, --name string                                Specify the name of the registry (required)
       --no-headers                                 Don't print table headers when table output is used
   -o, --output string                              Desired output format [text|json|api-json] (default "text")
@@ -57,6 +57,6 @@ Create a registry to hold container images or OCI compliant artifacts
 ## Examples
 
 ```text
-ionosctl container-registry registry create
+ionosctl container-registry registry create --name NAME --location de/txl
 ```
 


### PR DESCRIPTION
Adds `-l` shorthand and improves help text for `container-registry registry create`