### PR TITLE
test: disable 'run all' on shared code changes

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -11,18 +11,6 @@ BATS_FILES=$(find "${SCRIPT_DIR}/suites" -name '*.bats' ! -name 'setup.bats')
 # modified files compared to the base
 MODIFIED_FILES=$(git diff --name-only $BASE_BRANCH | grep -vE 'vendor|docs')
 
-# If shared code is modified, run all test suites
-RUN_ALL=false
-for file in $MODIFIED_FILES; do
-    if [[ "$file" == internal/* ]] || [[ "$file" == pkg/* ]] || \
-       [[ "$file" == services/* ]] || [[ "$file" == commands/compute/helpers/* ]] || \
-       [[ "$file" == commands/compute/waiter/* ]]; then
-        echo "Shared code modified ($file) — running all test suites"
-        RUN_ALL=true
-        break
-    fi
-done
-
 # Check if any modified file matches a glob pattern.
 # Globs use * to match any path segment (e.g. commands/cdn/* matches commands/cdn/foo/bar.go).
 # Returns the matched glob and file on stdout, exit code 0 on match.
@@ -43,15 +31,6 @@ matches_path() {
 exit_code=0
 for file in $BATS_FILES; do
     file_absolute_path=$(realpath "$file")
-
-    if $RUN_ALL; then
-        echo "Running $file_absolute_path (shared code changed)"
-        bats "$file_absolute_path"
-        if [ $? -ne 0 ]; then
-            exit_code=1
-        fi
-        continue
-    fi
 
     # Get path globs for the current file
     if ! paths_output=$("${SCRIPT_DIR}/parse_paths.sh" "$file_absolute_path"); then

--- a/test/suites/client.bats
+++ b/test/suites/client.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# paths: services/cloudapi-v6/*, internal/client/*
+# paths: services/*, internal/*, pkg/*
 
 load './setup.bats'
 

--- a/test/suites/compute/compat.bats
+++ b/test/suites/compute/compat.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# paths: commands/compute/location/*, commands/compute/server/*, commands/compute/datacenter/*, commands/compute/k8s/*, commands/compute/image/*, commands/compute/template/*, commands/compute/user/*
+# paths: commands/compute/location/*, commands/compute/server/*, commands/compute/datacenter/*, commands/compute/k8s/*, commands/compute/image/*, commands/compute/template/*, commands/compute/user/*, commands/compute/helpers/*, commands/compute/waiter/*
 
 load '../setup.bats'
 


### PR DESCRIPTION
Removes RUN_ALL logic entirely, as this proves to run too many tests too much.

Devs should just do `/test compute/server` etc if they notice a bats test should be triggered but hasn't by the `paths` mechanism