### PR TITLE
enhancement: Order templates by category

### DIFF
--- a/services/cloudapi-v6/resources/template.go
+++ b/services/cloudapi-v6/resources/template.go
@@ -42,6 +42,9 @@ func NewTemplateService(client *client.Client, ctx context.Context) TemplatesSer
 
 func (ss *templatesService) List() (Templates, *Response, error) {
 	req := ss.client.TemplatesApi.TemplatesGet(ss.context)
+
+	req = req.OrderBy("category")
+
 	s, res, err := ss.client.TemplatesApi.TemplatesGetExecute(req)
 	return Templates{s}, &Response{*res}, err
 }


### PR DESCRIPTION
Sort the templates by category by default for the 'ionosctl template list' command.