### PR TITLE
fix: '--datacenter-id' and '--lan-id' completions for DBaaS Replicaset commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 - Fixed completions for '--datacenter-id' and '--lan-id' for DBaaS Replicaset commands
 - Allow changing authentication URL for 'login' (and 'whoami' when using a token).
 
-### Changed
-- Allow both '--replica-set-id' and '--replicaset-id' for DBaaS Replicaset commands
-
 ## [v6.9.4] – September 2025
 
 ### Added

--- a/commands/dbaas/inmemorydb/replicaset/replicaset.go
+++ b/commands/dbaas/inmemorydb/replicaset/replicaset.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/tabheaders"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -30,15 +29,6 @@ func Root() *core.Command {
 			return allCols, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
-
-	// allow both --replicaset-id and --replica-set-id
-	replicaSetIdNormalizer := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
-		if name == "replicaset-id" {
-			return pflag.NormalizedName(constants.FlagReplicasetID)
-		}
-		return pflag.NormalizedName(name)
-	}
-	cmd.Command.PersistentFlags().SetNormalizeFunc(replicaSetIdNormalizer)
 
 	cmd.AddCommand(Create())
 	cmd.AddCommand(Get())


### PR DESCRIPTION
Fixed completions for '--datacenter-id' and '--lan-id' for DBaaS Replicaset commands