### PR TITLE
fix: -v overriding sdk log level

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -126,10 +126,7 @@ func newClient(name, pwd, token, hostUrl string) *Client {
 		clientConfig.LogLevel = cloudv6.Debug
 		vmascConfig.LogLevel = vmasc.Debug
 	default:
-		// use CLI verbose prints only
-		shared.SdkLogLevel = shared.Off
-		clientConfig.LogLevel = cloudv6.Off
-		vmascConfig.LogLevel = vmasc.Off
+		// don't explicitly set to Off, as this breaks SDK handling of the IONOS_LOG_LEVEL variable
 	}
 
 	return &Client{


### PR DESCRIPTION
Fixes a yet unreleased bug which made the new -v flag set SDK Log level explicitly to 'Off' if the flag wasn't set, so users using `IONOS_LOG_LEVEL=trace <command>` would still get a SDK log level of 'Off'. 

Now the users can combine the two, so `IONOS_LOG_LEVEL=trace <command> -v` will activate both the CLI verbose prints, as well as the SDK trace.

`IONOS_LOG_LEVEL=debug <command> -vvv` will prioritize to 'trace'