### PR TITLE
docs: align customer-facing brand to "IONOS CLOUD"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: IONOS Cloud API
+  - name: IONOS CLOUD API
     url: https://devops.ionos.com/api/
     about: View API documentation

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ scoops:
       owner: ionos-cloud
       name: scoop-bucket
     homepage: https://github.com/ionos-cloud/ionosctl
-    description: IonosCTL is a tool to help you manage your Ionos Cloud resources directly from your terminal.
+    description: IonosCTL is a tool to help you manage your IONOS CLOUD resources directly from your terminal.
     license: Apache-2.0
 
 brews:
@@ -62,7 +62,7 @@ brews:
     directory: Formula
     goarm: "7"
     homepage: https://github.com/ionos-cloud/ionosctl
-    description: IonosCTL is a tool to help you manage your Ionos Cloud resources directly from your terminal.
+    description: IonosCTL is a tool to help you manage your IONOS CLOUD resources directly from your terminal.
     license: Apache-2.0
     dependencies:
       - name: go
@@ -73,9 +73,9 @@ brews:
 snapcrafts:
   - id: ionosctl
     title: ionosctl
-    summary: IONOS Cloud CLI tool
+    summary: IONOS CLOUD CLI tool
     description: |
-      The IONOS Cloud CLI (ionosctl) gives the ability to manage IONOS Cloud infrastructure directly from Command Line.
+      The IONOS CLOUD CLI (ionosctl) gives the ability to manage IONOS CLOUD infrastructure directly from Command Line.
     grade: stable
     channel_templates:
       - candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `object-storage` support, with `whoami --provenance` credentials resolution 
 - Added `--ftp-port` on `image upload` which is usable in combination with `--ftp-url`.
 ### Changed
+- Aligned customer-facing brand references to "IONOS CLOUD" in CLI help text, godoc, and release-config descriptions (no behaviour change).
 - Improved `ionosctl --help` output: rewrote command short descriptions for consistency and grouped commands into sections.
 - Improve `ionosctl shell` interactive shell prompt:
   - Removed beta warnings and notes. Interactive prompts (e.g. delete confirmations) now work natively instead of requiring `--force`.

--- a/commands/cfg/login.go
+++ b/commands/cfg/login.go
@@ -35,7 +35,7 @@ If using '--example', this command prints the config to stdout without any authe
 You can filter by version (--filter-version), whitelist (--whitelist) or blacklist (--blacklist) specific APIs,
 and customize the names of the APIs in the config file using --custom-names.
 
-There are three ways you can authenticate with the IONOS Cloud APIs:
+There are three ways you can authenticate with the IONOS CLOUD APIs:
   1. Interactive mode: Prompts for username and password, and generates a token that will be saved in the config file.
   2. Use the '--user' and '--password' flags: Used to generate a token that will be saved in the config file.
   3. Use the '--token' flag: Provide an authentication token.

--- a/commands/compute/applicationloadbalancer/flowlog/create.go
+++ b/commands/compute/applicationloadbalancer/flowlog/create.go
@@ -49,7 +49,7 @@ Required values to run command:
 	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.", core.RequiredFlagOption())
+	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS CLOUD S3 bucket.", core.RequiredFlagOption())
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer FlowLog creation to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer FlowLog creation [seconds]")
 	cmd.AddColsFlag(allFlowLogCols)

--- a/commands/compute/applicationloadbalancer/flowlog/update.go
+++ b/commands/compute/applicationloadbalancer/flowlog/update.go
@@ -54,7 +54,7 @@ Required values to run command:
 	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS Cloud S3 bucket.")
+	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 bucket name of an existing IONOS CLOUD S3 bucket.")
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Application Load Balancer FlowLog update to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.LbTimeoutSeconds, "Timeout option for Request for Application Load Balancer FlowLog update [seconds]")
 	cmd.AddColsFlag(allFlowLogCols)

--- a/commands/compute/flowlog/create.go
+++ b/commands/compute/flowlog/create.go
@@ -57,7 +57,7 @@ Required values to run command:
 	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
+	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS CLOUD S3 Bucket", core.RequiredFlagOption())
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for Request for FlowLog creation to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for FlowLog creation [seconds]")
 

--- a/commands/compute/natgateway/flowlog/create.go
+++ b/commands/compute/natgateway/flowlog/create.go
@@ -49,7 +49,7 @@ Required values to run command:
 	_ = create.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
