### PR TITLE
fix #600: 'tokens' now 'items' for GET tokens

### DIFF
--- a/commands/token/list.go
+++ b/commands/token/list.go
@@ -49,8 +49,7 @@ func runTokenList(c *core.CommandConfig) error {
 	}
 
 	cols := viper.GetStringSlice(core.GetFlagName(c.Resource, constants.ArgCols))
-
-	out, err := jsontabwriter.GenerateOutput("tokens", jsonpaths.AuthToken, tokens.Tokens,
+	out, err := jsontabwriter.GenerateOutput("items", jsonpaths.AuthToken, tokens.Tokens,
 		tabheaders.GetHeaders(allTokenCols, defaultTokenCols, cols))
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #600: mirror an API change that was causing the `token list` command to always return empty

Before
```
{
  "tokens": [
    {
      "createdDate": "2025-09-23T07:29:44Z",
```

Now:
```
{
  "items": [
    {
      "createdDate": "2025-09-23T07:29:44Z",
```

