### PR TITLE
bump: go to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ionos-cloud/ionosctl/v6
 
-go 1.24.6
+go 1.25.3
 
 require (
 	github.com/Jeffail/gabs/v2 v2.7.0


### PR DESCRIPTION
Bumps go to 1.25.3 to fix a few low severity vulnerabilities.