+	create.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS CLOUD S3 Bucket", core.RequiredFlagOption())
 	create.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway FlowLog creation to be executed")
 	create.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway FlowLog creation [seconds]")
 	create.AddColsFlag(allCols)

--- a/commands/compute/natgateway/flowlog/update.go
+++ b/commands/compute/natgateway/flowlog/update.go
@@ -54,7 +54,7 @@ Required values to run command:
 	_ = update.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	update.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket")
+	update.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS CLOUD S3 Bucket")
 	update.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for NAT Gateway FlowLog update to be executed")
 	update.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, constants.DefaultTimeoutSeconds, "Timeout option for Request for NAT Gateway FlowLog update [seconds]")
 	update.AddColsFlag(allCols)

--- a/commands/compute/networkloadbalancer/flowlog/create.go
+++ b/commands/compute/networkloadbalancer/flowlog/create.go
@@ -49,7 +49,7 @@ Required values to run command:
 	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket", core.RequiredFlagOption())
+	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS CLOUD S3 Bucket", core.RequiredFlagOption())
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer FlowLog creation to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer FlowLog creation [seconds]")
 	cmd.AddColsFlag(allCols)

--- a/commands/compute/networkloadbalancer/flowlog/update.go
+++ b/commands/compute/networkloadbalancer/flowlog/update.go
@@ -54,7 +54,7 @@ Required values to run command:
 	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgDirection, func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"BIDIRECTIONAL", "INGRESS", "EGRESS"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS Cloud S3 Bucket")
+	cmd.AddStringFlag(cloudapiv6.ArgS3Bucket, cloudapiv6.ArgS3BucketShort, "", "S3 Bucket name of an existing IONOS CLOUD S3 Bucket")
 	cmd.AddBoolFlag(constants.ArgWaitForRequest, constants.ArgWaitForRequestShort, constants.DefaultWait, "Wait for the Request for Network Load Balancer FlowLog update to be executed")
 	cmd.AddIntFlag(constants.ArgTimeout, constants.ArgTimeoutShort, cloudapiv6.NlbTimeoutSeconds, "Timeout option for Request for Network Load Balancer FlowLog update [seconds]")
 	cmd.AddColsFlag(allCols)

--- a/commands/dbaas/mongo/mongo.go
+++ b/commands/dbaas/mongo/mongo.go
@@ -24,7 +24,7 @@ func DBaaSMongoCmd() *core.Command {
 			Aliases: append(deprecatedAliases, "mongodb", "mg"),
 			Short:   "DBaaS Mongo Operations",
 			Long: `DBaaS Mongo Operations. Wiki: https://docs.ionos.com/cloud/managed-services/database-as-a-service/mongodb
-With IONOS Cloud Database as a Service (DBaaS) MongoDB, you can quickly set up and manage MongoDB database clusters. It is an open-source, NoSQL database solution that does not require a relational Database Management System (DBMS). The feature offers flexible data schemas, managed MongoDB solution with deployment and monitoring of your databases. To cater to your workload use cases, IONOS provides MongoDB editions such as Playground, Business, and Enterprise models.`,
+With IONOS CLOUD Database as a Service (DBaaS) MongoDB, you can quickly set up and manage MongoDB database clusters. It is an open-source, NoSQL database solution that does not require a relational Database Management System (DBMS). The feature offers flexible data schemas, managed MongoDB solution with deployment and monitoring of your databases. To cater to your workload use cases, IONOS provides MongoDB editions such as Playground, Business, and Enterprise models.`,
 			TraverseChildren: true,
 		},
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -35,8 +35,8 @@ var (
 	rootCmd = &core.Command{
 		Command: &cobra.Command{
 			Use:              "ionosctl",
-			Short:            "IONOS Cloud CLI",
-			Long:             "IonosCTL is a command-line interface for the Ionos Cloud API.",
+			Short:            "IONOS CLOUD CLI",
+			Long:             "IonosCTL is a command-line interface for the IONOS CLOUD API.",
 			TraverseChildren: true,
 		},
 	}

--- a/commands/version.go
+++ b/commands/version.go
@@ -48,7 +48,7 @@ func RunVersion(c *core.CommandConfig) error {
 
 	if viper.GetBool(core.GetFlagName(c.NS, constants.ArgUpdates)) {
 		/*
-			Latest Github Release for IONOS Cloud CLI
+			Latest Github Release for IONOS CLOUD CLI
 		*/
 		latestGhRelease, err := getGithubLatestRelease(latestGhApiReleaseUrl)
 		if err != nil {

--- a/commands/vpn/ipsec/tunnel/create.go
+++ b/commands/vpn/ipsec/tunnel/create.go
@@ -81,7 +81,7 @@ func Create() *core.Command {
 	cmd.AddSetFlag(constants.FlagESPIntegrityAlgorithm, "", "", []string{"SHA256", "SHA384", "SHA512", "AES-XCBC"}, "The integrity algorithm to use for IPSec Encryption.")
 	cmd.AddInt32Flag(constants.FlagESPLifetime, "", 0, "The phase lifetime in seconds")
 
-	cmd.AddStringSliceFlag(constants.FlagCloudNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Left\" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
+	cmd.AddStringSliceFlag(constants.FlagCloudNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Left\" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS CLOUD LAN. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
 	cmd.AddStringSliceFlag(constants.FlagPeerNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Right\" side that are allowed to connect to the IPSec tunnel. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
 
 	cmd.Command.SilenceUsage = true

--- a/commands/vpn/ipsec/tunnel/update.go
+++ b/commands/vpn/ipsec/tunnel/update.go
@@ -67,7 +67,7 @@ func Update() *core.Command {
 	cmd.AddSetFlag(constants.FlagESPIntegrityAlgorithm, "", "", []string{"SHA256", "SHA384", "SHA512", "AES-XCBC"}, "The integrity algorithm to use for IPSec Encryption.")
 	cmd.AddInt32Flag(constants.FlagESPLifetime, "", 0, "The phase lifetime in seconds")
 
-	cmd.AddStringSliceFlag(constants.FlagCloudNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Left\" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
+	cmd.AddStringSliceFlag(constants.FlagCloudNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Left\" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS CLOUD LAN. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
 	cmd.AddStringSliceFlag(constants.FlagPeerNetworkCIDRs, "", []string{}, "The network CIDRs on the \"Right\" side that are allowed to connect to the IPSec tunnel. Specify \"0.0.0.0/0\" or \"::/0\" for all addresses.")
 
 	cmd.Command.SilenceUsage = true

--- a/docs/subcommands/Application-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/create.md
@@ -65,7 +65,7 @@ Required values to run command:
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
       --query string                        JMESPath query string to filter the output
   -q, --quiet                               Quiet output
-  -b, --s3bucket string                     S3 bucket name of an existing IONOS Cloud S3 bucket. (required)
+  -b, --s3bucket string                     S3 bucket name of an existing IONOS CLOUD S3 bucket. (required)
   -t, --timeout int                         Timeout option for Request for Application Load Balancer FlowLog creation [seconds] (default 300)
   -v, --verbose count                       Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request                    Wait for the Request for Application Load Balancer FlowLog creation to be executed

--- a/docs/subcommands/Application-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Application-Load-Balancer/flowlog/update.md
@@ -66,7 +66,7 @@ Required values to run command:
   -o, --output string                       Desired output format [text|json|api-json] (default "text")
       --query string                        JMESPath query string to filter the output
   -q, --quiet                               Quiet output
-  -b, --s3bucket string                     S3 bucket name of an existing IONOS Cloud S3 bucket.
+  -b, --s3bucket string                     S3 bucket name of an existing IONOS CLOUD S3 bucket.
   -t, --timeout int                         Timeout option for Request for Application Load Balancer FlowLog update [seconds] (default 300)
   -v, --verbose count                       Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request                    Wait for the Request for Application Load Balancer FlowLog update to be executed

--- a/docs/subcommands/CLI Setup/login.md
+++ b/docs/subcommands/CLI Setup/login.md
@@ -27,7 +27,7 @@ If using '--example', this command prints the config to stdout without any authe
 You can filter by version (--filter-version), whitelist (--whitelist) or blacklist (--blacklist) specific APIs,
 and customize the names of the APIs in the config file using --custom-names.
 
-There are three ways you can authenticate with the IONOS Cloud APIs:
+There are three ways you can authenticate with the IONOS CLOUD APIs:
   1. Interactive mode: Prompts for username and password, and generates a token that will be saved in the config file.
   2. Use the '--user' and '--password' flags: Used to generate a token that will be saved in the config file.
   3. Use the '--token' flag: Provide an authentication token.

--- a/docs/subcommands/Compute Engine/flowlog/create.md
+++ b/docs/subcommands/Compute Engine/flowlog/create.md
@@ -62,7 +62,7 @@ Required values to run command:
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --query string           JMESPath query string to filter the output
   -q, --quiet                  Quiet output
-  -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)
+  -b, --s3bucket string        S3 Bucket name of an existing IONOS CLOUD S3 Bucket (required)
       --server-id string       The unique Server Id (required)
   -t, --timeout int            Timeout option for Request for FlowLog creation [seconds] (default 60)
   -v, --verbose count          Increase verbosity level [-v, -vv, -vvv]

--- a/docs/subcommands/NAT-Gateway/flowlog/create.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/create.md
@@ -65,7 +65,7 @@ Required values to run command:
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --query string           JMESPath query string to filter the output
   -q, --quiet                  Quiet output
-  -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)
+  -b, --s3bucket string        S3 Bucket name of an existing IONOS CLOUD S3 Bucket (required)
   -t, --timeout int            Timeout option for Request for NAT Gateway FlowLog creation [seconds] (default 60)
   -v, --verbose count          Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request       Wait for the Request for NAT Gateway FlowLog creation to be executed

--- a/docs/subcommands/NAT-Gateway/flowlog/update.md
+++ b/docs/subcommands/NAT-Gateway/flowlog/update.md
@@ -66,7 +66,7 @@ Required values to run command:
   -o, --output string          Desired output format [text|json|api-json] (default "text")
       --query string           JMESPath query string to filter the output
   -q, --quiet                  Quiet output
-  -b, --s3bucket string        S3 Bucket name of an existing IONOS Cloud S3 Bucket
+  -b, --s3bucket string        S3 Bucket name of an existing IONOS CLOUD S3 Bucket
   -t, --timeout int            Timeout option for Request for NAT Gateway FlowLog update [seconds] (default 60)
   -v, --verbose count          Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request       Wait for the Request for NAT Gateway FlowLog update to be executed

--- a/docs/subcommands/Network-Load-Balancer/flowlog/create.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/create.md
@@ -65,7 +65,7 @@ Required values to run command:
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
       --query string                    JMESPath query string to filter the output
   -q, --quiet                           Quiet output
-  -b, --s3bucket string                 S3 Bucket name of an existing IONOS Cloud S3 Bucket (required)
+  -b, --s3bucket string                 S3 Bucket name of an existing IONOS CLOUD S3 Bucket (required)
   -t, --timeout int                     Timeout option for Request for Network Load Balancer FlowLog creation [seconds] (default 300)
   -v, --verbose count                   Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request                Wait for the Request for Network Load Balancer FlowLog creation to be executed

--- a/docs/subcommands/Network-Load-Balancer/flowlog/update.md
+++ b/docs/subcommands/Network-Load-Balancer/flowlog/update.md
@@ -66,7 +66,7 @@ Required values to run command:
   -o, --output string                   Desired output format [text|json|api-json] (default "text")
       --query string                    JMESPath query string to filter the output
   -q, --quiet                           Quiet output
-  -b, --s3bucket string                 S3 Bucket name of an existing IONOS Cloud S3 Bucket
+  -b, --s3bucket string                 S3 Bucket name of an existing IONOS CLOUD S3 Bucket
   -t, --timeout int                     Timeout option for Request for Network Load Balancer FlowLog update [seconds] (default 300)
   -v, --verbose count                   Increase verbosity level [-v, -vv, -vvv]
   -w, --wait-for-request                Wait for the Request for Network Load Balancer FlowLog update to be executed

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
@@ -33,7 +33,7 @@ Create IPSec tunnels
 ```text
   -u, --api-url string                    Override default host URL. If contains placeholder, location will be embedded. Preferred over the config file override 'vpn' and env var 'IONOS_API_URL' (default "https://vpn.%s.ionos.com")
       --auth-method string                The authentication method for the IPSec tunnel. Valid values are PSK or RSA (required)
-      --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
+      --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS CLOUD LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
       --cols strings                      Set of columns to be printed on output 
                                           Available columns: [ID Name Description RemoteHost AuthMethod PSKKey IKEDiffieHellmanGroup IKEEncryptionAlgorithm IKEIntegrityAlgorithm IKELifetime ESPDiffieHellmanGroup ESPEncryptionAlgorithm ESPIntegrityAlgorithm ESPLifetime CloudNetworkCIDRs PeerNetworkCIDRs Status StatusMessage]
   -c, --config string                     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
@@ -33,7 +33,7 @@ Update a IPSec Tunnel
 ```text
   -u, --api-url string                    Override default host URL. If contains placeholder, location will be embedded. Preferred over the config file override 'vpn' and env var 'IONOS_API_URL' (default "https://vpn.%s.ionos.com")
       --auth-method string                The authentication method for the IPSec tunnel. Valid values are PSK or RSA (required)
-      --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS Cloud LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
+      --cloud-network-cidrs strings       The network CIDRs on the "Left" side that are allowed to connect to the IPSec tunnel, i.e the CIDRs within your IONOS CLOUD LAN. Specify "0.0.0.0/0" or "::/0" for all addresses.
       --cols strings                      Set of columns to be printed on output 
                                           Available columns: [ID Name Description RemoteHost AuthMethod PSKKey IKEDiffieHellmanGroup IKEEncryptionAlgorithm IKEIntegrityAlgorithm IKELifetime ESPDiffieHellmanGroup ESPEncryptionAlgorithm ESPIntegrityAlgorithm ESPLifetime CloudNetworkCIDRs PeerNetworkCIDRs Status StatusMessage]
   -c, --config string                     Configuration file used for authentication (default "$XDG_CONFIG_HOME/ionosctl/config.yaml")

--- a/internal/client/filter_keys.go
+++ b/internal/client/filter_keys.go
@@ -14,7 +14,7 @@ var (
 )
 
 // normalizeFilterKey maps any-cased filter key to the correct camelCase form
-// expected by the IONOS Cloud API. If the key is unknown, it is returned as-is.
+// expected by the IONOS CLOUD API. If the key is unknown, it is returned as-is.
 // E.g. "IMaGeTYpE" → "imageType", "imagetype" → "imageType", "imageType" → "imageType"
 func normalizeFilterKey(key string) string {
 	filterKeyOnce.Do(func() {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,8 @@
 name: ionosctl # registered name
-summary: IONOS Cloud CLI tool.
+summary: IONOS CLOUD CLI tool.
 base: core20
 description: |
-  The IONOS Cloud CLI (ionosctl) gives the ability to manage IONOS Cloud infrastructure directly from Command Line.
+  The IONOS CLOUD CLI (ionosctl) gives the ability to manage IONOS CLOUD infrastructure directly from Command Line.
 
 adopt-info: ionosctl
 grade: stable


### PR DESCRIPTION
## Summary

Brand-alignment pass per IONOS brand-team guidance: standardise prose references to the all-caps **"IONOS CLOUD"** form.

- **Source changes (18 files, 22 prose occurrences):** CLI help text, godoc comments, `.goreleaser.yml` package descriptions, `snap/snapcraft.yaml`, `.github/ISSUE_TEMPLATE/config.yml`, root `Short`/`Long` strings.
- **Regenerated autogenerated docs (10 files):** `make docs` output under `docs/subcommands/` now reflects the new brand strings.
- **Out of scope (intentionally untouched):**
  - `README.md` / `docs/README.md` (doc-pipeline-managed separately).
  - All identifiers: `github.com/ionos-cloud/...` import paths, `IONOS_*` env vars, the `IonosCTL` CLI product name, Homebrew tap / Scoop bucket names, logo asset filename.
  - Standalone `IONOS <product>` references (`IONOS S3`, `IONOS FTP`, etc.) — those name distinct products, not the corporate brand.

## Verification

| Check | Result |
|---|---|
| ``rg '\bIONOS Cloud\b\|\bIonos Cloud\b'`` excluding `.md` | 0 matches |
| ``rg 'IONOS CLOUD IONOS\|IONOS CLOUD Cloud\|CLOUD CLOUD'`` | 0 (no collapse-duplications) |
| `go build ./...` | passes |
| `go vet ./commands/... ./internal/...` | only pre-existing unrelated warnings |
| `make docs` | regenerated cleanly |
| CHANGELOG | one new entry under `[v6.10.1]` → `### Changed` |

## Test plan

- [ ] CI green
- [ ] Spot-check `ionosctl --help`, `ionosctl version`, and the `flowlog --s3bucket` help strings in a local build