### PR TITLE
feat: On regional APIs, list from all locations by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: Install FTPS test dependencies
-        run: pip install --only-binary :all: 'pyftpdlib==1.5.10' 'pyOpenSSL==26.2.0'
+        # pyftpdlib is pure-Python sdist-only (no wheel); --no-binary overrides --only-binary for it
+        run: pip install --only-binary=:all: --no-binary=pyftpdlib 'pyftpdlib==1.5.10' 'pyOpenSSL==26.2.0'
         if: matrix.os == 'ubuntu-latest'
 
       - name: Check code format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed
 ## [v6.10.2] - June 2026
 
 ### Added
-- **Regional API list from all locations**: List commands for multi-location regional APIs now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations (top-level `items` preserved); `-o api-json` returns an array of per-location responses. Single-location APIs (DNS, CDN, Certificate Manager) are unchanged — no `Location` column and identical `-o json`/`-o api-json` output as before.
-- **Multi-location tab completion**: Tab completion for regional resource IDs (e.g. `--cluster-id`, `--gateway-id`) now shows resources from all locations with location hints, when `--location` is not set.
-- **Explicit `--location` for location-scoped operations**: On multi-location regional APIs (Kafka, VPN, Logging, Monitoring, MariaDB, InMemoryDB, PostgreSQL), single-location commands (create/get/update/delete and single-parent list branches, e.g. `kafka topic list --cluster-id`, `logging-service logs list --pipeline-id`) now require `--location`, erroring with the valid locations instead of silently defaulting to the first one and returning a confusing `404 Not Found` when the resource lives elsewhere. Single-location APIs (DNS, CDN, Certificate Manager) are unaffected and still default automatically.
+- List resources from all locations by default on regional APIs (Kafka, VPN, Logging, Monitoring, DBaaS). Output shows a `Location` column, and JSON items include a `location` field. Use `--location` to list a single location.
+- Tab completion for regional resource IDs (e.g. `--cluster-id`) now shows resources from all locations.
+- `--location` is now required for create, get, update, and delete on regional APIs with more than one location. Previously these defaulted to the first location and returned a 404 if the resource was elsewhere.
+- `delete --all` on regional APIs now deletes from all locations by default, matching `list`. Previously it only deleted from the first location. Use `--location` to limit it to one location.
 
 ### Fixed
 - Added the `LicenceType` column to `compute snapshot list` output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed
 ## [v6.10.2] - June 2026
 
 ### Added
-- List resources from all locations by default on regional APIs (Kafka, VPN, Logging, Monitoring, DBaaS). Output shows a `Location` column, and JSON items include a `location` field. Use `--location` to list a single location.
+- List resources from all locations by default on regional APIs (DNS, CDN, Certificate Manager, Kafka, VPN, Logging, Monitoring, DBaaS). Output shows a `Location` column, and `-o json`/`-o api-json` items include a `location` field. Use `--location` to list a single location; the output shape is the same either way.
 - Tab completion for regional resource IDs (e.g. `--cluster-id`) now shows resources from all locations.
 - `--location` is now required for create, get, update, and delete on regional APIs with more than one location. Previously these defaulted to the first location and returned a 404 if the resource was elsewhere.
 - `delete --all` on regional APIs now deletes from all locations by default, matching `list`. Previously it only deleted from the first location. Use `--location` to limit it to one location.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed
 ## [v6.10.2] - June 2026
 
 ### Added
-- **Regional API list from all locations**: List commands for regional APIs (DNS, Kafka, VPN, DBaaS, Monitoring, Logging, CDN, CertManager) now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations; `-o api-json` returns an array of per-location responses.
+- **Regional API list from all locations**: List commands for regional APIs now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations; `-o api-json` returns an array of per-location responses.
 - **Multi-location tab completion**: Tab completion for regional resource IDs (e.g. `--cluster-id`, `--gateway-id`) now shows resources from all locations with location hints, when `--location` is not set.
 
 ## [v6.10.1] – May 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed**, **Deprecated**, **Fixed**, **Removed**, **Known Limitations**, **Dependencies**. Only user-visible changes listed. Older entries may use non-standard section names.
 
-## [Unreleased]
-
-### Fixed
-- Added the `LicenceType` column to `compute snapshot list` output.
-
 ## [v6.10.2] - June 2026
 
 ### Added
 - **Regional API list from all locations**: List commands for regional APIs now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations; `-o api-json` returns an array of per-location responses.
 - **Multi-location tab completion**: Tab completion for regional resource IDs (e.g. `--cluster-id`, `--gateway-id`) now shows resources from all locations with location hints, when `--location` is not set.
+
+### Fixed
+- Added the `LicenceType` column to `compute snapshot list` output.
 
 ## [v6.10.1] – May 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed
 ## [v6.10.2] - June 2026
 
 ### Added
-- **Regional API list from all locations**: List commands for regional APIs now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations; `-o api-json` returns an array of per-location responses.
+- **Regional API list from all locations**: List commands for multi-location regional APIs now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations (top-level `items` preserved); `-o api-json` returns an array of per-location responses. Single-location APIs (DNS, CDN, Certificate Manager) are unchanged — no `Location` column and identical `-o json`/`-o api-json` output as before.
 - **Multi-location tab completion**: Tab completion for regional resource IDs (e.g. `--cluster-id`, `--gateway-id`) now shows resources from all locations with location hints, when `--location` is not set.
+- **Explicit `--location` for location-scoped operations**: On multi-location regional APIs (Kafka, VPN, Logging, Monitoring, MariaDB, InMemoryDB, PostgreSQL), single-location commands (create/get/update/delete and single-parent list branches, e.g. `kafka topic list --cluster-id`, `logging-service logs list --pipeline-id`) now require `--location`, erroring with the valid locations instead of silently defaulting to the first one and returning a confusing `404 Not Found` when the resource lives elsewhere. Single-location APIs (DNS, CDN, Certificate Manager) are unaffected and still default automatically.
 
 ### Fixed
 - Added the `LicenceType` column to `compute snapshot list` output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
+Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed**, **Deprecated**, **Fixed**, **Removed**, **Known Limitations**, **Dependencies**. Only user-visible changes listed. Older entries may use non-standard section names.
+
 ## [Unreleased]
 
 ### Fixed
 - Added the `LicenceType` column to `compute snapshot list` output.
+
+## [v6.10.2] - June 2026
+
+### Added
+- **Regional API list from all locations**: List commands for regional APIs (DNS, Kafka, VPN, DBaaS, Monitoring, Logging, CDN, CertManager) now query all locations by default and display a `Location` column. Use `--location` to filter to a specific location. `-o json` merges items from all locations; `-o api-json` returns an array of per-location responses.
+- **Multi-location tab completion**: Tab completion for regional resource IDs (e.g. `--cluster-id`, `--gateway-id`) now shows resources from all locations with location hints, when `--location` is not set.
 
 ## [v6.10.1] – May 2026
 

--- a/commands/cdn/distribution/list.go
+++ b/commands/cdn/distribution/list.go
@@ -2,14 +2,13 @@ package distribution
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/commands/cdn/completer"
+	cdn "github.com/ionos-cloud/sdk-go-bundle/products/cdn/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/ionos-cloud/sdk-go-bundle/products/cdn/v2"
-
-	"github.com/spf13/viper"
 )
 
 func List() *core.Command {
@@ -25,7 +24,20 @@ func List() *core.Command {
 				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {
-				return listDistributions(c)
+				return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+					cdnClient := cdn.NewAPIClient(cfg)
+					req := cdnClient.DistributionsApi.DistributionsGet(context.Background())
+
+					if fn := core.GetFlagName(c.NS, constants.FlagCDNDistributionFilterState); viper.IsSet(fn) {
+						req = req.FilterState(viper.GetString(fn))
+					}
+					if fn := core.GetFlagName(c.NS, constants.FlagCDNDistributionFilterDomain); viper.IsSet(fn) {
+						req = req.FilterDomain(viper.GetString(fn))
+					}
+
+					ls, _, err := req.Execute()
+					return ls, err
+				})
 			},
 			InitClient: true,
 		},
@@ -35,28 +47,4 @@ func List() *core.Command {
 	cmd.AddSetFlag(constants.FlagCDNDistributionFilterState, "", "", []string{"AVAILABLE", "BUSY", "FAILED", "UNKNOWN"}, "Filter used to fetch only the records that contain specified state.")
 
 	return cmd
-}
-
-func listDistributions(c *core.CommandConfig) error {
-	ls, err := completer.Distributions(
-		func(req cdn.ApiDistributionsGetRequest) (cdn.ApiDistributionsGetRequest, error) {
-			if fn := core.GetFlagName(c.NS, constants.FlagCDNDistributionFilterState); viper.IsSet(fn) {
-				req = req.FilterState(viper.GetString(fn))
-			}
-			if fn := core.GetFlagName(c.NS, constants.FlagCDNDistributionFilterDomain); viper.IsSet(fn) {
-				req = req.FilterDomain(viper.GetString(fn))
-			}
-			return req, nil
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed listing cdn distributions: %w", err)
-	}
-
-	items, ok := ls.GetItemsOk()
-	if !ok || items == nil {
-		return fmt.Errorf("could not retrieve distributions")
-	}
-
-	return c.Printer(allCols).Print(items)
 }

--- a/commands/cert/autocertificate/list.go
+++ b/commands/cert/autocertificate/list.go
@@ -2,12 +2,13 @@ package autocertificate
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	cert "github.com/ionos-cloud/sdk-go-bundle/products/cert/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/spf13/viper"
 )
 
 func AutocertificateListCmd() *core.Command {
@@ -22,18 +23,17 @@ func AutocertificateListCmd() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			req := client.Must().CertManagerClient.AutoCertificateApi.AutoCertificatesGet(context.Background())
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				certClient := cert.NewAPIClient(cfg)
+				req := certClient.AutoCertificateApi.AutoCertificatesGet(context.Background())
 
-			if fn := core.GetFlagName(c.NS, constants.FlagCommonName); viper.IsSet(fn) {
-				req = req.FilterCommonName(viper.GetString(fn))
-			}
+				if fn := core.GetFlagName(c.NS, constants.FlagCommonName); viper.IsSet(fn) {
+					req = req.FilterCommonName(viper.GetString(fn))
+				}
 
-			ls, _, err := req.Execute()
-			if err != nil {
-				return fmt.Errorf("failed listing the AutoCertificates: %w", err)
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+				ls, _, err := req.Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/cert/certificate/list.go
+++ b/commands/cert/certificate/list.go
@@ -3,7 +3,9 @@ package certificate
 import (
 	"context"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	cert "github.com/ionos-cloud/sdk-go-bundle/products/cert/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 )
 
@@ -27,10 +29,9 @@ func CertListCmd() *core.Command {
 func CmdList(c *core.CommandConfig) error {
 	c.Verbose("Getting Certificates...")
 
-	certs, _, err := client.Must().CertManagerClient.CertificateApi.CertificatesGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	return c.Printer(allCols).Prefix("items").Print(certs)
+	return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+		certClient := cert.NewAPIClient(cfg)
+		ls, _, err := certClient.CertificateApi.CertificatesGet(context.Background()).Execute()
+		return ls, err
+	})
 }

--- a/commands/cert/provider/list.go
+++ b/commands/cert/provider/list.go
@@ -2,9 +2,10 @@ package provider
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	cert "github.com/ionos-cloud/sdk-go-bundle/products/cert/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 )
 
@@ -20,14 +21,11 @@ func ProviderListCmd() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			req := client.Must().CertManagerClient.ProviderApi.ProvidersGet(context.Background())
-
-			ls, _, err := req.Execute()
-			if err != nil {
-				return fmt.Errorf("failed listing the Providers: %w", err)
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				certClient := cert.NewAPIClient(cfg)
+				ls, _, err := certClient.ProviderApi.ProvidersGet(context.Background()).Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/dbaas/inmemorydb/replicaset/create.go
+++ b/commands/dbaas/inmemorydb/replicaset/create.go
@@ -59,6 +59,9 @@ volatile-ttl: The key with the nearest time to live will be removed first, but o
 				constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/dbaas/inmemorydb/replicaset/create.go
+++ b/commands/dbaas/inmemorydb/replicaset/create.go
@@ -52,17 +52,11 @@ volatile-ttl: The key with the nearest time to live will be removed first, but o
 			constants.FlagReplicas, constants.FlagCores, constants.FlagRam, constants.ArgUser, constants.ArgPassword,
 			constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS,
+			return c.CheckRequiredFlagsAndLocation(
 				constants.FlagName, constants.FlagReplicas,
 				constants.FlagCores, constants.FlagRam,
 				constants.ArgUser, constants.ArgPassword,
-				constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+				constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := inmemorydb.ReplicaSet{}

--- a/commands/dbaas/inmemorydb/replicaset/delete.go
+++ b/commands/dbaas/inmemorydb/replicaset/delete.go
@@ -26,11 +26,17 @@ ionosctl dbaas inmemorydb replicaset delete %s`,
 			core.FlagsUsage(constants.FlagReplicasetID, constants.ArgForce),
 			core.FlagsUsage(constants.ArgAll, constants.ArgForce)),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(
+			if err := core.CheckRequiredFlagsSets(
 				c.Command, c.NS,
 				[]string{constants.ArgAll},
 				[]string{constants.FlagReplicasetID},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)) {

--- a/commands/dbaas/inmemorydb/replicaset/delete.go
+++ b/commands/dbaas/inmemorydb/replicaset/delete.go
@@ -34,14 +34,14 @@ ionosctl dbaas inmemorydb replicaset delete %s`,
 			); err != nil {
 				return err
 			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)) {
 				return deleteAll(c)
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
 			}
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagReplicasetID))
 			return deleteSingle(c, id)

--- a/commands/dbaas/inmemorydb/replicaset/delete.go
+++ b/commands/dbaas/inmemorydb/replicaset/delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/dbaas/inmemorydb/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -99,15 +100,41 @@ func deleteSingle(c *core.CommandConfig, id string) error {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	list, _, err := client.Must().InMemoryDBClient.
-		ReplicaSetApi.
-		ReplicasetsGet(c.Context).
-		Execute()
-	if err != nil {
-		return fmt.Errorf("failed listing replica-sets: %w", err)
-	}
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		apiClient := inmemorydb.NewAPIClient(cfg)
 
-	return functional.ApplyAndAggregateErrors(list.GetItems(), func(rs inmemorydb.ReplicaSetRead) error {
-		return deleteSingle(c, rs.Id)
+		list, _, err := apiClient.ReplicaSetApi.
+			ReplicasetsGet(context.Background()).
+			Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing replica-sets in location %s: %w", location, err)
+		}
+
+		return functional.ApplyAndAggregateErrors(list.GetItems(), func(rs inmemorydb.ReplicaSetRead) error {
+			prompt := fmt.Sprintf(
+				"Are you sure you want to delete replica-set '%s' (dns name: '%s', replicas: %d, location: %s)",
+				rs.Properties.DisplayName,
+				rs.Metadata.DnsName,
+				rs.Properties.Replicas,
+				location,
+			)
+			yes := confirm.FAsk(
+				c.Command.Command.InOrStdin(),
+				prompt,
+				viper.GetBool(constants.ArgForce),
+			)
+			if !yes {
+				return nil
+			}
+
+			_, err := apiClient.ReplicaSetApi.
+				ReplicasetsDelete(context.Background(), rs.Id).
+				Execute()
+			if err != nil {
+				return fmt.Errorf("failed deleting replicaset %q in location %s: %w", rs.Id, location, err)
+			}
+
+			return nil
+		})
 	})
 }

--- a/commands/dbaas/inmemorydb/replicaset/get.go
+++ b/commands/dbaas/inmemorydb/replicaset/get.go
@@ -20,16 +20,9 @@ func Get() *core.Command {
 		ShortDesc: "Get an In-Memory DB Replica Set",
 		Example:   fmt.Sprintf("ionosctl dbaas inmemorydb replicaset get %s", core.FlagsUsage(constants.FlagReplicasetID)),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(
-				c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				[]string{constants.FlagReplicasetID},
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagReplicasetID))

--- a/commands/dbaas/inmemorydb/replicaset/get.go
+++ b/commands/dbaas/inmemorydb/replicaset/get.go
@@ -20,10 +20,16 @@ func Get() *core.Command {
 		ShortDesc: "Get an In-Memory DB Replica Set",
 		Example:   fmt.Sprintf("ionosctl dbaas inmemorydb replicaset get %s", core.FlagsUsage(constants.FlagReplicasetID)),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(
+			if err := core.CheckRequiredFlagsSets(
 				c.Command, c.NS,
 				[]string{constants.FlagReplicasetID},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagReplicasetID))

--- a/commands/dbaas/inmemorydb/replicaset/list.go
+++ b/commands/dbaas/inmemorydb/replicaset/list.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/inmemorydb/utils"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/ionos-cloud/sdk-go-bundle/products/dbaas/inmemorydb/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 )
 
 func List() *core.Command {
@@ -23,13 +23,12 @@ func List() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			ls, _, err := client.Must().InMemoryDBClient.ReplicaSetApi.
-				ReplicasetsGet(context.Background()).Execute()
-			if err != nil {
-				return err
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				apiClient := inmemorydb.NewAPIClient(cfg)
+				ls, _, err := apiClient.ReplicaSetApi.
+					ReplicasetsGet(context.Background()).Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/dbaas/inmemorydb/replicaset/update.go
+++ b/commands/dbaas/inmemorydb/replicaset/update.go
@@ -26,11 +26,7 @@ func Update() *core.Command {
 		Aliases:   []string{"u"},
 		ShortDesc: "Partially modify a replicaset's properties. NOTE: Passwords cannot be modified! This command uses a combination of GET and PUT to simulate a PATCH operation",
 		Example:   fmt.Sprintf("ionosctl dbaas inmemorydb replicaset update %s", core.FlagsUsage(constants.FlagReplicasetID, constants.FlagName, constants.FlagReplicas, constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)), PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS,
-				constants.FlagReplicasetID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
+			if err := c.CheckRequiredFlagsAndLocation(constants.FlagReplicasetID); err != nil {
 				return err
 			}
 

--- a/commands/dbaas/inmemorydb/replicaset/update.go
+++ b/commands/dbaas/inmemorydb/replicaset/update.go
@@ -30,6 +30,9 @@ func Update() *core.Command {
 				constants.FlagReplicasetID); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 
 			// if viper.IsSet(core.GetFlagName(c.NS, constants.ArgPassword)) {
 			// 	return fmt.Errorf("changing passwords is not yet supported")

--- a/commands/dbaas/inmemorydb/snapshot/list.go
+++ b/commands/dbaas/inmemorydb/snapshot/list.go
@@ -3,8 +3,9 @@ package snapshot
 import (
 	"context"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	"github.com/ionos-cloud/sdk-go-bundle/products/dbaas/inmemorydb/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 )
 
 func List() *core.Command {
@@ -20,13 +21,12 @@ func List() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			ls, _, err := client.Must().InMemoryDBClient.SnapshotApi.
-				SnapshotsGet(context.Background()).Execute()
-			if err != nil {
-				return err
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				apiClient := inmemorydb.NewAPIClient(cfg)
+				ls, _, err := apiClient.SnapshotApi.
+					SnapshotsGet(context.Background()).Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/dbaas/inmemorydb/snapshot/restore/create.go
+++ b/commands/dbaas/inmemorydb/snapshot/restore/create.go
@@ -22,7 +22,13 @@ func Create() *core.Command {
 		ShortDesc: "Create an In-Memory DB Restore",
 		Example:   "ionosctl dbaas inmemorydb restore create " + core.FlagsUsage(constants.FlagReplicasetID, constants.FlagSnapshotId, constants.FlagName, constants.FlagDescription),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagReplicasetID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagReplicasetID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := inmemorydb.Restore{}

--- a/commands/dbaas/inmemorydb/snapshot/restore/create.go
+++ b/commands/dbaas/inmemorydb/snapshot/restore/create.go
@@ -22,13 +22,7 @@ func Create() *core.Command {
 		ShortDesc: "Create an In-Memory DB Restore",
 		Example:   "ionosctl dbaas inmemorydb restore create " + core.FlagsUsage(constants.FlagReplicasetID, constants.FlagSnapshotId, constants.FlagName, constants.FlagDescription),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagReplicasetID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagReplicasetID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := inmemorydb.Restore{}

--- a/commands/dbaas/inmemorydb/snapshot/restore/list.go
+++ b/commands/dbaas/inmemorydb/snapshot/restore/list.go
@@ -20,13 +20,7 @@ func List() *core.Command {
 		ShortDesc: "List In-Memory DB Restores",
 		Example:   "ionosctl dbaas inmemorydb restore list",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagSnapshotId); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagSnapshotId)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, _, err := client.Must().InMemoryDBClient.RestoreApi.

--- a/commands/dbaas/inmemorydb/snapshot/restore/list.go
+++ b/commands/dbaas/inmemorydb/snapshot/restore/list.go
@@ -20,7 +20,13 @@ func List() *core.Command {
 		ShortDesc: "List In-Memory DB Restores",
 		Example:   "ionosctl dbaas inmemorydb restore list",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagSnapshotId)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagSnapshotId); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, _, err := client.Must().InMemoryDBClient.RestoreApi.

--- a/commands/dbaas/mariadb/backup/get.go
+++ b/commands/dbaas/mariadb/backup/get.go
@@ -21,13 +21,7 @@ func Get() *core.Command {
 		ShortDesc: "Get a MariaDB Backup",
 		Example:   "ionosctl dbaas mariadb backup get --backup-id BACKUP_ID",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagBackupId)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			backup, _, err := client.Must().MariaClient.BackupsApi.BackupsFindById(context.Background(),

--- a/commands/dbaas/mariadb/backup/get.go
+++ b/commands/dbaas/mariadb/backup/get.go
@@ -21,7 +21,13 @@ func Get() *core.Command {
 		ShortDesc: "Get a MariaDB Backup",
 		Example:   "ionosctl dbaas mariadb backup get --backup-id BACKUP_ID",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			backup, _, err := client.Must().MariaClient.BackupsApi.BackupsFindById(context.Background(),

--- a/commands/dbaas/mariadb/backup/list.go
+++ b/commands/dbaas/mariadb/backup/list.go
@@ -26,6 +26,9 @@ func List() *core.Command {
 			var err error
 
 			if clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)); clusterId != "" {
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
+				}
 				backups, _, err = client.Must().MariaClient.BackupsApi.ClusterBackupsGet(context.Background(), clusterId).Execute()
 			} else {
 				backups, err = Backups()

--- a/commands/dbaas/mariadb/cluster/create.go
+++ b/commands/dbaas/mariadb/cluster/create.go
@@ -32,15 +32,7 @@ func Create() *core.Command {
 		ShortDesc: "Create DBaaS MariaDB clusters",
 		Example:   fmt.Sprintf("i db mariadb cluster create %s", core.FlagsUsage(baseReqFlags...)),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			err := core.CheckRequiredFlags(c.Command, c.NS, baseReqFlags...)
-			if err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-
-			return nil
+			return c.CheckRequiredFlagsAndLocation(baseReqFlags...)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			cluster := mariadb.CreateClusterProperties{}

--- a/commands/dbaas/mariadb/cluster/create.go
+++ b/commands/dbaas/mariadb/cluster/create.go
@@ -36,6 +36,9 @@ func Create() *core.Command {
 			if err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/commands/dbaas/mariadb/cluster/delete.go
+++ b/commands/dbaas/mariadb/cluster/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/dbaas/mariadb/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -98,19 +99,27 @@ ionosctl db mar c d --all --name <name>`,
 
 func deleteAll(c *core.CommandConfig) error {
 	c.Verbose("Deleting All Clusters!")
-	xs, err := Clusters(FilterNameFlags(c))
-	if err != nil {
-		return err
-	}
 
-	return functional.ApplyAndAggregateErrors(xs.GetItems(), func(x mariadb.ClusterResponse) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), confirmStringForCluster(x), viper.GetBool(constants.ArgForce))
-		if yes {
-			_, _, delErr := client.Must().MariaClient.ClustersApi.ClustersDelete(c.Context, *x.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting cluster %s: %w", *x.Properties.DisplayName, delErr)
-			}
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		apiClient := mariadb.NewAPIClient(cfg)
+
+		req := apiClient.ClustersApi.ClustersGet(context.Background())
+		req = FilterNameFlags(c)(req)
+
+		xs, _, err := req.Execute()
+		if err != nil {
+			return fmt.Errorf("failed getting clusters: %w", err)
 		}
-		return nil
+
+		return functional.ApplyAndAggregateErrors(xs.GetItems(), func(x mariadb.ClusterResponse) error {
+			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf("%s (location: %s)", confirmStringForCluster(x), location), viper.GetBool(constants.ArgForce))
+			if yes {
+				_, _, delErr := apiClient.ClustersApi.ClustersDelete(context.Background(), *x.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting cluster %s: %w", *x.Properties.DisplayName, delErr)
+				}
+			}
+			return nil
+		})
 	})
 }

--- a/commands/dbaas/mariadb/cluster/delete.go
+++ b/commands/dbaas/mariadb/cluster/delete.go
@@ -44,14 +44,15 @@ ionosctl db mar c d --all --name <name>`,
 			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId}); err != nil {
 				return err
 			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
 				return deleteAll(c)
+			}
+
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
 			}
 
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))

--- a/commands/dbaas/mariadb/cluster/delete.go
+++ b/commands/dbaas/mariadb/cluster/delete.go
@@ -40,7 +40,13 @@ func Delete() *core.Command {
 ionosctl db mar c d --all
 ionosctl db mar c d --all --name <name>`,
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId})
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagClusterId}); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/dbaas/mariadb/cluster/get.go
+++ b/commands/dbaas/mariadb/cluster/get.go
@@ -19,10 +19,7 @@ func Get() *core.Command {
 		ShortDesc: "Get a MariaDB Cluster by ID",
 		Example:   "ionosctl dbaas mariadb cluster get --cluster-id <cluster-id>",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.Command.Command.MarkFlagRequired(constants.FlagClusterId); err != nil {
-				return err
-			}
-			return c.RequireExplicitLocation()
+			return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))

--- a/commands/dbaas/mariadb/cluster/get.go
+++ b/commands/dbaas/mariadb/cluster/get.go
@@ -19,6 +19,9 @@ func Get() *core.Command {
 		ShortDesc: "Get a MariaDB Cluster by ID",
 		Example:   "ionosctl dbaas mariadb cluster get --cluster-id <cluster-id>",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return c.Command.Command.MarkFlagRequired(constants.FlagClusterId)
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/dbaas/mariadb/cluster/get.go
+++ b/commands/dbaas/mariadb/cluster/get.go
@@ -19,10 +19,10 @@ func Get() *core.Command {
 		ShortDesc: "Get a MariaDB Cluster by ID",
 		Example:   "ionosctl dbaas mariadb cluster get --cluster-id <cluster-id>",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
+			if err := c.Command.Command.MarkFlagRequired(constants.FlagClusterId); err != nil {
 				return err
 			}
-			return c.Command.Command.MarkFlagRequired(constants.FlagClusterId)
+			return c.RequireExplicitLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))

--- a/commands/dbaas/mariadb/cluster/list.go
+++ b/commands/dbaas/mariadb/cluster/list.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	"github.com/ionos-cloud/sdk-go-bundle/products/dbaas/mariadb/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
 )
 
 func List() *core.Command {
@@ -20,12 +23,17 @@ func List() *core.Command {
 		CmdRun: func(c *core.CommandConfig) error {
 			c.Verbose("Getting Clusters...")
 
-			clusters, err := Clusters(FilterNameFlags(c))
-			if err != nil {
-				return err
-			}
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				apiClient := mariadb.NewAPIClient(cfg)
+				req := apiClient.ClustersApi.ClustersGet(context.Background())
 
-			return c.Printer(allCols).Prefix("items").Print(clusters)
+				if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
+					req = req.FilterName(viper.GetString(fn))
+				}
+
+				clusters, _, err := req.Execute()
+				return clusters, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/dbaas/mariadb/cluster/update.go
+++ b/commands/dbaas/mariadb/cluster/update.go
@@ -30,10 +30,7 @@ func Update() *core.Command {
 		Example:   "ionosctl dbaas mariadb cluster update" + core.FlagsUsage(constants.ClusterId, constants.FlagVersion),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
 			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
-			if err := c.Command.Command.MarkFlagRequired(constants.FlagClusterId); err != nil {
-				return err
-			}
-			return c.RequireExplicitLocation()
+			return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			cluster := mariadb.PatchClusterProperties{}

--- a/commands/dbaas/mariadb/cluster/update.go
+++ b/commands/dbaas/mariadb/cluster/update.go
@@ -29,11 +29,11 @@ func Update() *core.Command {
 		ShortDesc: "Update a MariaDB Cluster",
 		Example:   "ionosctl dbaas mariadb cluster update" + core.FlagsUsage(constants.ClusterId, constants.FlagVersion),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
+			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
+			if err := c.Command.Command.MarkFlagRequired(constants.FlagClusterId); err != nil {
 				return err
 			}
-			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
-			return c.Command.Command.MarkFlagRequired(constants.FlagClusterId)
+			return c.RequireExplicitLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			cluster := mariadb.PatchClusterProperties{}

--- a/commands/dbaas/mariadb/cluster/update.go
+++ b/commands/dbaas/mariadb/cluster/update.go
@@ -29,6 +29,9 @@ func Update() *core.Command {
 		ShortDesc: "Update a MariaDB Cluster",
 		Example:   "ionosctl dbaas mariadb cluster update" + core.FlagsUsage(constants.ClusterId, constants.FlagVersion),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
 			return c.Command.Command.MarkFlagRequired(constants.FlagClusterId)
 		},

--- a/commands/dbaas/postgres-v2/backup/get.go
+++ b/commands/dbaas/postgres-v2/backup/get.go
@@ -32,13 +32,7 @@ func BackupGetCmd() *core.Command {
 }
 
 func PreRunBackupId(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagBackupId)
 }
 
 func RunBackupGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/backup/get.go
+++ b/commands/dbaas/postgres-v2/backup/get.go
@@ -32,7 +32,13 @@ func BackupGetCmd() *core.Command {
 }
 
 func PreRunBackupId(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupId); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func RunBackupGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/backup/list.go
+++ b/commands/dbaas/postgres-v2/backup/list.go
@@ -35,6 +35,10 @@ func BackupListCmd() *core.Command {
 }
 
 func RunBackupList(c *core.CommandConfig) error {
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+
 	req := client.Must().PostgresClientV2.BackupsApi.BackupsGet(context.Background())
 
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagClusterId)) {

--- a/commands/dbaas/postgres-v2/backup/list.go
+++ b/commands/dbaas/postgres-v2/backup/list.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/ionos-cloud/ionosctl/v6/commands/dbaas/postgres-v2/completer"
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/ionos-cloud/ionosctl/v6/internal/printer/table"
+	psqlv2 "github.com/ionos-cloud/sdk-go-bundle/products/dbaas/psql/v3"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -35,27 +35,23 @@ func BackupListCmd() *core.Command {
 }
 
 func RunBackupList(c *core.CommandConfig) error {
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
+	// Fan out over all locations by default (like `cluster list`), so backups
+	// from every location are listed when --location is not set.
+	return c.ListAllLocations(backupCols, func(cfg *shared.Configuration) (any, error) {
+		apiClient := psqlv2.NewAPIClient(cfg)
+		req := apiClient.BackupsApi.BackupsGet(context.Background())
 
-	req := client.Must().PostgresClientV2.BackupsApi.BackupsGet(context.Background())
+		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagClusterId)) {
+			req = req.FilterClusterId(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)))
+		}
+		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagLimit)) {
+			req = req.Limit(viper.GetInt32(core.GetFlagName(c.NS, constants.FlagLimit)))
+		}
+		if viper.IsSet(core.GetFlagName(c.NS, constants.FlagOffset)) {
+			req = req.Offset(viper.GetInt32(core.GetFlagName(c.NS, constants.FlagOffset)))
+		}
 
-	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagClusterId)) {
-		req = req.FilterClusterId(viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)))
-	}
-	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagLimit)) {
-		req = req.Limit(viper.GetInt32(core.GetFlagName(c.NS, constants.FlagLimit)))
-	}
-	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagOffset)) {
-		req = req.Offset(viper.GetInt32(core.GetFlagName(c.NS, constants.FlagOffset)))
-	}
-
-	backups, _, err := req.Execute()
-	if err != nil {
-		return err
-	}
-
-	cols := viper.GetStringSlice(core.GetFlagName(c.NS, constants.ArgCols))
-	return c.Out(table.Sprint(backupCols, backups, cols, table.WithPrefix("items")))
+		backups, _, err := req.Execute()
+		return backups, err
+	})
 }

--- a/commands/dbaas/postgres-v2/backup/location/get.go
+++ b/commands/dbaas/postgres-v2/backup/location/get.go
@@ -34,13 +34,7 @@ func BackupLocationGetCmd() *core.Command {
 }
 
 func PreRunBackupLocationId(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupLocationId); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagBackupLocationId)
 }
 
 func RunBackupLocationGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/backup/location/get.go
+++ b/commands/dbaas/postgres-v2/backup/location/get.go
@@ -34,7 +34,13 @@ func BackupLocationGetCmd() *core.Command {
 }
 
 func PreRunBackupLocationId(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupLocationId)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagBackupLocationId); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func RunBackupLocationGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/cluster/create.go
+++ b/commands/dbaas/postgres-v2/cluster/create.go
@@ -106,11 +106,7 @@ Required values to run command:
 }
 
 func PreRunClusterCreate(c *core.PreCommandConfig) error {
-	err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr, constants.FlagDbUsername, constants.FlagDbPassword, constants.FlagDatabase, constants.FlagVersion)
-	if err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
+	if err := c.CheckRequiredFlagsAndLocation(constants.FlagDatacenterId, constants.FlagLanId, constants.FlagCidr, constants.FlagDbUsername, constants.FlagDbPassword, constants.FlagDatabase, constants.FlagVersion); err != nil {
 		return err
 	}
 	// Validate Flags

--- a/commands/dbaas/postgres-v2/cluster/create.go
+++ b/commands/dbaas/postgres-v2/cluster/create.go
@@ -110,6 +110,9 @@ func PreRunClusterCreate(c *core.PreCommandConfig) error {
 	if err != nil {
 		return err
 	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
 	// Validate Flags
 	cores := viper.GetInt32(core.GetFlagName(c.NS, constants.FlagCores))
 	if cores < 1 || cores > 62 {

--- a/commands/dbaas/postgres-v2/cluster/delete.go
+++ b/commands/dbaas/postgres-v2/cluster/delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	psqlv2 "github.com/ionos-cloud/sdk-go-bundle/products/dbaas/psql/v3"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -94,36 +95,35 @@ func ClusterDeleteAll(c *core.CommandConfig) error {
 		c.Verbose("Filtering based on Cluster Name: %v", viper.GetString(core.GetFlagName(c.NS, constants.FlagName)))
 	}
 
-	req := client.Must().PostgresClientV2.ClustersApi.ClustersGet(context.Background())
-	if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) && viper.GetString(fn) != "" {
-		req = req.FilterName(viper.GetString(fn))
-	}
-	if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
-		req = req.FilterState(psqlv2.PostgresClusterStates(viper.GetString(fn)))
-	}
-	clusters, _, err := req.Execute()
-	if err != nil {
-		return err
-	}
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		apiClient := psqlv2.NewAPIClient(cfg)
 
-	items := clusters.GetItems()
-	if len(items) == 0 {
-		return fmt.Errorf("no Clusters found")
-	}
-
-	return functional.ApplyAndAggregateErrors(items, func(cluster psqlv2.ClusterRead) error {
-		if !confirm.FAsk(c.Command.Command.InOrStdin(),
-			fmt.Sprintf("delete cluster %s (%s)", cluster.Id, cluster.Properties.Name),
-			viper.GetBool(constants.ArgForce)) {
-			return fmt.Errorf(confirm.UserDenied)
+		req := apiClient.ClustersApi.ClustersGet(context.Background())
+		if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) && viper.GetString(fn) != "" {
+			req = req.FilterName(viper.GetString(fn))
+		}
+		if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
+			req = req.FilterState(psqlv2.PostgresClusterStates(viper.GetString(fn)))
+		}
+		clusters, _, err := req.Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing clusters in location %s: %w", location, err)
 		}
 
-		c.Verbose("Deleting cluster: %s (%s)", cluster.Id, cluster.Properties.Name)
-		_, delErr := client.Must().PostgresClientV2.ClustersApi.ClustersDelete(context.Background(), cluster.Id).Execute()
-		if delErr != nil {
-			return fmt.Errorf("failed deleting cluster %s (%s): %w", cluster.Id, cluster.Properties.Name, delErr)
-		}
+		return functional.ApplyAndAggregateErrors(clusters.GetItems(), func(cluster psqlv2.ClusterRead) error {
+			if !confirm.FAsk(c.Command.Command.InOrStdin(),
+				fmt.Sprintf("delete cluster %s (%s) (location: %s)", cluster.Id, cluster.Properties.Name, location),
+				viper.GetBool(constants.ArgForce)) {
+				return fmt.Errorf(confirm.UserDenied)
+			}
 
-		return nil
+			c.Verbose("Deleting cluster: %s (%s)", cluster.Id, cluster.Properties.Name)
+			_, delErr := apiClient.ClustersApi.ClustersDelete(context.Background(), cluster.Id).Execute()
+			if delErr != nil {
+				return fmt.Errorf("failed deleting cluster %s (%s): %w", cluster.Id, cluster.Properties.Name, delErr)
+			}
+
+			return nil
+		})
 	})
 }

--- a/commands/dbaas/postgres-v2/cluster/delete.go
+++ b/commands/dbaas/postgres-v2/cluster/delete.go
@@ -53,6 +53,9 @@ func PreRunClusterDelete(c *core.PreCommandConfig) error {
 	if err != nil {
 		return err
 	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
 	// Validate Flags
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagName)) && !viper.IsSet(core.GetFlagName(c.NS, constants.ArgAll)) {
 		return errors.New("error: --name flag can only be used with the --all flag")

--- a/commands/dbaas/postgres-v2/cluster/delete.go
+++ b/commands/dbaas/postgres-v2/cluster/delete.go
@@ -54,9 +54,6 @@ func PreRunClusterDelete(c *core.PreCommandConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
 	// Validate Flags
 	if viper.IsSet(core.GetFlagName(c.NS, constants.FlagName)) && !viper.IsSet(core.GetFlagName(c.NS, constants.ArgAll)) {
 		return errors.New("error: --name flag can only be used with the --all flag")
@@ -73,6 +70,10 @@ func RunClusterDelete(c *core.CommandConfig) error {
 			return err
 		}
 		return nil
+	}
+
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
 	}
 
 	clusterId := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))
@@ -111,10 +112,12 @@ func ClusterDeleteAll(c *core.CommandConfig) error {
 		}
 
 		return functional.ApplyAndAggregateErrors(clusters.GetItems(), func(cluster psqlv2.ClusterRead) error {
+			// Skip (not fail) on decline, matching the other delete --all
+			// commands: a "no" for one cluster must not abort the whole run.
 			if !confirm.FAsk(c.Command.Command.InOrStdin(),
 				fmt.Sprintf("delete cluster %s (%s) (location: %s)", cluster.Id, cluster.Properties.Name, location),
 				viper.GetBool(constants.ArgForce)) {
-				return fmt.Errorf(confirm.UserDenied)
+				return nil
 			}
 
 			c.Verbose("Deleting cluster: %s (%s)", cluster.Id, cluster.Properties.Name)

--- a/commands/dbaas/postgres-v2/cluster/get.go
+++ b/commands/dbaas/postgres-v2/cluster/get.go
@@ -34,7 +34,13 @@ func ClusterGetCmd() *core.Command {
 }
 
 func PreRunClusterId(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func RunClusterGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/cluster/get.go
+++ b/commands/dbaas/postgres-v2/cluster/get.go
@@ -34,13 +34,7 @@ func ClusterGetCmd() *core.Command {
 }
 
 func PreRunClusterId(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId)
 }
 
 func RunClusterGet(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/cluster/list.go
+++ b/commands/dbaas/postgres-v2/cluster/list.go
@@ -3,11 +3,10 @@ package cluster
 import (
 	"context"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/ionos-cloud/ionosctl/v6/internal/printer/table"
 	psqlv2 "github.com/ionos-cloud/sdk-go-bundle/products/dbaas/psql/v3"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,27 +36,24 @@ func ClusterListCmd() *core.Command {
 }
 
 func RunClusterList(c *core.CommandConfig) error {
-	req := client.Must().PostgresClientV2.ClustersApi.ClustersGet(context.Background())
+	return c.ListAllLocations(clusterCols, func(cfg *shared.Configuration) (any, error) {
+		apiClient := psqlv2.NewAPIClient(cfg)
+		req := apiClient.ClustersApi.ClustersGet(context.Background())
 
-	if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
-		req = req.FilterName(viper.GetString(fn))
-	}
-	if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
-		req = req.FilterState(psqlv2.PostgresClusterStates(viper.GetString(fn)))
-	}
-	if fn := core.GetFlagName(c.NS, constants.FlagLimit); viper.IsSet(fn) {
-		req = req.Limit(viper.GetInt32(fn))
-	}
-	if fn := core.GetFlagName(c.NS, constants.FlagOffset); viper.IsSet(fn) {
-		req = req.Offset(viper.GetInt32(fn))
-	}
+		if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
+			req = req.FilterName(viper.GetString(fn))
+		}
+		if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
+			req = req.FilterState(psqlv2.PostgresClusterStates(viper.GetString(fn)))
+		}
+		if fn := core.GetFlagName(c.NS, constants.FlagLimit); viper.IsSet(fn) {
+			req = req.Limit(viper.GetInt32(fn))
+		}
+		if fn := core.GetFlagName(c.NS, constants.FlagOffset); viper.IsSet(fn) {
+			req = req.Offset(viper.GetInt32(fn))
+		}
 
-	clusters, _, err := req.Execute()
-	if err != nil {
-		return err
-	}
-
-	cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)
-
-	return c.Out(table.Sprint(clusterCols, clusters, cols, table.WithPrefix("items")))
+		clusters, _, err := req.Execute()
+		return clusters, err
+	})
 }

--- a/commands/dbaas/postgres-v2/cluster/restore.go
+++ b/commands/dbaas/postgres-v2/cluster/restore.go
@@ -49,13 +49,7 @@ Required values to run command:
 }
 
 func PreRunClusterBackupIds(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagBackupId, constants.FlagDbPassword); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId, constants.FlagBackupId, constants.FlagDbPassword)
 }
 
 func RunClusterRestore(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/cluster/restore.go
+++ b/commands/dbaas/postgres-v2/cluster/restore.go
@@ -49,7 +49,13 @@ Required values to run command:
 }
 
 func PreRunClusterBackupIds(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagBackupId, constants.FlagDbPassword)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagBackupId, constants.FlagDbPassword); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func RunClusterRestore(c *core.CommandConfig) error {

--- a/commands/dbaas/postgres-v2/cluster/update.go
+++ b/commands/dbaas/postgres-v2/cluster/update.go
@@ -35,7 +35,13 @@ Required values to run command:
 		Example: "ionosctl dbaas postgres-v2 cluster update --cluster-id <cluster-id> --db-password <password> --cores 4 --ram 8GB",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
 			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagDbPassword)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagDbPassword); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun:     RunClusterUpdate,
 		InitClient: true,

--- a/commands/dbaas/postgres-v2/cluster/update.go
+++ b/commands/dbaas/postgres-v2/cluster/update.go
@@ -35,13 +35,7 @@ Required values to run command:
 		Example: "ionosctl dbaas postgres-v2 cluster update --cluster-id <cluster-id> --db-password <password> --cores 4 --ram 8GB",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
 			c.Command.Command.MarkFlagsRequiredTogether(constants.FlagMaintenanceDay, constants.FlagMaintenanceTime)
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagClusterId, constants.FlagDbPassword); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId, constants.FlagDbPassword)
 		},
 		CmdRun:     RunClusterUpdate,
 		InitClient: true,

--- a/commands/dns/record/list.go
+++ b/commands/dns/record/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/printer/table"
 	"github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/cobra"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
@@ -95,45 +96,29 @@ ionosctl dns r list --zone ZONE_ID`,
 }
 
 func listRecordsCmd(c *core.CommandConfig) error {
-	ls, err := Records(
-		func(req dns.ApiRecordsGetRequest) (dns.ApiRecordsGetRequest, error) {
-			if fn := core.GetFlagName(c.NS, constants.FlagZone); viper.IsSet(fn) {
-				zoneId, err := utils.ZoneResolve(viper.GetString(fn))
-				if err != nil {
-					return req, err
-				}
-				req = req.FilterZoneId(zoneId)
-			}
-			if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
-				req = req.FilterName(viper.GetString(fn))
-			}
-			return req, nil
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed listing zone records: %w", err)
-	}
+	// Records are listed via the cross-zone /records endpoint (one call per
+	// location). When --location is unset, ListAllLocations queries all
+	// locations and merges results with a Location column. The ZoneName column
+	// is not enriched here (it is not a default column and would cost one
+	// ZonesFindById call per record); ZoneId is shown instead.
+	return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+		dnsClient := dns.NewAPIClient(cfg)
+		req := dnsClient.RecordsApi.RecordsGet(context.Background())
 
-	items, ok := ls.GetItemsOk()
-	if !ok || items == nil {
-		return fmt.Errorf("could not retrieve Zone Record items")
-	}
-
-	t := table.New(allCols, table.WithPrefix("items"))
-	if err := t.Extract(ls); err != nil {
-		return err
-	}
-
-	for i, item := range items {
-		if m, ok := item.GetMetadataOk(); ok && m != nil {
-			z, _, err := client.Must().DnsClient.ZonesApi.ZonesFindById(context.Background(), m.ZoneId).Execute()
-			if err == nil {
-				t.SetCell(i, "ZoneName", z.Properties.ZoneName)
+		if fn := core.GetFlagName(c.NS, constants.FlagZone); viper.IsSet(fn) {
+			zoneId, err := utils.ZoneResolve(viper.GetString(fn))
+			if err != nil {
+				return nil, err
 			}
+			req = req.FilterZoneId(zoneId)
 		}
-	}
+		if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
+			req = req.FilterName(viper.GetString(fn))
+		}
 
-	return c.Out(t.Render(table.ResolveCols(allCols, c.Cols())))
+		ls, _, err := req.Execute()
+		return ls, err
+	})
 }
 
 func listSecondaryRecords(c *core.CommandConfig) error {

--- a/commands/dns/reverse-record/list.go
+++ b/commands/dns/reverse-record/list.go
@@ -2,11 +2,12 @@ package reverse_record
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
+	dns "github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
 )
 
 func List() *core.Command {
@@ -18,17 +19,17 @@ func List() *core.Command {
 		ShortDesc: "Retrieve all reverse records",
 		Example:   "ionosctl dns rr list",
 		CmdRun: func(c *core.CommandConfig) error {
-			ls, err := Records(FilterRecordsByIp(c.NS))
-			if err != nil {
-				return fmt.Errorf("failed listing records: %w", err)
-			}
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				dnsClient := dns.NewAPIClient(cfg)
+				req := dnsClient.ReverseRecordsApi.ReverserecordsGet(context.Background())
 
-			items, ok := ls.GetItemsOk()
-			if !ok || items == nil {
-				return fmt.Errorf("could not retrieve Record items")
-			}
+				if fn := core.GetFlagName(c.NS, constants.FlagIps); viper.IsSet(fn) {
+					req = req.FilterRecordIp(viper.GetStringSlice(fn))
+				}
 
-			return c.Printer(allCols).Prefix("items").Print(ls)
+				ls, _, err := req.Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/dns/secondary-zones/list.go
+++ b/commands/dns/secondary-zones/list.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	dns "github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/cobra"
-
-	"github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
 )
 
 func listCmd() *core.Command {
@@ -22,25 +21,24 @@ func listCmd() *core.Command {
 			Example:   "ionosctl dns secondary-zone list",
 			PreCmdRun: nil,
 			CmdRun: func(c *core.CommandConfig) error {
-				req := client.Must().DnsClient.SecondaryZonesApi.SecondaryzonesGet(context.Background())
+				return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+					dnsClient := dns.NewAPIClient(cfg)
+					req := dnsClient.SecondaryZonesApi.SecondaryzonesGet(context.Background())
 
-				if c.Command.Command.Flags().Changed(constants.FlagName) {
-					name, _ := c.Command.Command.Flags().GetString(constants.FlagName)
-					req = req.FilterZoneName(name)
-				}
+					if c.Command.Command.Flags().Changed(constants.FlagName) {
+						name, _ := c.Command.Command.Flags().GetString(constants.FlagName)
+						req = req.FilterZoneName(name)
+					}
+					if c.Command.Command.Flags().Changed(constants.FlagState) {
+						state, _ := c.Command.Command.Flags().GetString(constants.FlagState)
+						req = req.FilterState(dns.ProvisioningState(state))
+					}
 
-				if c.Command.Command.Flags().Changed(constants.FlagState) {
-					state, _ := c.Command.Command.Flags().GetString(constants.FlagState)
-					req = req.FilterState(dns.ProvisioningState(state))
-				}
-
-				secZones, _, err := req.Execute()
-				if err != nil {
-					return err
-				}
-
-				return c.Printer(allCols).Prefix("items").Print(secZones)
+					ls, _, err := req.Execute()
+					return ls, err
+				})
 			},
+			InitClient: true,
 		},
 	)
 

--- a/commands/dns/zone/list.go
+++ b/commands/dns/zone/list.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	dns "github.com/ionos-cloud/sdk-go-bundle/products/dns/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 
 	"github.com/spf13/cobra"
-
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
-	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/spf13/viper"
 )
 
@@ -27,21 +26,20 @@ func ZonesGetCmd() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			req := client.Must().DnsClient.ZonesApi.ZonesGet(context.Background())
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				dnsClient := dns.NewAPIClient(cfg)
+				req := dnsClient.ZonesApi.ZonesGet(context.Background())
 
-			if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
-				req = req.FilterZoneName(viper.GetString(fn))
-			}
-			if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
-				req = req.FilterState(dns.ProvisioningState(viper.GetString(fn)))
-			}
+				if fn := core.GetFlagName(c.NS, constants.FlagName); viper.IsSet(fn) {
+					req = req.FilterZoneName(viper.GetString(fn))
+				}
+				if fn := core.GetFlagName(c.NS, constants.FlagState); viper.IsSet(fn) {
+					req = req.FilterState(dns.ProvisioningState(viper.GetString(fn)))
+				}
 
-			ls, _, err := req.Execute()
-			if err != nil {
-				return err
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+				ls, _, err := req.Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/kafka/cluster/create.go
+++ b/commands/kafka/cluster/create.go
@@ -23,19 +23,10 @@ func Create() *core.Command {
 			ShortDesc: "Create a kafka cluster. Wiki: https://docs.ionos.com/cloud/data-analytics/kafka/api-howtos/create-kafka",
 			Example:   "ionosctl kafka cl create --name my-cluster --version 3.9.0 --size XS --location de/txl --datacenter-id DATACENTER_ID --lan-id LAN_ID --broker-addresses 127.0.0.1/24,127.0.0.2/24,127.0.0.3/24",
 			PreCmdRun: func(c *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					c.Command, c.NS,
-					constants.FlagName, constants.FlagVersion, constants.FlagSize, constants.FlagLocation,
+				return c.CheckRequiredFlagsAndLocation(
+					constants.FlagName, constants.FlagVersion, constants.FlagSize,
 					constants.FlagDatacenterId, constants.FlagLanId, constants.FlagKafkaBrokerAddresses,
-				); err != nil {
-					return err
-				}
-
-				if err := c.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				)
 			},
 			CmdRun: func(c *core.CommandConfig) error {
 				input := setPropertiesFromFlags(c)

--- a/commands/kafka/cluster/create.go
+++ b/commands/kafka/cluster/create.go
@@ -31,6 +31,10 @@ func Create() *core.Command {
 					return err
 				}
 
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
 				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {

--- a/commands/kafka/cluster/delete.go
+++ b/commands/kafka/cluster/delete.go
@@ -33,6 +33,10 @@ func Delete() *core.Command {
 					return err
 				}
 
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
 				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {

--- a/commands/kafka/cluster/delete.go
+++ b/commands/kafka/cluster/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/kafka/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
@@ -28,12 +29,8 @@ func Delete() *core.Command {
 				if err := core.CheckRequiredFlagsSets(
 					c.Command, c.NS,
 					[]string{constants.FlagClusterId, constants.FlagLocation},
-					[]string{constants.ArgAll, constants.FlagLocation},
+					[]string{constants.ArgAll},
 				); err != nil {
-					return err
-				}
-
-				if err := c.RequireExplicitLocation(); err != nil {
 					return err
 				}
 
@@ -42,6 +39,10 @@ func Delete() *core.Command {
 			CmdRun: func(c *core.CommandConfig) error {
 				if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
 					return deleteAll(c)
+				}
+
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
 				}
 
 				return deleteSingle(c, viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId)))
@@ -75,16 +76,37 @@ func Delete() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	records, err := completer.Clusters()
-	if err != nil {
-		return fmt.Errorf("failed getting all clusters: %w", err)
-	}
+	// Fan out over every location (when --location is unset) so `delete --all`
+	// spans all locations, matching `list`. Each location gets its own client.
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		kc := kafka.NewAPIClient(cfg)
+		c.Verbose("Deleting all clusters in %s!", location)
 
-	return functional.ApplyAndAggregateErrors(
-		records.GetItems(), func(d kafka.ClusterRead) error {
-			return deleteSingle(c, d.Id)
-		},
-	)
+		records, _, err := kc.ClustersApi.ClustersGet(context.Background()).Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing kafka clusters: %w", err)
+		}
+
+		return functional.ApplyAndAggregateErrors(
+			records.GetItems(), func(d kafka.ClusterRead) error {
+				yes := confirm.FAsk(
+					c.Command.Command.InOrStdin(),
+					fmt.Sprintf(
+						"Are you sure you want to delete cluster %s with name %s (location: %s) ",
+						d.Id, d.Properties.Name, location,
+					),
+					viper.GetBool(constants.ArgForce),
+				)
+				if yes {
+					_, delErr := kc.ClustersApi.ClustersDelete(context.Background(), d.Id).Execute()
+					if delErr != nil {
+						return fmt.Errorf("failed deleting %s (name: %s): %w", d.Id, d.Properties.Name, delErr)
+					}
+				}
+				return nil
+			},
+		)
+	})
 }
 
 func deleteSingle(c *core.CommandConfig, id string) error {

--- a/commands/kafka/cluster/get.go
+++ b/commands/kafka/cluster/get.go
@@ -27,6 +27,10 @@ func FindByID() *core.Command {
 					return err
 				}
 
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
 				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {

--- a/commands/kafka/cluster/get.go
+++ b/commands/kafka/cluster/get.go
@@ -21,17 +21,7 @@ func FindByID() *core.Command {
 			ShortDesc: "Retrieve a cluster",
 			Example:   "ionosctl kafka cl get --cluster-id ID",
 			PreCmdRun: func(c *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					c.Command, c.NS, constants.FlagClusterId, constants.FlagLocation,
-				); err != nil {
-					return err
-				}
-
-				if err := c.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				return c.CheckRequiredFlagsAndLocation(constants.FlagClusterId)
 			},
 			CmdRun: func(c *core.CommandConfig) error {
 				clusterID := viper.GetString(core.GetFlagName(c.NS, constants.FlagClusterId))

--- a/commands/kafka/cluster/list.go
+++ b/commands/kafka/cluster/list.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/commands/kafka/completer"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/ionos-cloud/sdk-go-bundle/products/kafka/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -19,16 +19,29 @@ func List() *core.Command {
 			Verb:      "list",
 			Aliases:   []string{"ls"},
 			ShortDesc: "Retrieve all clusters using pagination and optional filters",
-			Example:   `ionosctl kafka c list --location de/txl`,
+			Example:   `ionosctl kafka c list`,
 			PreCmdRun: func(c *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLocation); err != nil {
-					return err
-				}
-
 				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {
-				return listClusters(c)
+				return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+					client := kafka.NewAPIClient(cfg)
+
+					req := client.ClustersApi.ClustersGet(context.Background())
+					if fn := core.GetFlagName(c.NS, constants.FlagFilterState); viper.IsSet(fn) {
+						req = req.FilterState(viper.GetString(fn))
+					}
+					if fn := core.GetFlagName(c.NS, constants.FlagFilterName); viper.IsSet(fn) {
+						req = req.FilterName(viper.GetString(fn))
+					}
+
+					ls, _, err := req.Execute()
+					if err != nil {
+						return nil, fmt.Errorf("failed listing kafka clusters: %w", err)
+					}
+
+					return ls, nil
+				})
 			},
 			InitClient: true,
 		},
@@ -41,23 +54,4 @@ func List() *core.Command {
 	)
 
 	return cmd
-}
-
-func listClusters(c *core.CommandConfig) error {
-	ls, err := completer.Clusters(
-		func(req kafka.ApiClustersGetRequest) (kafka.ApiClustersGetRequest, error) {
-			if fn := core.GetFlagName(c.NS, constants.FlagFilterState); viper.IsSet(fn) {
-				req = req.FilterState(viper.GetString(fn))
-			}
-			if fn := core.GetFlagName(c.NS, constants.FlagFilterName); viper.IsSet(fn) {
-				req = req.FilterName(viper.GetString(fn))
-			}
-			return req, nil
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed listing kafka clusters: %w", err)
-	}
-
-	return c.Printer(allCols).Prefix("items").Print(ls)
 }

--- a/commands/kafka/topic/create.go
+++ b/commands/kafka/topic/create.go
@@ -20,9 +20,17 @@ func createCmd() *core.Command {
 			Aliases:   []string{"c", "post"},
 			Example:   "ionosctl kafka topic create --location LOCATION --name my-topic --cluster-id CLUSTER_ID --partitions 1 --replication-factor 1",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				return core.CheckRequiredFlags(
+				if err := core.CheckRequiredFlags(
 					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagName,
-				)
+				); err != nil {
+					return err
+				}
+
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				name, _ := cmd.Command.Command.Flags().GetString(constants.FlagName)

--- a/commands/kafka/topic/create.go
+++ b/commands/kafka/topic/create.go
@@ -20,17 +20,7 @@ func createCmd() *core.Command {
 			Aliases:   []string{"c", "post"},
 			Example:   "ionosctl kafka topic create --location LOCATION --name my-topic --cluster-id CLUSTER_ID --partitions 1 --replication-factor 1",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagName,
-				); err != nil {
-					return err
-				}
-
-				if err := cmd.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				return cmd.CheckRequiredFlagsAndLocation(constants.FlagClusterId, constants.FlagName)
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				name, _ := cmd.Command.Command.Flags().GetString(constants.FlagName)

--- a/commands/kafka/topic/delete.go
+++ b/commands/kafka/topic/delete.go
@@ -24,11 +24,19 @@ func deleteCmd() *core.Command {
 			Aliases:   []string{"d"},
 			Example:   "ionosctl kafka topic delete --location LOCATION --topic-id TOPIC_ID",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				return core.CheckRequiredFlagsSets(
+				if err := core.CheckRequiredFlagsSets(
 					cmd.Command, cmd.NS,
 					[]string{constants.FlagLocation, constants.FlagClusterId, constants.FlagKafkaTopicId},
 					[]string{constants.FlagLocation, constants.FlagClusterId, constants.ArgAll},
-				)
+				); err != nil {
+					return err
+				}
+
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				if cmd.Command.Command.Flags().Changed(constants.ArgAll) {

--- a/commands/kafka/topic/get.go
+++ b/commands/kafka/topic/get.go
@@ -20,17 +20,7 @@ func getCmd() *core.Command {
 			Aliases:   []string{"g"},
 			Example:   "ionosctl kafka topic get --location LOCATION --cluster-id CLUSTER_ID --topic-id TOPIC_ID",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagKafkaTopicId,
-				); err != nil {
-					return err
-				}
-
-				if err := cmd.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				return cmd.CheckRequiredFlagsAndLocation(constants.FlagClusterId, constants.FlagKafkaTopicId)
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/kafka/topic/get.go
+++ b/commands/kafka/topic/get.go
@@ -20,9 +20,17 @@ func getCmd() *core.Command {
 			Aliases:   []string{"g"},
 			Example:   "ionosctl kafka topic get --location LOCATION --cluster-id CLUSTER_ID --topic-id TOPIC_ID",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				return core.CheckRequiredFlags(
+				if err := core.CheckRequiredFlags(
 					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagKafkaTopicId,
-				)
+				); err != nil {
+					return err
+				}
+
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/kafka/topic/list.go
+++ b/commands/kafka/topic/list.go
@@ -29,6 +29,10 @@ ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID`,
 					return listAll(cmd)
 				}
 
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)
 				topics, _, err := client.Must().Kafka.TopicsApi.ClustersTopicsGet(
 					context.Background(), clusterID,

--- a/commands/kafka/topic/list.go
+++ b/commands/kafka/topic/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 	"github.com/ionos-cloud/sdk-go-bundle/products/kafka/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 )
 
 func listCmd() *core.Command {
@@ -59,20 +60,25 @@ ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID`,
 }
 
 func listAll(c *core.CommandConfig) error {
-	clusters, _, err := client.Must().Kafka.ClustersApi.ClustersGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	var allItems []kafka.TopicRead
-	for _, cluster := range clusters.Items {
-		topics, _, err := client.Must().Kafka.TopicsApi.ClustersTopicsGet(context.Background(), cluster.Id).Execute()
+	// When --location is unset, ListAllLocations queries every location
+	// concurrently, enumerating clusters and their topics per location and
+	// merging the results with a Location column.
+	return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+		kc := kafka.NewAPIClient(cfg)
+		clusters, _, err := kc.ClustersApi.ClustersGet(context.Background()).Execute()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		allItems = append(allItems, topics.Items...)
-	}
+		var items []kafka.TopicRead
+		for _, cluster := range clusters.Items {
+			topics, _, err := kc.TopicsApi.ClustersTopicsGet(context.Background(), cluster.Id).Execute()
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, topics.Items...)
+		}
 
-	return c.Printer(allCols).Print(allItems)
+		return kafka.TopicReadList{Items: items}, nil
+	})
 }

--- a/commands/kafka/topic/list.go
+++ b/commands/kafka/topic/list.go
@@ -18,7 +18,7 @@ func listCmd() *core.Command {
 			Resource:  "topic",
 			ShortDesc: "List all kafka topics",
 			Aliases:   []string{"ls"},
-			Example: `ionosctl kafka topic list --location LOCATION
+			Example: `ionosctl kafka topic list --cluster-id CLUSTER_ID
 ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID`,
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
 				return nil

--- a/commands/kafka/topic/list.go
+++ b/commands/kafka/topic/list.go
@@ -21,7 +21,7 @@ func listCmd() *core.Command {
 			Example: `ionosctl kafka topic list --location LOCATION
 ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID`,
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				return core.CheckRequiredFlags(cmd.Command, cmd.NS, constants.FlagLocation)
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				if !cmd.Command.Command.Flags().Changed(constants.FlagClusterId) {

--- a/commands/kafka/user/get-access.go
+++ b/commands/kafka/user/get-access.go
@@ -34,10 +34,17 @@ IMPORTANT: Keep these credentials secure. The private key should never be shared
 			Aliases: []string{"g", "get", "access"},
 			Example: "ionosctl kafka user get-access " + core.FlagsUsage(constants.FlagLocation, constants.FlagClusterId, constants.FlagUserId),
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-
-				return core.CheckRequiredFlags(
+				if err := core.CheckRequiredFlags(
 					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagUserId,
-				)
+				); err != nil {
+					return err
+				}
+
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/kafka/user/get-access.go
+++ b/commands/kafka/user/get-access.go
@@ -34,17 +34,7 @@ IMPORTANT: Keep these credentials secure. The private key should never be shared
 			Aliases: []string{"g", "get", "access"},
 			Example: "ionosctl kafka user get-access " + core.FlagsUsage(constants.FlagLocation, constants.FlagClusterId, constants.FlagUserId),
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId, constants.FlagUserId,
-				); err != nil {
-					return err
-				}
-
-				if err := cmd.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				return cmd.CheckRequiredFlagsAndLocation(constants.FlagClusterId, constants.FlagUserId)
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/kafka/user/list.go
+++ b/commands/kafka/user/list.go
@@ -21,17 +21,7 @@ func List() *core.Command {
 			Aliases:   []string{"l", "ls"},
 			Example:   "ionosctl kafka user list",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlags(
-					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId,
-				); err != nil {
-					return err
-				}
-
-				if err := cmd.RequireExplicitLocation(); err != nil {
-					return err
-				}
-
-				return nil
+				return cmd.CheckRequiredFlagsAndLocation(constants.FlagClusterId)
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/kafka/user/list.go
+++ b/commands/kafka/user/list.go
@@ -21,9 +21,17 @@ func List() *core.Command {
 			Aliases:   []string{"l", "ls"},
 			Example:   "ionosctl kafka user list",
 			PreCmdRun: func(cmd *core.PreCommandConfig) error {
-				return core.CheckRequiredFlags(
+				if err := core.CheckRequiredFlags(
 					cmd.Command, cmd.NS, constants.FlagLocation, constants.FlagClusterId,
-				)
+				); err != nil {
+					return err
+				}
+
+				if err := cmd.RequireExplicitLocation(); err != nil {
+					return err
+				}
+
+				return nil
 			},
 			CmdRun: func(cmd *core.CommandConfig) error {
 				clusterID, _ := cmd.Command.Command.Flags().GetString(constants.FlagClusterId)

--- a/commands/logging-service/central/disable.go
+++ b/commands/logging-service/central/disable.go
@@ -15,6 +15,9 @@ func CentralDisable() *core.Command {
 		ShortDesc: "Disable CentralLogging",
 		Example:   "ionosctl logging-service central disable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/logging-service/central/disable.go
+++ b/commands/logging-service/central/disable.go
@@ -15,10 +15,7 @@ func CentralDisable() *core.Command {
 		ShortDesc: "Disable CentralLogging",
 		Example:   "ionosctl logging-service central disable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			return enable(c, false)

--- a/commands/logging-service/central/enable.go
+++ b/commands/logging-service/central/enable.go
@@ -15,10 +15,7 @@ func CentralEnable() *core.Command {
 		ShortDesc: "Enable CentralLogging",
 		Example:   "ionosctl logging-service central enable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			return enable(c, true)

--- a/commands/logging-service/central/enable.go
+++ b/commands/logging-service/central/enable.go
@@ -15,6 +15,9 @@ func CentralEnable() *core.Command {
 		ShortDesc: "Enable CentralLogging",
 		Example:   "ionosctl logging-service central enable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/logging-service/central/get.go
+++ b/commands/logging-service/central/get.go
@@ -17,6 +17,9 @@ func CentralFindByIdCmd() *core.Command {
 		ShortDesc: "Retrieve CentralLogging",
 		Example:   "ionosctl logging-service central get --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/logging-service/central/get.go
+++ b/commands/logging-service/central/get.go
@@ -17,10 +17,7 @@ func CentralFindByIdCmd() *core.Command {
 		ShortDesc: "Retrieve CentralLogging",
 		Example:   "ionosctl logging-service central get --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			r, _, err := client.Must().LoggingServiceClient.CentralApi.CentralGet(context.Background()).Execute()

--- a/commands/logging-service/logs/add.go
+++ b/commands/logging-service/logs/add.go
@@ -57,10 +57,16 @@ func LogsAddCmd() *core.Command {
 }
 
 func preRunAddCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(
+	if err := core.CheckRequiredFlags(
 		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
 		constants.FlagLoggingPipelineLogSource, constants.FlagLoggingPipelineLogProtocol,
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func runAddCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/logs/add.go
+++ b/commands/logging-service/logs/add.go
@@ -57,16 +57,10 @@ func LogsAddCmd() *core.Command {
 }
 
 func preRunAddCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(
-		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
+	return c.CheckRequiredFlagsAndLocation(
+		constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
 		constants.FlagLoggingPipelineLogSource, constants.FlagLoggingPipelineLogProtocol,
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 func runAddCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/logs/get.go
+++ b/commands/logging-service/logs/get.go
@@ -67,13 +67,7 @@ func runGetCmd(c *core.CommandConfig) error {
 }
 
 func preRunGetCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(
-		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(
+		constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
+	)
 }

--- a/commands/logging-service/logs/get.go
+++ b/commands/logging-service/logs/get.go
@@ -67,7 +67,13 @@ func runGetCmd(c *core.CommandConfig) error {
 }
 
 func preRunGetCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(
+	if err := core.CheckRequiredFlags(
 		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/commands/logging-service/logs/list.go
+++ b/commands/logging-service/logs/list.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
+	"github.com/ionos-cloud/sdk-go-bundle/products/logging/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -23,7 +25,7 @@ func LogsListCmd() *core.Command {
 			CmdRun:    runListCmd,
 		},
 	)
-	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "Use this flag to list all logging pipeline logs")
+	cmd.AddBoolFlag(constants.ArgAll, constants.ArgAllShort, false, "List logs from all logging pipelines. When --location is unset, logs from all locations are listed")
 	cmd.AddStringFlag(
 		constants.FlagLoggingPipelineId, constants.FlagIdShort, "",
 		"The ID of the logging pipeline", core.RequiredFlagOption(),
@@ -57,10 +59,15 @@ func runListCmd(c *core.CommandConfig) error {
 }
 
 func listAll(c *core.CommandConfig) error {
-	pipelines, _, err := client.Must().LoggingServiceClient.PipelinesApi.PipelinesGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	return handleLogsPrint(pipelines, c)
+	// When --location is unset, ListAllLocations queries every location
+	// concurrently, listing all pipelines (and their logs) per location and
+	// merging the results with a Location column.
+	return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+		lc := logging.NewAPIClient(cfg)
+		pipelines, _, err := lc.PipelinesApi.PipelinesGet(context.Background()).Execute()
+		if err != nil {
+			return nil, err
+		}
+		return flattenPipelineLogs(pipelines), nil
+	})
 }

--- a/commands/logging-service/logs/list.go
+++ b/commands/logging-service/logs/list.go
@@ -36,9 +36,18 @@ func LogsListCmd() *core.Command {
 }
 
 func preRunListCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(
+	if err := core.CheckRequiredFlagsSets(
 		c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagLoggingPipelineId},
-	)
+	); err != nil {
+		return err
+	}
+
+	// --all fans out over every location; a specific --pipeline-id is
+	// location-scoped and cannot be inferred, so require --location for it.
+	if !viper.IsSet(core.GetFlagName(c.NS, constants.ArgAll)) {
+		return c.RequireExplicitLocation()
+	}
+	return nil
 }
 
 func runListCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/logs/logs.go
+++ b/commands/logging-service/logs/logs.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -59,35 +60,28 @@ func LogsCmd() *core.Command {
 	return cmd
 }
 
-func handleLogsPrint(pipelines logging.PipelineReadList, c *core.CommandConfig) error {
-	items, ok := pipelines.GetItemsOk()
-	if !ok || items == nil {
-		return fmt.Errorf("could not retrieve Logging Service Pipeline items")
-	}
-
-	var allLogs []logging.PipelineNoAddrLogs
-	// Map to track which pipeline each log belongs to
-	var pipelineIds []string
-	for _, p := range items {
-		for range p.Properties.Logs {
-			pipelineIds = append(pipelineIds, p.Id)
-		}
-		allLogs = append(allLogs, p.Properties.Logs...)
-	}
-
-	t := table.New(allCols)
-	if err := t.Extract(allLogs); err != nil {
-		return err
-	}
-
-	// Set PipelineId for each row
-	for i, pid := range pipelineIds {
-		if i < len(t.Rows()) {
-			t.Rows()[i]["_pipelineId"] = pid
+// flattenPipelineLogs flattens the logs of all pipelines into a single
+// {"items": [...]} payload, tagging each log with its parent pipeline ID so the
+// PipelineId column can be rendered. The {"items": ...} shape lets
+// [core.CommandConfig.ListAllLocations] merge logs across locations and render
+// them (text, json, api-json) uniformly.
+func flattenPipelineLogs(pipelines logging.PipelineReadList) map[string]any {
+	items := make([]any, 0)
+	for _, p := range pipelines.Items {
+		for _, log := range p.Properties.Logs {
+			b, err := json.Marshal(log)
+			if err != nil {
+				continue
+			}
+			var m map[string]any
+			if err := json.Unmarshal(b, &m); err != nil {
+				continue
+			}
+			m["_pipelineId"] = p.Id
+			items = append(items, m)
 		}
 	}
-
-	return c.Out(t.Render(table.ResolveCols(allCols, c.Cols())))
+	return map[string]any{"items": items}
 }
 
 func handleLogPrint(pipeline logging.PipelineRead, c *core.CommandConfig) error {

--- a/commands/logging-service/logs/logs_test.go
+++ b/commands/logging-service/logs/logs_test.go
@@ -1,0 +1,60 @@
+package logs
+
+import (
+	"testing"
+
+	logging "github.com/ionos-cloud/sdk-go-bundle/products/logging/v2"
+)
+
+// TestFlattenPipelineLogs verifies that logs from multiple pipelines are
+// flattened into a single {"items": [...]} payload, in order, with each log
+// tagged by its parent pipeline ID.
+func TestFlattenPipelineLogs(t *testing.T) {
+	pipelines := logging.PipelineReadList{
+		Items: []logging.PipelineRead{
+			{Id: "p1", Properties: logging.Pipeline{Logs: []logging.PipelineNoAddrLogs{
+				{Tag: "a", Source: "kubernetes"},
+				{Tag: "b", Source: "docker"},
+			}}},
+			{Id: "p2", Properties: logging.Pipeline{Logs: []logging.PipelineNoAddrLogs{
+				{Tag: "c", Source: "systemd"},
+			}}},
+		},
+	}
+
+	out := flattenPipelineLogs(pipelines)
+	items, ok := out["items"].([]any)
+	if !ok {
+		t.Fatalf("items is not []any, got %T", out["items"])
+	}
+	if len(items) != 3 {
+		t.Fatalf("want 3 logs, got %d", len(items))
+	}
+
+	want := []struct{ tag, pid string }{{"a", "p1"}, {"b", "p1"}, {"c", "p2"}}
+	for i, w := range want {
+		m, ok := items[i].(map[string]any)
+		if !ok {
+			t.Fatalf("item %d is not map[string]any, got %T", i, items[i])
+		}
+		if m["tag"] != w.tag {
+			t.Errorf("item %d tag = %v, want %v", i, m["tag"], w.tag)
+		}
+		if m["_pipelineId"] != w.pid {
+			t.Errorf("item %d _pipelineId = %v, want %v", i, m["_pipelineId"], w.pid)
+		}
+	}
+}
+
+// TestFlattenPipelineLogsEmpty verifies a non-nil empty items slice when there
+// are no pipelines, so JSON output renders [] rather than null.
+func TestFlattenPipelineLogsEmpty(t *testing.T) {
+	out := flattenPipelineLogs(logging.PipelineReadList{})
+	items, ok := out["items"].([]any)
+	if !ok {
+		t.Fatalf("items is not []any, got %T", out["items"])
+	}
+	if len(items) != 0 {
+		t.Fatalf("want 0 logs, got %d", len(items))
+	}
+}

--- a/commands/logging-service/logs/remove.go
+++ b/commands/logging-service/logs/remove.go
@@ -90,7 +90,13 @@ func runRemoveCmd(c *core.CommandConfig) error {
 }
 
 func preRunRemoveCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(
+	if err := core.CheckRequiredFlags(
 		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/commands/logging-service/logs/remove.go
+++ b/commands/logging-service/logs/remove.go
@@ -90,13 +90,7 @@ func runRemoveCmd(c *core.CommandConfig) error {
 }
 
 func preRunRemoveCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(
-		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(
+		constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
+	)
 }

--- a/commands/logging-service/logs/update.go
+++ b/commands/logging-service/logs/update.go
@@ -64,15 +64,9 @@ func LogsUpdateCmd() *core.Command {
 }
 
 func preRunUpdateCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(
-		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(
+		constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
+	)
 }
 
 func runUpdateCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/logs/update.go
+++ b/commands/logging-service/logs/update.go
@@ -64,9 +64,15 @@ func LogsUpdateCmd() *core.Command {
 }
 
 func preRunUpdateCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(
+	if err := core.CheckRequiredFlags(
 		c.Command, c.NS, constants.FlagLoggingPipelineId, constants.FlagLoggingPipelineLogTag,
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func runUpdateCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/create.go
+++ b/commands/logging-service/pipeline/create.go
@@ -76,13 +76,19 @@ func runCreateCmd(c *core.CommandConfig) error {
 }
 
 func preRunCreateCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(
+	if err := core.CheckRequiredFlagsSets(
 		c.Command, c.NS, []string{constants.FlagJsonProperties}, []string{constants.FlagJsonPropertiesExample},
 		[]string{
 			constants.FlagName, constants.FlagLoggingPipelineLogTag, constants.FlagLoggingPipelineLogSource,
 			constants.FlagLoggingPipelineLogProtocol,
 		},
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func createFromFlags(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/create.go
+++ b/commands/logging-service/pipeline/create.go
@@ -76,19 +76,13 @@ func runCreateCmd(c *core.CommandConfig) error {
 }
 
 func preRunCreateCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(
-		c.Command, c.NS, []string{constants.FlagJsonProperties}, []string{constants.FlagJsonPropertiesExample},
+	return c.CheckRequiredFlagsSetsAndLocation(
+		[]string{constants.FlagJsonProperties}, []string{constants.FlagJsonPropertiesExample},
 		[]string{
 			constants.FlagName, constants.FlagLoggingPipelineLogTag, constants.FlagLoggingPipelineLogSource,
 			constants.FlagLoggingPipelineLogProtocol,
 		},
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 func createFromFlags(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/delete.go
+++ b/commands/logging-service/pipeline/delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/logging/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -80,53 +81,51 @@ func runDeleteCmd(c *core.CommandConfig) error {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	pipelines, _, err := client.Must().LoggingServiceClient.PipelinesApi.PipelinesGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
+	// When --location is unset, RunForAllLocations invokes fn once per location
+	// (aggregating errors) so that --all spans every location instead of only
+	// the default one. Each invocation builds its own location-scoped client.
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		lc := logging.NewAPIClient(cfg)
 
-	items, ok := pipelines.GetItemsOk()
-	if !ok || items == nil {
-		return fmt.Errorf("could not retrieve Logging-Service Pipelines items")
-	}
+		c.Verbose("Deleting all logging pipelines in %s!", location)
 
-	if len(items) <= 0 {
-		return fmt.Errorf("no Logging-Service Pipelines to delete")
-	}
+		pipelines, _, err := lc.PipelinesApi.PipelinesGet(context.Background()).Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing pipelines in %s: %w", location, err)
+		}
 
-	err = functional.ApplyAndAggregateErrors(
-		items, func(p logging.PipelineRead) error {
-			t := table.New(allCols)
-			if extractErr := t.Extract(p); extractErr != nil {
-				return extractErr
-			}
-			rows := t.Rows()
-			var pInfo string
-			if len(rows) > 0 {
-				pInfo = fmt.Sprintf("%v (%v)", rows[0]["Id"], rows[0]["Name"])
-			} else {
-				pInfo = p.Id
-			}
-			pInfo = strings.TrimSpace(pInfo)
-
-			yes := confirm.FAsk(
-				c.Command.Command.InOrStdin(), fmt.Sprintf(
-					"delete %s", pInfo,
-				),
-				viper.GetBool(constants.ArgForce),
-			)
-			if yes {
-				_, delErr := client.Must().LoggingServiceClient.PipelinesApi.PipelinesDelete(
-					c.Context,
-					p.Id,
-				).Execute()
-				if delErr != nil {
-					return fmt.Errorf("failed deleting %s: %w", pInfo, delErr)
+		return functional.ApplyAndAggregateErrors(
+			pipelines.GetItems(), func(p logging.PipelineRead) error {
+				t := table.New(allCols)
+				if extractErr := t.Extract(p); extractErr != nil {
+					return extractErr
 				}
-			}
-			return nil
-		},
-	)
+				rows := t.Rows()
+				var pInfo string
+				if len(rows) > 0 {
+					pInfo = fmt.Sprintf("%v (%v)", rows[0]["Id"], rows[0]["Name"])
+				} else {
+					pInfo = p.Id
+				}
+				pInfo = strings.TrimSpace(pInfo)
 
-	return err
+				yes := confirm.FAsk(
+					c.Command.Command.InOrStdin(), fmt.Sprintf(
+						"delete %s (location: %s)", pInfo, location,
+					),
+					viper.GetBool(constants.ArgForce),
+				)
+				if yes {
+					_, delErr := lc.PipelinesApi.PipelinesDelete(
+						context.Background(),
+						p.Id,
+					).Execute()
+					if delErr != nil {
+						return fmt.Errorf("failed deleting %s: %w", pInfo, delErr)
+					}
+				}
+				return nil
+			},
+		)
+	})
 }

--- a/commands/logging-service/pipeline/delete.go
+++ b/commands/logging-service/pipeline/delete.go
@@ -55,6 +55,10 @@ func runDeleteCmd(c *core.CommandConfig) error {
 		return nil
 	}
 
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+
 	pipelineId := viper.GetString(core.GetFlagName(c.NS, constants.FlagLoggingPipelineId))
 
 	if !confirm.FAsk(

--- a/commands/logging-service/pipeline/get.go
+++ b/commands/logging-service/pipeline/get.go
@@ -32,13 +32,7 @@ func PipelineGetCmd() *core.Command {
 }
 
 func preRunGetCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagLoggingPipelineId)
 }
 
 func runGetCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/get.go
+++ b/commands/logging-service/pipeline/get.go
@@ -32,7 +32,13 @@ func PipelineGetCmd() *core.Command {
 }
 
 func preRunGetCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func runGetCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/key.go
+++ b/commands/logging-service/pipeline/key.go
@@ -32,13 +32,7 @@ func PipelineKeyCmd() *core.Command {
 }
 
 func preRunKeyCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	return c.CheckRequiredFlagsAndLocation(constants.FlagLoggingPipelineId)
 }
 
 func runKeyCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/key.go
+++ b/commands/logging-service/pipeline/key.go
@@ -32,7 +32,13 @@ func PipelineKeyCmd() *core.Command {
 }
 
 func preRunKeyCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId)
+	if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagLoggingPipelineId); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func runKeyCmd(c *core.CommandConfig) error {

--- a/commands/logging-service/pipeline/list.go
+++ b/commands/logging-service/pipeline/list.go
@@ -3,7 +3,9 @@ package pipeline
 import (
 	"context"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	logging "github.com/ionos-cloud/sdk-go-bundle/products/logging/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 )
 
@@ -16,18 +18,16 @@ func PipelineListCmd() *core.Command {
 			Aliases:   []string{"ls"},
 			ShortDesc: "Retrieve logging pipelines",
 			Example:   "ionosctl logging-service pipeline list",
-			CmdRun:    runListCmd,
+			CmdRun: func(c *core.CommandConfig) error {
+				return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+					loggingClient := logging.NewAPIClient(cfg)
+					ls, _, err := loggingClient.PipelinesApi.PipelinesGet(context.Background()).Execute()
+					return ls, err
+				})
+			},
+			InitClient: true,
 		},
 	)
 
 	return cmd
-}
-
-func runListCmd(c *core.CommandConfig) error {
-	pipelines, _, err := client.Must().LoggingServiceClient.PipelinesApi.PipelinesGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	return c.Printer(allCols).Prefix("items").Print(pipelines)
 }

--- a/commands/logging-service/pipeline/update.go
+++ b/commands/logging-service/pipeline/update.go
@@ -55,8 +55,14 @@ func runUpdateCmd(c *core.CommandConfig) error {
 }
 
 func preRunUpdateCmd(c *core.PreCommandConfig) error {
-	return core.CheckRequiredFlagsSets(
+	if err := core.CheckRequiredFlagsSets(
 		c.Command, c.NS, []string{constants.FlagLoggingPipelineId, constants.FlagJsonProperties},
 		[]string{constants.FlagJsonPropertiesExample},
-	)
+	); err != nil {
+		return err
+	}
+	if err := c.RequireExplicitLocation(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/commands/logging-service/pipeline/update.go
+++ b/commands/logging-service/pipeline/update.go
@@ -55,14 +55,8 @@ func runUpdateCmd(c *core.CommandConfig) error {
 }
 
 func preRunUpdateCmd(c *core.PreCommandConfig) error {
-	if err := core.CheckRequiredFlagsSets(
-		c.Command, c.NS, []string{constants.FlagLoggingPipelineId, constants.FlagJsonProperties},
+	return c.CheckRequiredFlagsSetsAndLocation(
+		[]string{constants.FlagLoggingPipelineId, constants.FlagJsonProperties},
 		[]string{constants.FlagJsonPropertiesExample},
-	); err != nil {
-		return err
-	}
-	if err := c.RequireExplicitLocation(); err != nil {
-		return err
-	}
-	return nil
+	)
 }

--- a/commands/monitoring/central/disable.go
+++ b/commands/monitoring/central/disable.go
@@ -15,6 +15,9 @@ func CentralDisable() *core.Command {
 		ShortDesc: "Disable CentralMonitoring",
 		Example:   "ionosctl monitoring central disable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/monitoring/central/disable.go
+++ b/commands/monitoring/central/disable.go
@@ -15,10 +15,7 @@ func CentralDisable() *core.Command {
 		ShortDesc: "Disable CentralMonitoring",
 		Example:   "ionosctl monitoring central disable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			return enable(c, false)

--- a/commands/monitoring/central/enable.go
+++ b/commands/monitoring/central/enable.go
@@ -15,10 +15,7 @@ func CentralEnable() *core.Command {
 		ShortDesc: "Enable CentralMonitoring",
 		Example:   "ionosctl monitoring central enable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			return enable(c, true)

--- a/commands/monitoring/central/enable.go
+++ b/commands/monitoring/central/enable.go
@@ -15,6 +15,9 @@ func CentralEnable() *core.Command {
 		ShortDesc: "Enable CentralMonitoring",
 		Example:   "ionosctl monitoring central enable --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/monitoring/central/get.go
+++ b/commands/monitoring/central/get.go
@@ -17,6 +17,9 @@ func CentralFindByIdCmd() *core.Command {
 		ShortDesc: "Retrieve CentralMonitoring",
 		Example:   "ionosctl monitoring central get --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/monitoring/central/get.go
+++ b/commands/monitoring/central/get.go
@@ -17,10 +17,7 @@ func CentralFindByIdCmd() *core.Command {
 		ShortDesc: "Retrieve CentralMonitoring",
 		Example:   "ionosctl monitoring central get --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation()
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			r, _, err := client.Must().Monitoring.CentralApi.CentralGet(context.Background()).Execute()

--- a/commands/monitoring/key/create.go
+++ b/commands/monitoring/key/create.go
@@ -23,6 +23,9 @@ func KeyPostCmd() *core.Command {
 			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/commands/monitoring/key/create.go
+++ b/commands/monitoring/key/create.go
@@ -20,14 +20,7 @@ func KeyPostCmd() *core.Command {
 		ShortDesc: "Create a new key for a pipeline",
 		Example:   "ionosctl monitoring key create --location de/txl --pipeline-id ID",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagPipelineID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 

--- a/commands/monitoring/pipeline/create.go
+++ b/commands/monitoring/pipeline/create.go
@@ -20,14 +20,7 @@ func MonitoringPostCmd() *core.Command {
 		ShortDesc: "Create an pipeline",
 		Example:   "ionosctl monitoring pipeline create --location de/txl --name name",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagName); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagName)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 

--- a/commands/monitoring/pipeline/create.go
+++ b/commands/monitoring/pipeline/create.go
@@ -23,6 +23,9 @@ func MonitoringPostCmd() *core.Command {
 			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagName); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/commands/monitoring/pipeline/delete.go
+++ b/commands/monitoring/pipeline/delete.go
@@ -30,6 +30,10 @@ func MonitoringDeleteCmd() *core.Command {
 				return deleteAll(c)
 			}
 
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+
 			monitoringId := viper.GetString(core.GetFlagName(c.NS, constants.FlagPipelineID))
 			z, _, err := client.Must().Monitoring.PipelinesApi.PipelinesFindById(context.Background(), monitoringId).Execute()
 			if err != nil {

--- a/commands/monitoring/pipeline/delete.go
+++ b/commands/monitoring/pipeline/delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/monitoring/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -71,22 +72,27 @@ func MonitoringDeleteCmd() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	c.Verbose("Deleting all pipelines!")
-	xs, _, err := client.Must().Monitoring.PipelinesApi.PipelinesGet(context.Background()).Execute()
-
-	err = functional.ApplyAndAggregateErrors(xs.GetItems(), func(z monitoring.PipelineRead) error {
-		yes :=
-			confirm.FAsk(c.Command.Command.InOrStdin(),
-				fmt.Sprintf("Are you sure you want to delete pipeline with name: %s, id: %s ", z.Properties.Name, z.Id),
-				viper.GetBool(constants.ArgForce))
-		if yes {
-			_, delErr := client.Must().Monitoring.PipelinesApi.PipelinesDelete(context.Background(), z.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s (name: %s): %w", z.Id, z.Properties.Name, delErr)
-			}
+	// Fan out over every location (when --location is unset) so `delete --all`
+	// spans all locations, matching `list`. Each location gets its own client.
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		mc := monitoring.NewAPIClient(cfg)
+		c.Verbose("Deleting all pipelines in %s!", location)
+		xs, _, err := mc.PipelinesApi.PipelinesGet(context.Background()).Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing pipelines: %w", err)
 		}
-		return nil
-	})
 
-	return err
+		return functional.ApplyAndAggregateErrors(xs.GetItems(), func(z monitoring.PipelineRead) error {
+			yes := confirm.FAsk(c.Command.Command.InOrStdin(),
+				fmt.Sprintf("Are you sure you want to delete pipeline with name: %s, id: %s (location: %s) ", z.Properties.Name, z.Id, location),
+				viper.GetBool(constants.ArgForce))
+			if yes {
+				_, delErr := mc.PipelinesApi.PipelinesDelete(context.Background(), z.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s (name: %s): %w", z.Id, z.Properties.Name, delErr)
+				}
+			}
+			return nil
+		})
+	})
 }

--- a/commands/monitoring/pipeline/get.go
+++ b/commands/monitoring/pipeline/get.go
@@ -24,6 +24,9 @@ func MonitoringFindByIdCmd() *core.Command {
 			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/commands/monitoring/pipeline/get.go
+++ b/commands/monitoring/pipeline/get.go
@@ -21,14 +21,7 @@ func MonitoringFindByIdCmd() *core.Command {
 		ShortDesc: "Retrieve a pipeline",
 		Example:   "ionosctl monitoring pipeline get --location de/txl --pipeline-id ID",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagPipelineID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			pipelineId := viper.GetString(core.GetFlagName(c.NS, constants.FlagPipelineID))

--- a/commands/monitoring/pipeline/list.go
+++ b/commands/monitoring/pipeline/list.go
@@ -18,7 +18,7 @@ func MonitoringListCmd() *core.Command {
 		Verb:      "list",
 		Aliases:   []string{"ls"},
 		ShortDesc: "Retrieve pipelines",
-		Example:   "ionosctl monitoring pipeline list --location de/txl",
+		Example:   "ionosctl monitoring pipeline list\nionosctl monitoring pipeline list --location de/txl",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
 			return nil
 		},

--- a/commands/monitoring/pipeline/list.go
+++ b/commands/monitoring/pipeline/list.go
@@ -3,10 +3,12 @@ package pipeline
 import (
 	"context"
 
-	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	"github.com/ionos-cloud/sdk-go-bundle/products/monitoring/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
+
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
-	"github.com/spf13/viper"
 )
 
 func MonitoringListCmd() *core.Command {
@@ -21,18 +23,17 @@ func MonitoringListCmd() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			req := client.Must().Monitoring.PipelinesApi.PipelinesGet(context.Background())
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				monitoringClient := monitoring.NewAPIClient(cfg)
+				req := monitoringClient.PipelinesApi.PipelinesGet(context.Background())
 
-			if fn := core.GetFlagName(c.NS, constants.FlagOrderBy); viper.IsSet(fn) {
-				req = req.OrderBy(viper.GetString(fn))
-			}
+				if fn := core.GetFlagName(c.NS, constants.FlagOrderBy); viper.IsSet(fn) {
+					req = req.OrderBy(viper.GetString(fn))
+				}
 
-			ls, _, err := req.Execute()
-			if err != nil {
-				return err
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+				ls, _, err := req.Execute()
+				return ls, err
+			})
 		},
 		InitClient: true,
 	})

--- a/commands/monitoring/pipeline/update.go
+++ b/commands/monitoring/pipeline/update.go
@@ -24,6 +24,9 @@ func MonitoringPutCmd() *core.Command {
 			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
 				return err
 			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {

--- a/commands/monitoring/pipeline/update.go
+++ b/commands/monitoring/pipeline/update.go
@@ -21,13 +21,7 @@ func MonitoringPutCmd() *core.Command {
 		ShortDesc: "Partially modify a pipeline's properties. This command uses a combination of GET and PUT to simulate a PATCH operation",
 		Example:   "ionosctl monitoring pipeline update --location de/txl --pipeline-id ID --name name",
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagPipelineID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagPipelineID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			pipelineId := viper.GetString(core.GetFlagName(c.NS, constants.FlagPipelineID))

--- a/commands/vpn/ipsec/gateway/create.go
+++ b/commands/vpn/ipsec/gateway/create.go
@@ -26,19 +26,13 @@ func Create() *core.Command {
 		ShortDesc: "Create a IPSec Gateway",
 		Example:   "ionosctl vpn ipsec gateway create " + core.FlagsUsage(constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS,
+			return c.CheckRequiredFlagsAndLocation(
 				constants.FlagName,
 				constants.FlagDatacenterId,
 				constants.FlagLanId,
 				constants.FlagConnectionIP,
 				constants.FlagGatewayIP,
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.IPSecGateway{}

--- a/commands/vpn/ipsec/gateway/create.go
+++ b/commands/vpn/ipsec/gateway/create.go
@@ -26,13 +26,19 @@ func Create() *core.Command {
 		ShortDesc: "Create a IPSec Gateway",
 		Example:   "ionosctl vpn ipsec gateway create " + core.FlagsUsage(constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS,
+			if err := core.CheckRequiredFlags(c.Command, c.NS,
 				constants.FlagName,
 				constants.FlagDatacenterId,
 				constants.FlagLanId,
 				constants.FlagConnectionIP,
 				constants.FlagGatewayIP,
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.IPSecGateway{}

--- a/commands/vpn/ipsec/gateway/delete.go
+++ b/commands/vpn/ipsec/gateway/delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/vpn/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -24,17 +25,15 @@ func Delete() *core.Command {
 		ShortDesc: "Delete a gateway",
 		Example:   "ionosctl vpn ipsec gateway " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID}); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID})
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
 				return deleteAll(c)
+			}
+
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
 			}
 
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))
@@ -71,25 +70,28 @@ func Delete() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	c.Verbose("Deleting all gateways!")
-	xs, _, err := client.Must().VPNClient.IPSecGatewaysApi.IpsecgatewaysGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	err = functional.ApplyAndAggregateErrors(xs.GetItems(), func(g vpn.IPSecGatewayRead) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf(
-			"Are you sure you want to delete gateway %s at %s",
-			g.Properties.Name, g.Properties.GatewayIP),
-			viper.GetBool(constants.ArgForce))
-		if yes {
-			_, delErr := client.Must().VPNClient.IPSecGatewaysApi.IpsecgatewaysDelete(context.Background(), g.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s (name: %s): %w", g.Id, g.Properties.Name, delErr)
-			}
+	// Fan out over every location (when --location is unset) so `delete --all`
+	// spans all locations, matching `list`. Each location gets its own client.
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		vc := vpn.NewAPIClient(cfg)
+		c.Verbose("Deleting all gateways in %s!", location)
+		xs, _, err := vc.IPSecGatewaysApi.IpsecgatewaysGet(context.Background()).Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing gateways: %w", err)
 		}
-		return nil
-	})
 
-	return err
+		return functional.ApplyAndAggregateErrors(xs.GetItems(), func(g vpn.IPSecGatewayRead) error {
+			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf(
+				"Are you sure you want to delete gateway %s at %s (location: %s)",
+				g.Properties.Name, g.Properties.GatewayIP, location),
+				viper.GetBool(constants.ArgForce))
+			if yes {
+				_, delErr := vc.IPSecGatewaysApi.IpsecgatewaysDelete(context.Background(), g.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s (name: %s): %w", g.Id, g.Properties.Name, delErr)
+				}
+			}
+			return nil
+		})
+	})
 }

--- a/commands/vpn/ipsec/gateway/delete.go
+++ b/commands/vpn/ipsec/gateway/delete.go
@@ -24,7 +24,13 @@ func Delete() *core.Command {
 		ShortDesc: "Delete a gateway",
 		Example:   "ionosctl vpn ipsec gateway " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID})
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID}); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/ipsec/gateway/get.go
+++ b/commands/vpn/ipsec/gateway/get.go
@@ -21,7 +21,13 @@ func Get() *core.Command {
 		ShortDesc: "Find a gateway by ID",
 		Example:   "ionosctl vpn ipsec gateway get " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/gateway/get.go
+++ b/commands/vpn/ipsec/gateway/get.go
@@ -21,13 +21,7 @@ func Get() *core.Command {
 		ShortDesc: "Find a gateway by ID",
 		Example:   "ionosctl vpn ipsec gateway get " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/gateway/list.go
+++ b/commands/vpn/ipsec/gateway/list.go
@@ -2,9 +2,9 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/commands/vpn/ipsec/completer"
+	vpn "github.com/ionos-cloud/sdk-go-bundle/products/vpn/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 )
@@ -21,13 +21,13 @@ func List() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			ls, err := completer.Gateways()
-			if err != nil {
-				return fmt.Errorf("failed listing gateways: %w", err)
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				vpnClient := vpn.NewAPIClient(cfg)
+				ls, _, err := vpnClient.IPSecGatewaysApi.IpsecgatewaysGet(context.Background()).Execute()
+				return ls, err
+			})
 		},
+		InitClient: true,
 	})
 
 	return cmd

--- a/commands/vpn/ipsec/gateway/update.go
+++ b/commands/vpn/ipsec/gateway/update.go
@@ -29,13 +29,7 @@ func Update() *core.Command {
 		ShortDesc: "Update a IPSec Gateway",
 		Example:   "ionosctl vpn ipsec gateway update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/gateway/update.go
+++ b/commands/vpn/ipsec/gateway/update.go
@@ -29,7 +29,13 @@ func Update() *core.Command {
 		ShortDesc: "Update a IPSec Gateway",
 		Example:   "ionosctl vpn ipsec gateway update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/tunnel/create.go
+++ b/commands/vpn/ipsec/tunnel/create.go
@@ -27,7 +27,7 @@ func Create() *core.Command {
 			LongDesc:  "Create IPSec tunnels",
 			Example:   "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagHost, constants.FlagAuthMethod, constants.FlagPSKKey, constants.FlagIKEDiffieHellmanGroup, constants.FlagIKEEncryptionAlgorithm, constants.FlagIKEIntegrityAlgorithm, constants.FlagIKELifetime, constants.FlagESPDiffieHellmanGroup, constants.FlagESPEncryptionAlgorithm, constants.FlagESPIntegrityAlgorithm, constants.FlagESPLifetime, constants.FlagCloudNetworkCIDRs, constants.FlagPeerNetworkCIDRs) + "\n" + "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagJsonProperties) + "\n" + "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagJsonProperties) + " " + constants.FlagJsonPropertiesExample,
 			PreCmdRun: func(c *core.PreCommandConfig) error {
-				if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+				return c.CheckRequiredFlagsSetsAndLocation(
 					[]string{constants.FlagJsonProperties, constants.FlagGatewayID},
 					[]string{constants.FlagJsonPropertiesExample},
 					[]string{
@@ -47,13 +47,7 @@ func Create() *core.Command {
 						constants.FlagCloudNetworkCIDRs,
 						constants.FlagPeerNetworkCIDRs,
 					},
-				); err != nil {
-					return err
-				}
-				if err := c.RequireExplicitLocation(); err != nil {
-					return err
-				}
-				return nil
+				)
 			},
 			CmdRun: func(c *core.CommandConfig) error {
 				if c.Command.Command.Flags().Changed(constants.FlagJsonProperties) {

--- a/commands/vpn/ipsec/tunnel/create.go
+++ b/commands/vpn/ipsec/tunnel/create.go
@@ -27,7 +27,7 @@ func Create() *core.Command {
 			LongDesc:  "Create IPSec tunnels",
 			Example:   "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagHost, constants.FlagAuthMethod, constants.FlagPSKKey, constants.FlagIKEDiffieHellmanGroup, constants.FlagIKEEncryptionAlgorithm, constants.FlagIKEIntegrityAlgorithm, constants.FlagIKELifetime, constants.FlagESPDiffieHellmanGroup, constants.FlagESPEncryptionAlgorithm, constants.FlagESPIntegrityAlgorithm, constants.FlagESPLifetime, constants.FlagCloudNetworkCIDRs, constants.FlagPeerNetworkCIDRs) + "\n" + "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagJsonProperties) + "\n" + "ionosctl vpn ipsec tunnel create " + core.FlagsUsage(constants.FlagJsonProperties) + " " + constants.FlagJsonPropertiesExample,
 			PreCmdRun: func(c *core.PreCommandConfig) error {
-				return core.CheckRequiredFlagsSets(c.Command, c.NS,
+				if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 					[]string{constants.FlagJsonProperties, constants.FlagGatewayID},
 					[]string{constants.FlagJsonPropertiesExample},
 					[]string{
@@ -47,7 +47,13 @@ func Create() *core.Command {
 						constants.FlagCloudNetworkCIDRs,
 						constants.FlagPeerNetworkCIDRs,
 					},
-				)
+				); err != nil {
+					return err
+				}
+				if err := c.RequireExplicitLocation(); err != nil {
+					return err
+				}
+				return nil
 			},
 			CmdRun: func(c *core.CommandConfig) error {
 				if c.Command.Command.Flags().Changed(constants.FlagJsonProperties) {

--- a/commands/vpn/ipsec/tunnel/delete.go
+++ b/commands/vpn/ipsec/tunnel/delete.go
@@ -24,16 +24,10 @@ func Delete() *core.Command {
 		ShortDesc: "Remove a IPSec Tunnel",
 		Example:   "ionosctl vpn ipsec tunnel delete " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				[]string{constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagGatewayID, constants.ArgAll},
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/ipsec/tunnel/delete.go
+++ b/commands/vpn/ipsec/tunnel/delete.go
@@ -24,10 +24,16 @@ func Delete() *core.Command {
 		ShortDesc: "Remove a IPSec Tunnel",
 		Example:   "ionosctl vpn ipsec tunnel delete " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 				[]string{constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagGatewayID, constants.ArgAll},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/ipsec/tunnel/get.go
+++ b/commands/vpn/ipsec/tunnel/get.go
@@ -21,13 +21,7 @@ func Get() *core.Command {
 		ShortDesc: "Find a tunnel by ID",
 		Example:   "ionosctl vpn ipsec tunnel get " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagTunnelID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID, constants.FlagTunnelID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/tunnel/get.go
+++ b/commands/vpn/ipsec/tunnel/get.go
@@ -21,7 +21,13 @@ func Get() *core.Command {
 		ShortDesc: "Find a tunnel by ID",
 		Example:   "ionosctl vpn ipsec tunnel get " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagTunnelID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagTunnelID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/ipsec/tunnel/list.go
+++ b/commands/vpn/ipsec/tunnel/list.go
@@ -20,13 +20,7 @@ func List() *core.Command {
 		ShortDesc: "List IPSec Tunnels",
 		Example:   "ionosctl vpn ipsec tunnel list " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, err := completer.Tunnels(viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID)))

--- a/commands/vpn/ipsec/tunnel/list.go
+++ b/commands/vpn/ipsec/tunnel/list.go
@@ -20,7 +20,13 @@ func List() *core.Command {
 		ShortDesc: "List IPSec Tunnels",
 		Example:   "ionosctl vpn ipsec tunnel list " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, err := completer.Tunnels(viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID)))

--- a/commands/vpn/ipsec/tunnel/update.go
+++ b/commands/vpn/ipsec/tunnel/update.go
@@ -24,11 +24,17 @@ func Update() *core.Command {
 		ShortDesc: "Update a IPSec Tunnel",
 		Example:   "ionosctl vpn ipsec tunnel update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID, constants.FlagName),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 				[]string{constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagJsonProperties, constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagJsonPropertiesExample},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if viper.IsSet(constants.FlagJsonProperties) {

--- a/commands/vpn/ipsec/tunnel/update.go
+++ b/commands/vpn/ipsec/tunnel/update.go
@@ -24,17 +24,11 @@ func Update() *core.Command {
 		ShortDesc: "Update a IPSec Tunnel",
 		Example:   "ionosctl vpn ipsec tunnel update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagTunnelID, constants.FlagName),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				[]string{constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagJsonProperties, constants.FlagGatewayID, constants.FlagTunnelID},
 				[]string{constants.FlagJsonPropertiesExample},
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if viper.IsSet(constants.FlagJsonProperties) {

--- a/commands/vpn/wireguard/gateway/create.go
+++ b/commands/vpn/wireguard/gateway/create.go
@@ -37,11 +37,17 @@ func Create() *core.Command {
 				constants.FlagGatewayIP,
 				constants.FlagInterfaceIP,
 			}
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 				// either privateKey or privateKeyPath are required
 				append(baseReq, constants.FlagPrivateKey),
 				append(baseReq, constants.FlagPrivateKeyPath),
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.WireguardGateway{}

--- a/commands/vpn/wireguard/gateway/create.go
+++ b/commands/vpn/wireguard/gateway/create.go
@@ -37,17 +37,11 @@ func Create() *core.Command {
 				constants.FlagGatewayIP,
 				constants.FlagInterfaceIP,
 			}
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				// either privateKey or privateKeyPath are required
 				append(baseReq, constants.FlagPrivateKey),
 				append(baseReq, constants.FlagPrivateKeyPath),
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.WireguardGateway{}

--- a/commands/vpn/wireguard/gateway/delete.go
+++ b/commands/vpn/wireguard/gateway/delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ionos-cloud/ionosctl/v6/pkg/confirm"
 	"github.com/ionos-cloud/ionosctl/v6/pkg/functional"
 	"github.com/ionos-cloud/sdk-go-bundle/products/vpn/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
 )
 
@@ -24,17 +25,15 @@ func Delete() *core.Command {
 		ShortDesc: "Delete a gateway",
 		Example:   "ionosctl vpn wg gateway delete " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID}); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID})
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {
 				return deleteAll(c)
+			}
+
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
 			}
 
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))
@@ -72,25 +71,28 @@ func Delete() *core.Command {
 }
 
 func deleteAll(c *core.CommandConfig) error {
-	c.Verbose("Deleting all gateways!")
-	xs, _, err := client.Must().VPNClient.WireguardGatewaysApi.WireguardgatewaysGet(context.Background()).Execute()
-	if err != nil {
-		return err
-	}
-
-	err = functional.ApplyAndAggregateErrors(xs.GetItems(), func(g vpn.WireguardGatewayRead) error {
-		yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf(
-			"Are you sure you want to delete gateway %s at %s",
-			g.Properties.Name, g.Properties.GatewayIP),
-			viper.GetBool(constants.ArgForce))
-		if yes {
-			_, delErr := client.Must().VPNClient.WireguardGatewaysApi.WireguardgatewaysDelete(context.Background(), g.Id).Execute()
-			if delErr != nil {
-				return fmt.Errorf("failed deleting %s (name: %s): %w", g.Id, g.Properties.Name, delErr)
-			}
+	// Fan out over every location (when --location is unset) so `delete --all`
+	// spans all locations, matching `list`. Each location gets its own client.
+	return c.RunForAllLocations(func(cfg *shared.Configuration, location string) error {
+		vc := vpn.NewAPIClient(cfg)
+		c.Verbose("Deleting all gateways in %s!", location)
+		xs, _, err := vc.WireguardGatewaysApi.WireguardgatewaysGet(context.Background()).Execute()
+		if err != nil {
+			return fmt.Errorf("failed listing gateways: %w", err)
 		}
-		return nil
-	})
 
-	return err
+		return functional.ApplyAndAggregateErrors(xs.GetItems(), func(g vpn.WireguardGatewayRead) error {
+			yes := confirm.FAsk(c.Command.Command.InOrStdin(), fmt.Sprintf(
+				"Are you sure you want to delete gateway %s at %s (location: %s)",
+				g.Properties.Name, g.Properties.GatewayIP, location),
+				viper.GetBool(constants.ArgForce))
+			if yes {
+				_, delErr := vc.WireguardGatewaysApi.WireguardgatewaysDelete(context.Background(), g.Id).Execute()
+				if delErr != nil {
+					return fmt.Errorf("failed deleting %s (name: %s): %w", g.Id, g.Properties.Name, delErr)
+				}
+			}
+			return nil
+		})
+	})
 }

--- a/commands/vpn/wireguard/gateway/delete.go
+++ b/commands/vpn/wireguard/gateway/delete.go
@@ -24,7 +24,13 @@ func Delete() *core.Command {
 		ShortDesc: "Delete a gateway",
 		Example:   "ionosctl vpn wg gateway delete " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID})
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS, []string{constants.ArgAll}, []string{constants.FlagGatewayID}); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/wireguard/gateway/get.go
+++ b/commands/vpn/wireguard/gateway/get.go
@@ -21,7 +21,13 @@ func Get() *core.Command {
 		ShortDesc: "Find a gateway by ID",
 		Example:   "ionosctl vpn wireguard gateway get " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/gateway/get.go
+++ b/commands/vpn/wireguard/gateway/get.go
@@ -21,13 +21,7 @@ func Get() *core.Command {
 		ShortDesc: "Find a gateway by ID",
 		Example:   "ionosctl vpn wireguard gateway get " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/gateway/list.go
+++ b/commands/vpn/wireguard/gateway/list.go
@@ -2,9 +2,9 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/ionos-cloud/ionosctl/v6/commands/vpn/wireguard/completer"
+	vpn "github.com/ionos-cloud/sdk-go-bundle/products/vpn/v2"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/core"
 )
@@ -21,13 +21,13 @@ func List() *core.Command {
 			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
-			ls, err := completer.Gateways()
-			if err != nil {
-				return fmt.Errorf("failed listing gateways: %w", err)
-			}
-
-			return c.Printer(allCols).Prefix("items").Print(ls)
+			return c.ListAllLocations(allCols, func(cfg *shared.Configuration) (any, error) {
+				vpnClient := vpn.NewAPIClient(cfg)
+				ls, _, err := vpnClient.WireguardGatewaysApi.WireguardgatewaysGet(context.Background()).Execute()
+				return ls, err
+			})
 		},
+		InitClient: true,
 	})
 
 	return cmd

--- a/commands/vpn/wireguard/gateway/update.go
+++ b/commands/vpn/wireguard/gateway/update.go
@@ -32,10 +32,16 @@ func Update() *core.Command {
 		LongDesc:  "Update a WireGuard Gateway. Note: The private key MUST be provided again (or changed) on updates.",
 		Example:   "ionosctl vpn wireguard gateway update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 				[]string{constants.FlagGatewayID, constants.FlagPrivateKey},
 				[]string{constants.FlagGatewayID, constants.FlagPrivateKeyPath},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/gateway/update.go
+++ b/commands/vpn/wireguard/gateway/update.go
@@ -32,16 +32,10 @@ func Update() *core.Command {
 		LongDesc:  "Update a WireGuard Gateway. Note: The private key MUST be provided again (or changed) on updates.",
 		Example:   "ionosctl vpn wireguard gateway update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagDatacenterId, constants.FlagLanId, constants.FlagConnectionIP, constants.FlagGatewayIP, constants.FlagInterfaceIP),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				[]string{constants.FlagGatewayID, constants.FlagPrivateKey},
 				[]string{constants.FlagGatewayID, constants.FlagPrivateKeyPath},
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			id := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/peer/create.go
+++ b/commands/vpn/wireguard/peer/create.go
@@ -24,15 +24,9 @@ func Create() *core.Command {
 		LongDesc:  "Create WireGuard Peers. There is a limit to the total number of peers. Please refer to product documentation",
 		Example:   "ionosctl vpn wireguard peer create " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS,
+			return c.CheckRequiredFlagsAndLocation(
 				constants.FlagGatewayID, constants.FlagName, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost,
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.WireguardPeer{}

--- a/commands/vpn/wireguard/peer/create.go
+++ b/commands/vpn/wireguard/peer/create.go
@@ -24,9 +24,15 @@ func Create() *core.Command {
 		LongDesc:  "Create WireGuard Peers. There is a limit to the total number of peers. Please refer to product documentation",
 		Example:   "ionosctl vpn wireguard peer create " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagName, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS,
+			if err := core.CheckRequiredFlags(c.Command, c.NS,
 				constants.FlagGatewayID, constants.FlagName, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost,
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			input := vpn.WireguardPeer{}

--- a/commands/vpn/wireguard/peer/delete.go
+++ b/commands/vpn/wireguard/peer/delete.go
@@ -24,10 +24,16 @@ func Delete() *core.Command {
 		ShortDesc: "Remove a WireGuard Peer",
 		Example:   "ionosctl vpn wireguard peer delete " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlagsSets(c.Command, c.NS,
+			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
 				[]string{constants.FlagGatewayID, constants.FlagPeerID},
 				[]string{constants.FlagGatewayID, constants.ArgAll},
-			)
+			); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/wireguard/peer/delete.go
+++ b/commands/vpn/wireguard/peer/delete.go
@@ -24,16 +24,10 @@ func Delete() *core.Command {
 		ShortDesc: "Remove a WireGuard Peer",
 		Example:   "ionosctl vpn wireguard peer delete " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlagsSets(c.Command, c.NS,
+			return c.CheckRequiredFlagsSetsAndLocation(
 				[]string{constants.FlagGatewayID, constants.FlagPeerID},
 				[]string{constants.FlagGatewayID, constants.ArgAll},
-			); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			if all := viper.GetBool(core.GetFlagName(c.NS, constants.ArgAll)); all {

--- a/commands/vpn/wireguard/peer/get.go
+++ b/commands/vpn/wireguard/peer/get.go
@@ -21,7 +21,13 @@ func Get() *core.Command {
 		ShortDesc: "Find a peer by ID",
 		Example:   "ionosctl vpn wg peer get " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/peer/get.go
+++ b/commands/vpn/wireguard/peer/get.go
@@ -21,13 +21,7 @@ func Get() *core.Command {
 		ShortDesc: "Find a peer by ID",
 		Example:   "ionosctl vpn wg peer get " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID, constants.FlagPeerID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/peer/list.go
+++ b/commands/vpn/wireguard/peer/list.go
@@ -20,7 +20,13 @@ func List() *core.Command {
 		ShortDesc: "List WireGuard Peers",
 		Example:   "ionosctl vpn wireguard peer list " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, err := completer.Peers(viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID)))

--- a/commands/vpn/wireguard/peer/list.go
+++ b/commands/vpn/wireguard/peer/list.go
@@ -20,13 +20,7 @@ func List() *core.Command {
 		ShortDesc: "List WireGuard Peers",
 		Example:   "ionosctl vpn wireguard peer list " + core.FlagsUsage(constants.FlagGatewayID),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			ls, err := completer.Peers(viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID)))

--- a/commands/vpn/wireguard/peer/update.go
+++ b/commands/vpn/wireguard/peer/update.go
@@ -23,7 +23,13 @@ func Update() *core.Command {
 		ShortDesc: "Update a WireGuard Peer",
 		Example:   "ionosctl vpn wireguard peer update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID, constants.FlagName, constants.FlagDescription, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost, constants.FlagPort),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			return core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID)
+			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID); err != nil {
+				return err
+			}
+			if err := c.RequireExplicitLocation(); err != nil {
+				return err
+			}
+			return nil
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/commands/vpn/wireguard/peer/update.go
+++ b/commands/vpn/wireguard/peer/update.go
@@ -23,13 +23,7 @@ func Update() *core.Command {
 		ShortDesc: "Update a WireGuard Peer",
 		Example:   "ionosctl vpn wireguard peer update " + core.FlagsUsage(constants.FlagGatewayID, constants.FlagPeerID, constants.FlagName, constants.FlagDescription, constants.FlagIps, constants.FlagPublicKey, constants.FlagHost, constants.FlagPort),
 		PreCmdRun: func(c *core.PreCommandConfig) error {
-			if err := core.CheckRequiredFlags(c.Command, c.NS, constants.FlagGatewayID, constants.FlagPeerID); err != nil {
-				return err
-			}
-			if err := c.RequireExplicitLocation(); err != nil {
-				return err
-			}
-			return nil
+			return c.CheckRequiredFlagsAndLocation(constants.FlagGatewayID, constants.FlagPeerID)
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			gatewayId := viper.GetString(core.GetFlagName(c.NS, constants.FlagGatewayID))

--- a/docs/subcommands/CDN/distribution/create.md
+++ b/docs/subcommands/CDN/distribution/create.md
@@ -42,7 +42,7 @@ Create a CDN distribution. Wiki: https://docs.ionos.com/cloud/network-services/c
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/CDN/distribution/delete.md
+++ b/docs/subcommands/CDN/distribution/delete.md
@@ -42,7 +42,7 @@ Delete a distribution
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/get.md
+++ b/docs/subcommands/CDN/distribution/get.md
@@ -41,7 +41,7 @@ Retrieve a distribution
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/list.md
+++ b/docs/subcommands/CDN/distribution/list.md
@@ -41,7 +41,7 @@ Retrieve all distributions using pagination and optional filters
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/CDN/distribution/routingrules/get.md
+++ b/docs/subcommands/CDN/distribution/routingrules/get.md
@@ -47,7 +47,7 @@ Retrieve a distribution routing rules
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/update.md
+++ b/docs/subcommands/CDN/distribution/update.md
@@ -43,7 +43,7 @@ Partially modify a distribution's properties. This command uses a combination of
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/create.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/create.md
@@ -48,7 +48,7 @@ Create an AutoCertificate. Requires an enabled DNS Zone with the same name as th
   -h, --help                                Print usage
       --key-algorithm string                The key algorithm used to generate the certificate. (required)
       --limit int                           Maximum number of items to return per request (default 50)
-  -l, --location string                     Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string                     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string                         The name of the AutoCertificate
       --no-headers                          Don't print table headers when table output is used
       --offset int                          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/autocertificate/delete.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/delete.md
@@ -48,7 +48,7 @@ Delete an AutoCertificate
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/get.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/get.md
@@ -47,7 +47,7 @@ Retrieve an AutoCertificate
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/list.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/list.md
@@ -47,7 +47,7 @@ Retrieve AutoCertificate list
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/update.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/update.md
@@ -47,7 +47,7 @@ Update an AutoCertificate.
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string                 The new name of the AutoCertificate (required)
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/certificate/create.md
+++ b/docs/subcommands/Certificate-Manager/certificate/create.md
@@ -51,7 +51,7 @@ Use this command to add a Certificate.
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --limit int                       Maximum number of items to return per request (default 50)
-  -l, --location string                 Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string                 Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers                      Don't print table headers when table output is used
       --offset int                      Number of items to skip before starting to collect the results
       --order-by string                 Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/delete.md
+++ b/docs/subcommands/Certificate-Manager/certificate/delete.md
@@ -48,7 +48,7 @@ Use this command to delete a Certificate by ID.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/get.md
+++ b/docs/subcommands/Certificate-Manager/certificate/get.md
@@ -49,7 +49,7 @@ Use this command to retrieve a Certificate by ID.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/list.md
+++ b/docs/subcommands/Certificate-Manager/certificate/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve all Certificates.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/update.md
+++ b/docs/subcommands/Certificate-Manager/certificate/update.md
@@ -48,7 +48,7 @@ Use this change a certificate's name.
   -f, --force                     Force command to execute without user input
   -h, --help                      Print usage
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results
       --order-by string           Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/create.md
+++ b/docs/subcommands/Certificate-Manager/provider/create.md
@@ -49,7 +49,7 @@ Create an Provider
       --key-id string       The key ID of the external account binding
       --key-secret string   The key secret of the external account binding
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string         The name of the certificate Provider
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/provider/delete.md
+++ b/docs/subcommands/Certificate-Manager/provider/delete.md
@@ -47,7 +47,7 @@ Delete an Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/get.md
+++ b/docs/subcommands/Certificate-Manager/provider/get.md
@@ -46,7 +46,7 @@ Retrieve a Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/list.md
+++ b/docs/subcommands/Certificate-Manager/provider/list.md
@@ -46,7 +46,7 @@ Retrieve Provider list
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/update.md
+++ b/docs/subcommands/Certificate-Manager/provider/update.md
@@ -46,7 +46,7 @@ Modify an Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new name of the Provider (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Compute Engine/monitoring/central/disable.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/disable.md
@@ -40,7 +40,7 @@ Disable CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/central/enable.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/enable.md
@@ -40,7 +40,7 @@ Enable CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/central/get.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/get.md
@@ -40,7 +40,7 @@ Retrieve CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/key/create.md
+++ b/docs/subcommands/Compute Engine/monitoring/key/create.md
@@ -38,7 +38,7 @@ Create a new key for a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/create.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/create.md
@@ -40,7 +40,7 @@ Create an pipeline
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
   -n, --name string       The name of the Monitoring pipeline
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/delete.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/delete.md
@@ -41,7 +41,7 @@ Delete a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/get.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/get.md
@@ -40,7 +40,7 @@ Retrieve a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/list.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/list.md
@@ -40,7 +40,7 @@ Retrieve pipelines
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by
@@ -55,6 +55,7 @@ Retrieve pipelines
 ## Examples
 
 ```text
+ionosctl monitoring pipeline list
 ionosctl monitoring pipeline list --location de/txl
 ```
 

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/update.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/update.md
@@ -40,7 +40,7 @@ Partially modify a pipeline's properties. This command uses a combination of GET
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
   -n, --name string          The new name of the Monitoring Pipeline (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/dnssec/create.md
+++ b/docs/subcommands/DNS/dnssec/create.md
@@ -42,7 +42,7 @@ Enable DNSSEC keys and create associated DNSKEY records for your DNS zone
   -h, --help                   Print usage
       --ksk-bits int           Key signing key length in bits. kskBits >= zskBits: [1024/2048/4096] (default 1024)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers             Don't print table headers when table output is used
       --nsec-mode string       NSEC mode.. Can be one of: NSEC, NSEC3 (default "NSEC")
       --nsec3-iterations int   Number of iterations for NSEC3. [0..50]

--- a/docs/subcommands/DNS/dnssec/delete.md
+++ b/docs/subcommands/DNS/dnssec/delete.md
@@ -40,7 +40,7 @@ Removes ALL associated DNSKEY records for your DNS zone and disables DNSSEC keys
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/dnssec/list.md
+++ b/docs/subcommands/DNS/dnssec/list.md
@@ -40,7 +40,7 @@ Retrieve your zone's DNSSEC keys
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/quota/get.md
+++ b/docs/subcommands/DNS/quota/get.md
@@ -40,7 +40,7 @@ Retrieve your quotas
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/create.md
+++ b/docs/subcommands/DNS/record/create.md
@@ -42,7 +42,7 @@ Create a record. Wiki: https://docs.ionos.com/cloud/network-services/cloud-dns/a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name \*           The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/record/delete.md
+++ b/docs/subcommands/DNS/record/delete.md
@@ -51,7 +51,7 @@ Here, PARTIAL_NAME is a part of the name of the DNS record you want to delete. I
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/get.md
+++ b/docs/subcommands/DNS/record/get.md
@@ -40,7 +40,7 @@ Retrieve a record
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/list.md
+++ b/docs/subcommands/DNS/record/list.md
@@ -41,7 +41,7 @@ Retrieve all records from either a primary or secondary zone
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string             Filter used to fetch only the records that contain specified record name. NOTE: Only available for zone records.
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/record/update.md
+++ b/docs/subcommands/DNS/record/update.md
@@ -42,7 +42,7 @@ Partially modify a record's properties. This command uses a combination of GET a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name \*           The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/reverse/record/create.md
+++ b/docs/subcommands/DNS/reverse/record/create.md
@@ -42,7 +42,7 @@ Create a record. Wiki: https://docs.ionos.com/cloud/network-services/cloud-dns/a
   -h, --help                 Print usage
       --ip string            [IPv4/IPv6] Specifies for which IP address the reverse record should be created. The IP addresses needs to be owned by the contract (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string          The name of the DNS Reverse Record. (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/reverse/record/delete.md
+++ b/docs/subcommands/DNS/reverse/record/delete.md
@@ -41,7 +41,7 @@ Delete a record
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/get.md
+++ b/docs/subcommands/DNS/reverse/record/get.md
@@ -40,7 +40,7 @@ Find a record by IP or ID
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/list.md
+++ b/docs/subcommands/DNS/reverse/record/list.md
@@ -41,7 +41,7 @@ Retrieve all reverse records
   -h, --help              Print usage
   -i, --ips string        Optional filter for the IP address of the reverse record
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/update.md
+++ b/docs/subcommands/DNS/reverse/record/update.md
@@ -42,7 +42,7 @@ Update a record
   -h, --help                 Print usage
       --ip string            The new IP
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new record name
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/create.md
+++ b/docs/subcommands/DNS/secondary/zone/create.md
@@ -44,7 +44,7 @@ IPv6: 2001:8d8:fe:53::5cd:25
   -f, --force                 Force command to execute without user input
   -h, --help                  Print usage
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string           Name of the secondary zone
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/delete.md
+++ b/docs/subcommands/DNS/secondary/zone/delete.md
@@ -41,7 +41,7 @@ Delete a secondary zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/get.md
+++ b/docs/subcommands/DNS/secondary/zone/get.md
@@ -34,7 +34,7 @@ Retrieve a secondary zone by its ID or name
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/list.md
+++ b/docs/subcommands/DNS/secondary/zone/list.md
@@ -34,7 +34,7 @@ List all secondary zones. Default limit is the first 100 items. Use pagination q
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string       Filter used to fetch only the zones that contain the specified zone name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/transfer/get.md
+++ b/docs/subcommands/DNS/secondary/zone/transfer/get.md
@@ -46,7 +46,7 @@ Get the transfer status for a secondary zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/transfer/start.md
+++ b/docs/subcommands/DNS/secondary/zone/transfer/start.md
@@ -46,7 +46,7 @@ Initiate zone transfer
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/update.md
+++ b/docs/subcommands/DNS/secondary/zone/update.md
@@ -35,7 +35,7 @@ Update or create a secondary zone
   -f, --force                 Force command to execute without user input
   -h, --help                  Print usage
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results
       --order-by string       Property to order the results by

--- a/docs/subcommands/DNS/zone/create.md
+++ b/docs/subcommands/DNS/zone/create.md
@@ -42,7 +42,7 @@ Create a zone
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string          The name of the DNS zone, e.g. foo.com
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/zone/delete.md
+++ b/docs/subcommands/DNS/zone/delete.md
@@ -41,7 +41,7 @@ Delete a zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/file/get.md
+++ b/docs/subcommands/DNS/zone/file/get.md
@@ -46,7 +46,7 @@ Get the exported zone file in BIND format (RFC 1035)
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/file/update.md
+++ b/docs/subcommands/DNS/zone/file/update.md
@@ -40,7 +40,7 @@ Update a zone file
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/DNS/zone/get.md
+++ b/docs/subcommands/DNS/zone/get.md
@@ -40,7 +40,7 @@ Retrieve a zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/list.md
+++ b/docs/subcommands/DNS/zone/list.md
@@ -40,7 +40,7 @@ Retrieve zones
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string       Filter used to fetch only the zones that contain the specified zone name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/zone/update.md
+++ b/docs/subcommands/DNS/zone/update.md
@@ -42,7 +42,7 @@ Partially modify a zone's properties. This command uses a combination of GET and
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new name of the DNS zone, e.g. foo.com
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/create.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/create.md
@@ -69,7 +69,7 @@ volatile-ttl: The key with the nearest time to live will be removed first, but o
   -h, --help                      Print usage
       --lan-id string             The numeric Private LAN ID to connect your instance to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of the Replica Set (required)

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/delete.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/delete.md
@@ -47,7 +47,7 @@ Delete In-Memory DB Replica Sets
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/get.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/get.md
@@ -46,7 +46,7 @@ Get an In-Memory DB Replica Set
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Replica Sets
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
   -n, --name string       You can filter the Replica Sets by name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Snapshots
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/create.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/create.md
@@ -47,7 +47,7 @@ Create an In-Memory DB Restore
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
   -n, --name string             The human readable name of your snapshot
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Restores
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/backup/get.md
@@ -47,7 +47,7 @@ Get a MariaDB Backup
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/backup/list.md
@@ -47,7 +47,7 @@ List all MariaDB Backups, or optionally provide a Cluster ID to list those of a 
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
@@ -51,7 +51,7 @@ Create DBaaS MariaDB clusters
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries) (default 1)
       --lan-id string             The numeric LAN ID with which you connect your cluster (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of your cluster (required)

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/delete.md
@@ -48,7 +48,7 @@ Delete a MariaDB Cluster by ID
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
   -n, --name                When deleting all clusters, filter the clusters by a name
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/get.md
@@ -47,7 +47,7 @@ Get a MariaDB Cluster by ID
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of MariaDB Clusters provisioned under your a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
   -n, --name string       Response filter to list only the MariaDB Clusters that contain the specified name in the DisplayName field. The value is case insensitive
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/update.md
@@ -49,7 +49,7 @@ Update a MariaDB Cluster
   -h, --help                      Print usage
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries). Instances can only be increased (3,5,7)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. e.g.: Monday. To change maintenance provide both --maintenance-day and --maintenance-time
       --maintenance-time string   Time for the MaintenanceWindows. e.g.: 16:30:59. To change maintenance provide both --maintenance-day and --maintenance-time
   -n, --name string               The name of your cluster

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/list.md
@@ -47,7 +47,7 @@ Use this command to retrieve a list of PostgreSQL Backups.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int32         The limit of the number of items to return (default 100)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers          Don't print table headers when table output is used
       --offset int32        The offset of the listing
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of PostgreSQL Backup Locations.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The limit of the number of items to return (default 100)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int32      The offset of the listing
       --order-by string   Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/create.md
@@ -66,7 +66,7 @@ Required values to run command:
   -I, --instances int              The number of instances in your cluster (one primary and n-1 standbys). Minimum: 1, Maximum: 5 (default 1)
   -L, --lan-id string              The unique ID of the LAN to connect your cluster to (required)
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --logs-enabled               Enable collection and reporting of logs for this cluster
   -d, --maintenance-day string     Day of the week for the MaintenanceWindow. Defaults to a random day during Mon-Fri. Can be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday (default "Random (Mon-Fri 10:00-16:00)")
   -T, --maintenance-time string    Time for the MaintenanceWindow. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random time during 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/delete.md
@@ -52,7 +52,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
   -n, --name string         Delete all Clusters after filtering based on name. It does not require an exact match. Can be used with --all flag
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of PostgreSQL Clusters provisioned under you
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The maximum number of elements to return (default 100)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
   -n, --name string       Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive
       --no-headers        Don't print table headers when table output is used
       --offset int32      The first element to return

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/restore.md
@@ -55,7 +55,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results
       --order-by string        Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/update.md
@@ -60,7 +60,7 @@ Required values to run command:
   -I, --instances int              The number of instances in your cluster. Minimum: 1, Maximum: 5
   -L, --lan-id string              The unique ID of the LAN to connect your cluster to
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --logs-enabled               Enable collection and reporting of logs for this cluster
   -d, --maintenance-day string     Day of the week for the MaintenanceWindow. Must be specified together with --maintenance-time. Can be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
   -T, --maintenance-time string    Time for the MaintenanceWindow. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59. Must be specified together with --maintenance-day

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/version/get.md
@@ -50,7 +50,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/version/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of available PostgreSQL Versions.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The maximum number of elements to return (default 100)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int32      The first element to return
       --order-by string   Property to order the results by

--- a/docs/subcommands/Kafka/cluster/create.md
+++ b/docs/subcommands/Kafka/cluster/create.md
@@ -43,7 +43,7 @@ Create a kafka cluster. Wiki: https://docs.ionos.com/cloud/data-analytics/kafka/
   -h, --help                       Print usage
       --lan-id string              The ID of the LAN (required)
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
   -n, --name string                The name of the kafka cluster (required)
       --no-headers                 Don't print table headers when table output is used
       --offset int                 Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/cluster/delete.md
+++ b/docs/subcommands/Kafka/cluster/delete.md
@@ -42,7 +42,7 @@ Delete a cluster
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/cluster/get.md
+++ b/docs/subcommands/Kafka/cluster/get.md
@@ -41,7 +41,7 @@ Retrieve a cluster
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/cluster/list.md
+++ b/docs/subcommands/Kafka/cluster/list.md
@@ -40,7 +40,7 @@ Retrieve all clusters using pagination and optional filters
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --name string       Filter used to fetch only the records that contain specified name.
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/cluster/list.md
+++ b/docs/subcommands/Kafka/cluster/list.md
@@ -57,6 +57,6 @@ Retrieve all clusters using pagination and optional filters
 ## Examples
 
 ```text
-ionosctl kafka c list --location de/txl
+ionosctl kafka c list
 ```
 

--- a/docs/subcommands/Kafka/topic/create.md
+++ b/docs/subcommands/Kafka/topic/create.md
@@ -41,7 +41,7 @@ Create a kafka topic
   -f, --force                      Force command to execute without user input
   -h, --help                       Print usage
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
   -n, --name string                The name of the topic (required)
       --no-headers                 Don't print table headers when table output is used
       --offset int                 Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/topic/delete.md
+++ b/docs/subcommands/Kafka/topic/delete.md
@@ -42,7 +42,7 @@ Delete a kafka topic
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/topic/get.md
+++ b/docs/subcommands/Kafka/topic/get.md
@@ -41,7 +41,7 @@ Get a kafka topic
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/topic/list.md
+++ b/docs/subcommands/Kafka/topic/list.md
@@ -41,7 +41,7 @@ List all kafka topics
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by
@@ -56,7 +56,7 @@ List all kafka topics
 ## Examples
 
 ```text
-ionosctl kafka topic list --location LOCATION
+ionosctl kafka topic list --cluster-id CLUSTER_ID
 ionosctl kafka topic list --location LOCATION --cluster-id CLUSTER_ID
 ```
 

--- a/docs/subcommands/Kafka/user/get/access.md
+++ b/docs/subcommands/Kafka/user/get/access.md
@@ -49,7 +49,7 @@ IMPORTANT: Keep these credentials secure. The private key should never be shared
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/user/list.md
+++ b/docs/subcommands/Kafka/user/list.md
@@ -41,7 +41,7 @@ List a cluster's users
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Logging-Service/central/disable.md
+++ b/docs/subcommands/Logging-Service/central/disable.md
@@ -44,7 +44,7 @@ Disable CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/central/enable.md
+++ b/docs/subcommands/Logging-Service/central/enable.md
@@ -44,7 +44,7 @@ Enable CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/central/get.md
+++ b/docs/subcommands/Logging-Service/central/get.md
@@ -44,7 +44,7 @@ Retrieve CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/logs/add.md
+++ b/docs/subcommands/Logging-Service/logs/add.md
@@ -26,7 +26,7 @@ Add a log to a logging pipeline
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp (required)
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/logs/get.md
+++ b/docs/subcommands/Logging-Service/logs/get.md
@@ -26,7 +26,7 @@ Retrieve a log from a logging pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --log-tag string       The tag of the pipeline log that you want to retrieve (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Logging-Service/logs/list.md
+++ b/docs/subcommands/Logging-Service/logs/list.md
@@ -41,7 +41,7 @@ Retrieve logging pipeline logs
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/logs/list.md
+++ b/docs/subcommands/Logging-Service/logs/list.md
@@ -31,7 +31,7 @@ Retrieve logging pipeline logs
 ## Options
 
 ```text
-  -a, --all                  Use this flag to list all logging pipeline logs
+  -a, --all                  List logs from all logging pipelines. When --location is unset, logs from all locations are listed
   -u, --api-url string       Override default host URL. If contains placeholder, location will be embedded. Preferred over the config file override 'logging' and env var 'IONOS_API_URL' (default "https://logging.%s.ionos.com")
       --cols strings         Set of columns to be printed on output 
                              Available columns: [Tag Source Protocol Public Destinations Labels PipelineId]

--- a/docs/subcommands/Logging-Service/logs/remove.md
+++ b/docs/subcommands/Logging-Service/logs/remove.md
@@ -26,7 +26,7 @@ Remove a log from a logging pipeline. NOTE:There needs to be at least one log in
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --log-tag string       The tag of the pipeline log that you want to delete (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Logging-Service/logs/update.md
+++ b/docs/subcommands/Logging-Service/logs/update.md
@@ -26,7 +26,7 @@ Update a log from a logging pipeline
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/pipeline/create.md
+++ b/docs/subcommands/Logging-Service/pipeline/create.md
@@ -42,7 +42,7 @@ Create a logging pipeline
       --json-properties string      Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example     If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/pipeline/delete.md
+++ b/docs/subcommands/Logging-Service/pipeline/delete.md
@@ -41,7 +41,7 @@ Delete a logging pipeline using its ID
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/get.md
+++ b/docs/subcommands/Logging-Service/pipeline/get.md
@@ -40,7 +40,7 @@ Retrieve a logging pipeline by ID
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/key.md
+++ b/docs/subcommands/Logging-Service/pipeline/key.md
@@ -40,7 +40,7 @@ Generate a new key for a logging pipeline, invalidating the old one. The key is 
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/list.md
+++ b/docs/subcommands/Logging-Service/pipeline/list.md
@@ -46,7 +46,7 @@ Retrieve logging pipelines
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/update.md
+++ b/docs/subcommands/Logging-Service/pipeline/update.md
@@ -42,7 +42,7 @@ Update a logging pipeline
       --json-properties string    Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example   If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results
       --order-by string           Property to order the results by

--- a/docs/subcommands/Object-Storage/bucket/cors/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/delete.md
@@ -40,7 +40,7 @@ Delete the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/get.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/get.md
@@ -40,7 +40,7 @@ Get the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/put.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/put.md
@@ -42,7 +42,7 @@ Create or replace the CORS configuration for a bucket. The configuration must be
       --json-properties string    Path to a JSON file containing the CORS configuration
       --json-properties-example   Print an example CORS configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/create.md
+++ b/docs/subcommands/Object-Storage/bucket/create.md
@@ -46,7 +46,7 @@ Create a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket to create (required)
       --no-headers        Don't print table headers when table output is used
       --object-lock       Enable Object Lock on the new bucket (cannot be changed after creation)

--- a/docs/subcommands/Object-Storage/bucket/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/delete.md
@@ -47,7 +47,7 @@ Delete a contract-owned bucket, or all buckets using --all. The bucket must be e
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket to delete
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/delete.md
@@ -46,7 +46,7 @@ Delete the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/get.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/get.md
@@ -46,7 +46,7 @@ Get the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/put.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/put.md
@@ -48,7 +48,7 @@ Create or replace the default encryption configuration for a bucket. The configu
       --json-properties string    Path to a JSON file containing the encryption configuration
       --json-properties-example   Print an example encryption configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/get.md
+++ b/docs/subcommands/Object-Storage/bucket/get.md
@@ -46,7 +46,7 @@ Get details of a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket to retrieve (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/head.md
+++ b/docs/subcommands/Object-Storage/bucket/head.md
@@ -46,7 +46,7 @@ Check if a bucket exists and you have access
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket to check (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
@@ -46,7 +46,7 @@ Delete the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
@@ -46,7 +46,7 @@ Get the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
@@ -48,7 +48,7 @@ Create or replace the lifecycle configuration for a bucket. The configuration mu
       --json-properties string    Path to a JSON file containing the lifecycle configuration
       --json-properties-example   Print an example lifecycle configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/list.md
+++ b/docs/subcommands/Object-Storage/bucket/list.md
@@ -46,7 +46,7 @@ List all contract-owned buckets
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Object-Storage/bucket/object/lock/get.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/get.md
@@ -46,7 +46,7 @@ Get the Object Lock configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/object/lock/put.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/put.md
@@ -47,7 +47,7 @@ Apply an Object Lock configuration to a bucket. The bucket must have been create
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
       --mode string       Default retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/bucket/policy/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/delete.md
@@ -46,7 +46,7 @@ Delete the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/get.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/get.md
@@ -46,7 +46,7 @@ Get the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/put.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/put.md
@@ -48,7 +48,7 @@ Create or replace the bucket policy. The policy must be provided as a path to a 
       --json-properties string    Path to a JSON file containing the bucket policy
       --json-properties-example   Print an example bucket policy JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/status.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/status.md
@@ -46,7 +46,7 @@ Check if a bucket policy makes the bucket public
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
@@ -46,7 +46,7 @@ Delete the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
@@ -46,7 +46,7 @@ Get the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
@@ -48,7 +48,7 @@ Create or replace the public access block configuration for a bucket. The config
       --json-properties string    Path to a JSON file containing the public access block configuration
       --json-properties-example   Print an example public access block configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/delete.md
@@ -46,7 +46,7 @@ Delete the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/get.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/get.md
@@ -46,7 +46,7 @@ Get the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/put.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/put.md
@@ -48,7 +48,7 @@ Create or replace the tagging configuration for a bucket. The configuration must
       --json-properties string    Path to a JSON file containing the tagging configuration
       --json-properties-example   Print an example tagging configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/get.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/get.md
@@ -46,7 +46,7 @@ Get the versioning state of a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/set.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/set.md
@@ -46,7 +46,7 @@ Enable or suspend versioning on a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/copy.md
+++ b/docs/subcommands/Object-Storage/object/copy.md
@@ -48,7 +48,7 @@ Copy an object within or between buckets. The --copy-source must be in the forma
   -h, --help                 Print usage
   -k, --key string           Destination object key (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string          Destination bucket name (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/delete.md
+++ b/docs/subcommands/Object-Storage/object/delete.md
@@ -49,7 +49,7 @@ Delete a single object by key, or all objects (including versions and delete mar
   -h, --help                          Print usage
   -k, --key string                    Object key to delete
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string               Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used
       --offset int                    Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/get.md
+++ b/docs/subcommands/Object-Storage/object/get.md
@@ -48,7 +48,7 @@ Download an object to a file
   -h, --help                 Print usage
   -k, --key string           Object key to download (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string          Name of the bucket (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/head.md
+++ b/docs/subcommands/Object-Storage/object/head.md
@@ -47,7 +47,7 @@ Get object metadata
   -h, --help              Print usage
   -k, --key string        Object key (required)
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/get.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/get.md
@@ -47,7 +47,7 @@ Get the legal hold status of an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/put.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/put.md
@@ -47,7 +47,7 @@ Apply or remove a legal hold configuration on an object. Requires the bucket to 
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/list.md
+++ b/docs/subcommands/Object-Storage/object/list.md
@@ -46,7 +46,7 @@ List objects in a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
       --max-keys int32    Maximum number of objects to return (0 for no limit) (default 1000)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/put.md
+++ b/docs/subcommands/Object-Storage/object/put.md
@@ -48,7 +48,7 @@ Upload a file as an object
   -h, --help                  Print usage
   -k, --key string            Object key (path in the bucket) (required)
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string           Name of the bucket (required)
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/retention/get.md
+++ b/docs/subcommands/Object-Storage/object/retention/get.md
@@ -47,7 +47,7 @@ Get the Object Lock retention configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/retention/put.md
+++ b/docs/subcommands/Object-Storage/object/retention/put.md
@@ -48,7 +48,7 @@ Place an Object Lock retention configuration on an object. Requires the bucket t
   -h, --help                          Print usage
   -k, --key string                    Object key (required)
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string               Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
       --mode string                   Retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/object/tagging/delete.md
@@ -47,7 +47,7 @@ Delete the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/get.md
+++ b/docs/subcommands/Object-Storage/object/tagging/get.md
@@ -47,7 +47,7 @@ Get the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/put.md
+++ b/docs/subcommands/Object-Storage/object/tagging/put.md
@@ -49,7 +49,7 @@ Create or replace the tagging configuration for an object. The configuration mus
       --json-properties-example   Print an example tagging configuration JSON and exit
   -k, --key string                Object key (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
@@ -45,7 +45,7 @@ Create a IPSec Gateway
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
@@ -42,7 +42,7 @@ Delete a gateway
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
@@ -41,7 +41,7 @@ Find a gateway by ID
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
@@ -40,7 +40,7 @@ List IPSec Gateways
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
@@ -46,7 +46,7 @@ Update a IPSec Gateway
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
@@ -55,7 +55,7 @@ Create IPSec tunnels
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                         Maximum number of items to return per request (default 50)
-  -l, --location string                   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string                   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
       --offset int                        Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
@@ -42,7 +42,7 @@ Remove a IPSec Tunnel
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
@@ -41,7 +41,7 @@ Find a tunnel by ID
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
@@ -41,7 +41,7 @@ List IPSec Tunnels
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
@@ -55,7 +55,7 @@ Update a IPSec Tunnel
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                         Maximum number of items to return per request (default 50)
-  -l, --location string                   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string                   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
       --offset int                        Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
@@ -52,7 +52,7 @@ Create a WireGuard Gateway
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
@@ -48,7 +48,7 @@ Delete a gateway
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
@@ -47,7 +47,7 @@ Find a gateway by ID
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
@@ -46,7 +46,7 @@ List WireGuard Gateways
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
@@ -53,7 +53,7 @@ Update a WireGuard Gateway. Note: The private key MUST be provided again (or cha
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/peer/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/create.md
@@ -50,7 +50,7 @@ Create WireGuard Peers. There is a limit to the total number of peers. Please re
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
@@ -48,7 +48,7 @@ Remove a WireGuard Peer
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/get.md
@@ -47,7 +47,7 @@ Find a peer by ID
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/list.md
@@ -47,7 +47,7 @@ List WireGuard Peers
   -i, --gateway-id string   The ID of the Wireguard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/update.md
@@ -50,7 +50,7 @@ Update a WireGuard Peer
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
   -n, --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/internal/client/regional.go
+++ b/internal/client/regional.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/viper"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+)
+
+// NewRegionalConfig creates a shared.Configuration for a specific regional URL,
+// reusing credentials from the existing client singleton. It applies the same
+// user agent, query params, and filters as the main client builder.
+// This is used by ListAllLocations to create standalone SDK clients per location,
+// avoiding mutation of the global singleton.
+func NewRegionalConfig(url string) *shared.Configuration {
+	cl := Must()
+	cloudCfg := cl.CloudClient.GetConfig()
+
+	cfg := shared.NewConfiguration(cloudCfg.Username, cloudCfg.Password, cloudCfg.Token, url)
+	cfg.UserAgent = appendUserAgent(cfg.UserAgent)
+	cfg.HTTPClient = &http.Client{}
+
+	// Apply log level (shared.SdkLogLevel is package-level, already set by main client init)
+
+	// Apply query params
+	queryParams := map[string]string{
+		"limit":    viper.GetString(constants.FlagLimit),
+		"offset":   viper.GetString(constants.FlagOffset),
+		"depth":    viper.GetString(constants.FlagDepth),
+		"order-by": viper.GetString(constants.FlagOrderBy),
+	}
+	for k, v := range queryParams {
+		if v == "" {
+			delete(queryParams, k)
+		}
+	}
+	setQueryParams(cfg, queryParams)
+
+	// Apply filters
+	setFilters(cfg, viper.GetStringSlice(constants.FlagFilters))
+
+	return cfg
+}

--- a/internal/client/regional.go
+++ b/internal/client/regional.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/globalwait"
 )
 
 // NewRegionalConfig creates a shared.Configuration for a specific regional URL,
@@ -21,6 +22,13 @@ func NewRegionalConfig(url string) *shared.Configuration {
 	cfg := shared.NewConfiguration(cloudCfg.Username, cloudCfg.Password, cloudCfg.Token, url)
 	cfg.UserAgent = appendUserAgent(cfg.UserAgent)
 	cfg.HTTPClient = &http.Client{}
+	// Wrap the transport so --wait can capture request-status URLs from mutating
+	// calls made through per-location clients (e.g. delete --all fan-out), the
+	// same way the main client builder wraps each SDK client. Today the bundle
+	// SDKs deep-copy the config and fall back to the already-wrapped shared
+	// http.DefaultClient, so capture works regardless; this keeps it correct if
+	// the SDK is ever fixed to preserve the configured HTTPClient.
+	globalwait.WrapTransport(cfg.HTTPClient)
 
 	// Apply log level (shared.SdkLogLevel is package-level, already set by main client init)
 

--- a/internal/client/regional.go
+++ b/internal/client/regional.go
@@ -24,9 +24,14 @@ func NewRegionalConfig(url string) *shared.Configuration {
 
 	// Apply log level (shared.SdkLogLevel is package-level, already set by main client init)
 
-	// Apply query params
+	// Apply query params (mirrors builder.go logic, including deprecated --max-results)
+	limit := viper.GetString(constants.FlagLimit)
+	if argsContainAny([]string{"--" + constants.DeprecatedFlagMaxResults, "-M"}) {
+		limit = viper.GetString(constants.DeprecatedFlagMaxResults)
+	}
+
 	queryParams := map[string]string{
-		"limit":    viper.GetString(constants.FlagLimit),
+		"limit":    limit,
 		"offset":   viper.GetString(constants.FlagOffset),
 		"depth":    viper.GetString(constants.FlagDepth),
 		"order-by": viper.GetString(constants.FlagOrderBy),

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -58,6 +58,7 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 	}
 	c.Command.Annotations[AnnotationLocations] = strings.Join(allowedLocations, ",")
 	c.Command.Annotations[AnnotationTemplateURL] = templateFallbackURL
+	c.Command.Annotations[AnnotationProductNames] = strings.Join(productNames, ",")
 
 	// Add the server URL flag
 	c.Command.PersistentFlags().StringP(

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -42,7 +42,8 @@ import (
 //   - If an unsupported location is provided, a warning is logged:
 //     'WARN: <location> is an invalid location. Valid locations are: <allowedLocations>'
 //   - This also marks '--api-url' and '--location' flags as mutually exclusive.
-//   - The first location in 'allowedLocations' is used as the default URL if no location is provided.
+//   - The first location in 'allowedLocations' is used as the default for non-list commands.
+//   - List commands using [CommandConfig.ListAllLocations] query all locations when '--location' is not set.
 func WithRegionalConfigOverride(c *Command, productNames []string, templateFallbackURL string, allowedLocations []string) *Command {
 	if len(productNames) == 0 {
 		panic(fmt.Errorf("no productNames provided for %s", c.Command.Name()))
@@ -68,7 +69,7 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 	// Add the location flag
 	c.Command.PersistentFlags().StringP(
 		constants.FlagLocation, constants.FlagLocationShort, allowedLocations[0],
-		"Location of the resource to operate on. Can be one of: "+strings.Join(allowedLocations, ", "),
+		"Location of the resource to operate on. List commands query all locations when unset. Can be one of: "+strings.Join(allowedLocations, ", "),
 	)
 	viper.BindPFlag(constants.FlagLocation, c.Command.PersistentFlags().Lookup(constants.FlagLocation))
 	c.Command.RegisterFlagCompletionFunc(constants.FlagLocation,

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -51,6 +51,13 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 		panic(fmt.Errorf("no allowedLocations provided for %s", c.Command.Name()))
 	}
 
+	// Store regional metadata for child commands (e.g., ListAllLocations)
+	if c.Command.Annotations == nil {
+		c.Command.Annotations = map[string]string{}
+	}
+	c.Command.Annotations[AnnotationLocations] = strings.Join(allowedLocations, ",")
+	c.Command.Annotations[AnnotationTemplateURL] = templateFallbackURL
+
 	// Add the server URL flag
 	c.Command.PersistentFlags().StringP(
 		constants.ArgServerUrl, constants.ArgServerUrlShort, templateFallbackURL,

--- a/internal/core/flag-option.go
+++ b/internal/core/flag-option.go
@@ -65,21 +65,39 @@ func WithCompletionComplex(
 					return completionFunc(passedCmd, args, toComplete)
 				}
 
-				// Determine the location to use
-				location, _ := passedCmd.Flags().GetString(constants.FlagLocation)
-				if location == "" && len(locations) > 0 {
-					location = locations[0]
+				// If --location explicitly set, complete from that location only
+				if passedCmd.Flags().Changed(constants.FlagLocation) {
+					location, _ := passedCmd.Flags().GetString(constants.FlagLocation)
+					normalizedLoc := strings.ReplaceAll(location, "/", "-")
+					if strings.Contains(baseURL, "%s") {
+						viper.Set(constants.ArgServerUrl, fmt.Sprintf(baseURL, normalizedLoc))
+					} else {
+						viper.Set(constants.ArgServerUrl, baseURL)
+					}
+					return completionFunc(passedCmd, args, toComplete)
 				}
 
-				// Normalize the location and set the server URL
-				normalizedLoc := strings.ReplaceAll(location, "/", "-")
-				if strings.Contains(baseURL, "%s") {
-					viper.Set(constants.ArgServerUrl, fmt.Sprintf(baseURL, normalizedLoc))
-				} else {
+				// No explicit --location: query all locations, merge with location hints
+				if !strings.Contains(baseURL, "%s") || len(locations) == 0 {
 					viper.Set(constants.ArgServerUrl, baseURL)
+					return completionFunc(passedCmd, args, toComplete)
 				}
 
-				return completionFunc(passedCmd, args, toComplete)
+				var allResults []string
+				for _, loc := range locations {
+					normalizedLoc := strings.ReplaceAll(loc, "/", "-")
+					viper.Set(constants.ArgServerUrl, fmt.Sprintf(baseURL, normalizedLoc))
+
+					results, _ := completionFunc(passedCmd, args, toComplete)
+					for _, r := range results {
+						if strings.Contains(r, "\t") {
+							allResults = append(allResults, r+" ("+loc+")")
+						} else {
+							allResults = append(allResults, r+"\t("+loc+")")
+						}
+					}
+				}
+				return allResults, cobra.ShellCompDirectiveNoFileComp
 			},
 		)
 	}

--- a/internal/core/flag-option.go
+++ b/internal/core/flag-option.go
@@ -93,7 +93,7 @@ func WithCompletionComplex(
 					if directive == cobra.ShellCompDirectiveError {
 						continue // skip failed locations
 					}
-					mergedDirective &= directive
+					mergedDirective |= directive
 					for _, r := range results {
 						if strings.Contains(r, "\t") {
 							allResults = append(allResults, r+" ("+loc+")")

--- a/internal/core/flag-option.go
+++ b/internal/core/flag-option.go
@@ -84,11 +84,16 @@ func WithCompletionComplex(
 				}
 
 				var allResults []string
+				mergedDirective := cobra.ShellCompDirectiveNoFileComp
 				for _, loc := range locations {
 					normalizedLoc := strings.ReplaceAll(loc, "/", "-")
 					viper.Set(constants.ArgServerUrl, fmt.Sprintf(baseURL, normalizedLoc))
 
-					results, _ := completionFunc(passedCmd, args, toComplete)
+					results, directive := completionFunc(passedCmd, args, toComplete)
+					if directive == cobra.ShellCompDirectiveError {
+						continue // skip failed locations
+					}
+					mergedDirective &= directive
 					for _, r := range results {
 						if strings.Contains(r, "\t") {
 							allResults = append(allResults, r+" ("+loc+")")
@@ -97,7 +102,7 @@ func WithCompletionComplex(
 						}
 					}
 				}
-				return allResults, cobra.ShellCompDirectiveNoFileComp
+				return allResults, mergedDirective
 			},
 		)
 	}

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -55,38 +55,66 @@ func (c *CommandConfig) ListAllLocations(
 		return c.Printer(columns).Prefix("items").Print(data)
 	}
 
-	// Multi-location: query all concurrently
+	// Build all configs before spawning goroutines to avoid racing
+	// on client.Must() singleton (getters.go URL-change rebuild is not synchronized).
+	type locConfig struct {
+		location string
+		cfg      *shared.Configuration
+	}
+	configs := make([]locConfig, len(locations))
+	for i, loc := range locations {
+		normalizedLoc := strings.ReplaceAll(loc, "/", "-")
+		url := fmt.Sprintf(templateURL, normalizedLoc)
+		configs[i] = locConfig{location: loc, cfg: client.NewRegionalConfig(url)}
+	}
+
+	// Query all locations concurrently
 	results := make([]locResult, len(locations))
 	var wg sync.WaitGroup
 
-	for i, loc := range locations {
+	for i, lc := range configs {
 		wg.Add(1)
-		go func(i int, loc string) {
+		go func(i int, lc locConfig) {
 			defer wg.Done()
-
-			normalizedLoc := strings.ReplaceAll(loc, "/", "-")
-			url := fmt.Sprintf(templateURL, normalizedLoc)
-			cfg := client.NewRegionalConfig(url)
-
-			data, err := fetchFn(cfg)
-			results[i] = locResult{location: loc, data: data, err: err}
-		}(i, loc)
+			data, err := fetchFn(lc.cfg)
+			results[i] = locResult{location: lc.location, data: data, err: err}
+		}(i, lc)
 	}
 	wg.Wait()
 
-	// Check if all failed
+	// Collect errors, deduplicate identical messages
 	var lastErr error
 	anySuccess := false
+	errCounts := map[string][]string{} // error message → list of locations
 	for _, r := range results {
 		if r.err != nil {
 			lastErr = r.err
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to list from %s: %v\n", r.location, r.err)
+			msg := r.err.Error()
+			errCounts[msg] = append(errCounts[msg], r.location)
 		} else {
 			anySuccess = true
 		}
 	}
+
 	if !anySuccess {
-		return fmt.Errorf("failed to list from any location: %w", lastErr)
+		// All failed — return single error, no warnings
+		if len(errCounts) == 1 {
+			return fmt.Errorf("failed to list from all locations: %w", lastErr)
+		}
+		// Multiple distinct errors — join them
+		var parts []string
+		for msg, locs := range errCounts {
+			parts = append(parts, fmt.Sprintf("%s: %s", strings.Join(locs, ", "), msg))
+		}
+		return fmt.Errorf("failed to list from all locations:\n  %s", strings.Join(parts, "\n  "))
+	}
+
+	// Partial failure — warn only for failed locations
+	if len(errCounts) > 0 {
+		stderr := c.Command.Command.ErrOrStderr()
+		for msg, locs := range errCounts {
+			fmt.Fprintf(stderr, "WARN: failed to list from %s: %s\n", strings.Join(locs, ", "), msg)
+		}
 	}
 
 	// Determine output format

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -392,6 +392,22 @@ func (c *PreCommandConfig) RequireExplicitLocation() error {
 	return requireExplicitLocation(c.Command.Command)
 }
 
+// CheckRequiredFlagsAndLocation behaves like [CheckRequiredFlags], but for
+// multi-location regional APIs it also requires --location. This makes the
+// requirement visible up front: --location appears in the usage/error together
+// with the other required flags, instead of failing only after the user has
+// already satisfied everything else. It is a no-op location requirement for
+// single-location APIs or non-regional commands.
+//
+// Use this from PreCmdRun of single-resource commands (create/get/update)
+// instead of a separate [PreCommandConfig.RequireExplicitLocation] call.
+func (c *PreCommandConfig) CheckRequiredFlagsAndLocation(flags ...string) error {
+	if requireExplicitLocation(c.Command.Command) != nil {
+		flags = append(flags, constants.FlagLocation)
+	}
+	return CheckRequiredFlags(c.Command, c.NS, flags...)
+}
+
 // RequireExplicitLocation enforces that --location is set for location-scoped
 // (single-resource) operations on regional APIs. This CommandConfig variant is
 // for hybrid list commands that only take a single-location branch at runtime

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -50,8 +50,12 @@ func (c *CommandConfig) ListAllLocations(
 ) error {
 	locations, templateURL, productNames, found := findRegionalConfig(c.Command.Command)
 
-	// No regional config or --location explicitly set: single-location behavior
-	if !found || c.Command.Command.Flags().Changed(constants.FlagLocation) {
+	// Single-location behavior (raw passthrough, no Location column, no array
+	// wrapping, no key stripping) when: no regional config, the API exposes a
+	// single location (nothing to aggregate), or --location was set explicitly.
+	// This keeps single-location APIs (DNS, CDN, Cert) byte-for-byte compatible
+	// with pre-regional output.
+	if !found || len(locations) <= 1 || c.Command.Command.Flags().Changed(constants.FlagLocation) {
 		cfg := client.NewRegionalConfig(viper.GetString(constants.ArgServerUrl))
 		data, err := fetchFn(cfg)
 		if err != nil {
@@ -237,6 +241,51 @@ func (c *CommandConfig) regionalText(results []locResult, columns []table.Column
 	}
 
 	return c.Out(t.Render(table.ResolveCols(allCols, c.Cols())))
+}
+
+// requireExplicitLocation returns an error when the command targets a regional
+// API with more than one allowed location and --location was not explicitly
+// provided. Resource IDs (and target locations for writes) are location-scoped
+// and cannot be inferred, so single-location operations must know which
+// location to target. Otherwise they silently default to the first allowed
+// location, producing confusing 404s when the resource lives elsewhere.
+//
+// When the API exposes only a single location there is no ambiguity, so the
+// default applies and no error is returned.
+//
+// Returns nil when the command is not regional, has a single location, or when
+// --location was set.
+func requireExplicitLocation(cmd *cobra.Command) error {
+	locations, _, _, found := findRegionalConfig(cmd)
+	if !found || len(locations) <= 1 || cmd.Flags().Changed(constants.FlagLocation) {
+		return nil
+	}
+	return fmt.Errorf(
+		"--location is required here: resources are location-scoped and cannot be inferred. "+
+			"Set --location to one of: %s",
+		strings.Join(locations, ", "),
+	)
+}
+
+// RequireExplicitLocation enforces that --location is set for location-scoped
+// (single-resource) operations on regional APIs. Call it from PreCmdRun of
+// commands that operate on a specific resource ID. It is a no-op for
+// non-regional commands or when --location is already set.
+//
+// List commands that fan out over all locations must NOT call this; they use
+// [CommandConfig.ListAllLocations] instead.
+func (c *PreCommandConfig) RequireExplicitLocation() error {
+	return requireExplicitLocation(c.Command.Command)
+}
+
+// RequireExplicitLocation enforces that --location is set for location-scoped
+// (single-resource) operations on regional APIs. This CommandConfig variant is
+// for hybrid list commands that only take a single-location branch at runtime
+// (e.g. when a specific parent ID is provided); call it inside that branch. It
+// is a no-op for non-regional commands, single-location APIs, or when
+// --location is already set.
+func (c *CommandConfig) RequireExplicitLocation() error {
+	return requireExplicitLocation(c.Command.Command)
 }
 
 // findRegionalConfig walks parent commands to find regional annotations

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -147,8 +148,35 @@ func (c *CommandConfig) ListAllLocations(
 	return c.regionalText(results, columns)
 }
 
+// locationStampedItems extracts the "items" array from a collection response
+// and stamps each object item with a top-level "location" field, so provenance
+// survives the merge into a single {"items": [...]}. Non-object items are
+// passed through unchanged. Returns an empty slice when the response has no
+// "items" array.
+func locationStampedItems(data any, location string) ([]any, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	items, ok := m["items"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	for _, item := range items {
+		if obj, ok := item.(map[string]any); ok {
+			obj["location"] = location
+		}
+	}
+	return items, nil
+}
+
 // regionalLegacyJSON merges items from all locations into {"items": [...]}.
-// This matches the single-location -o json format (non-breaking).
+// Each item is stamped with its source location. This matches the
+// single-location -o json shape (top-level "items"), with the added field.
 func (c *CommandConfig) regionalLegacyJSON(results []locResult) error {
 	if viper.GetBool(constants.ArgQuiet) {
 		return nil
@@ -159,19 +187,12 @@ func (c *CommandConfig) regionalLegacyJSON(results []locResult) error {
 		if r.err != nil {
 			continue
 		}
-		b, err := json.Marshal(r.data)
+		items, err := locationStampedItems(r.data, r.location)
 		if err != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to marshal response from %s: %v\n", r.location, err)
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to process response from %s: %v\n", r.location, err)
 			continue
 		}
-		var m map[string]any
-		if err := json.Unmarshal(b, &m); err != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to parse response from %s: %v\n", r.location, err)
-			continue
-		}
-		if items, ok := m["items"].([]any); ok {
-			allItems = append(allItems, items...)
-		}
+		allItems = append(allItems, items...)
 	}
 
 	var data any = map[string]any{"items": allItems}
@@ -187,18 +208,48 @@ func (c *CommandConfig) regionalLegacyJSON(results []locResult) error {
 	return c.Out(string(out)+"\n", nil)
 }
 
-// regionalAPIJSON outputs an array of per-location API responses.
-// Each element is the raw, untouched API response for that location.
+// annotateLocation returns data with a top-level "location" field added, so
+// per-location API responses carry their provenance in aggregated api-json
+// output. It round-trips through JSON to avoid mutating the typed SDK response.
+// If the response is not a JSON object (unexpected for collections), it is
+// returned unmodified rather than dropped.
+func annotateLocation(data any, location string) (any, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		var raw any
+		if err := json.Unmarshal(b, &raw); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	}
+	m["location"] = location
+	return m, nil
+}
+
+// regionalAPIJSON outputs an array of per-location API responses. Each element
+// is the API response for that location, annotated with a "location" field so
+// provenance survives aggregation. Empty locations are kept (they reflect a
+// location that was queried and returned no items).
 func (c *CommandConfig) regionalAPIJSON(results []locResult) error {
 	if viper.GetBool(constants.ArgQuiet) {
 		return nil
 	}
 
-	var rawResponses []any
+	rawResponses := make([]any, 0, len(results))
 	for _, r := range results {
-		if r.err == nil {
-			rawResponses = append(rawResponses, r.data)
+		if r.err != nil {
+			continue
 		}
+		annotated, err := annotateLocation(r.data, r.location)
+		if err != nil {
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to process response from %s: %v\n", r.location, err)
+			continue
+		}
+		rawResponses = append(rawResponses, annotated)
 	}
 
 	var data any = rawResponses
@@ -241,6 +292,42 @@ func (c *CommandConfig) regionalText(results []locResult, columns []table.Column
 	}
 
 	return c.Out(t.Render(table.ResolveCols(allCols, c.Cols())))
+}
+
+// RunForAllLocations invokes fn once per allowed location (sequentially) for
+// multi-location regional APIs when --location is not set, so bulk operations
+// such as `delete --all` span every location the same way `list` does. Errors
+// from individual locations are aggregated; a failure in one location does not
+// stop the others.
+//
+// For non-regional commands, single-location APIs, or when --location is set
+// explicitly, fn runs exactly once against the resolved single-location config.
+//
+// fn receives a per-location [shared.Configuration] and the location label; it
+// must build its own SDK client from that config (do not use the global
+// client.Must() singleton, which is bound to a single location).
+func (c *CommandConfig) RunForAllLocations(fn func(cfg *shared.Configuration, location string) error) error {
+	locations, templateURL, productNames, found := findRegionalConfig(c.Command.Command)
+
+	if !found || len(locations) <= 1 || c.Command.Command.Flags().Changed(constants.FlagLocation) {
+		loc := ""
+		switch {
+		case c.Command.Command.Flags().Changed(constants.FlagLocation):
+			loc, _ = c.Command.Command.Flags().GetString(constants.FlagLocation)
+		case len(locations) == 1:
+			loc = locations[0]
+		}
+		return fn(client.NewRegionalConfig(viper.GetString(constants.ArgServerUrl)), loc)
+	}
+
+	var errs []error
+	for _, loc := range locations {
+		url := findOverridenURL(c.Command.Command, productNames, templateURL, loc)
+		if err := fn(client.NewRegionalConfig(url), loc); err != nil {
+			errs = append(errs, fmt.Errorf("location %s: %w", loc, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // requireExplicitLocation returns an error when the command targets a regional

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -1,0 +1,166 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/ionosctl/v6/internal/printer/table"
+)
+
+const (
+	// AnnotationLocations is set by WithRegionalConfigOverride on the service
+	// root command. It contains comma-separated allowed locations (e.g. "de/fra,de/txl").
+	AnnotationLocations = "regional.locations"
+
+	// AnnotationTemplateURL is the URL template with %s placeholder for location.
+	AnnotationTemplateURL = "regional.templateURL"
+)
+
+type locResult struct {
+	location string
+	data     any
+	err      error
+}
+
+// ListAllLocations queries all locations concurrently when --location is not
+// explicitly set, merging results into a single table with a Location column.
+//
+// For text output: merged table with "Location" as the first column.
+// For JSON/api-json output: array of untouched per-location API responses.
+// When --location is explicitly set: single-location behavior (unchanged).
+//
+// The fetchFn receives a [shared.Configuration] for the target location URL.
+// It must create its own SDK client from the config and execute the API call.
+func (c *CommandConfig) ListAllLocations(
+	columns []table.Column,
+	fetchFn func(cfg *shared.Configuration) (any, error),
+) error {
+	locations, templateURL, found := findRegionalConfig(c.Command.Command)
+
+	// No regional config or --location explicitly set: single-location behavior
+	if !found || c.Command.Command.Flags().Changed(constants.FlagLocation) {
+		cfg := client.NewRegionalConfig(viper.GetString(constants.ArgServerUrl))
+		data, err := fetchFn(cfg)
+		if err != nil {
+			return err
+		}
+		return c.Printer(columns).Prefix("items").Print(data)
+	}
+
+	// Multi-location: query all concurrently
+	results := make([]locResult, len(locations))
+	var wg sync.WaitGroup
+
+	for i, loc := range locations {
+		wg.Add(1)
+		go func(i int, loc string) {
+			defer wg.Done()
+
+			normalizedLoc := strings.ReplaceAll(loc, "/", "-")
+			url := fmt.Sprintf(templateURL, normalizedLoc)
+			cfg := client.NewRegionalConfig(url)
+
+			data, err := fetchFn(cfg)
+			results[i] = locResult{location: loc, data: data, err: err}
+		}(i, loc)
+	}
+	wg.Wait()
+
+	// Check if all failed
+	var lastErr error
+	anySuccess := false
+	for _, r := range results {
+		if r.err != nil {
+			lastErr = r.err
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to list from %s: %v\n", r.location, r.err)
+		} else {
+			anySuccess = true
+		}
+	}
+	if !anySuccess {
+		return fmt.Errorf("failed to list from any location: %w", lastErr)
+	}
+
+	// Determine output format
+	format := viper.GetString(constants.ArgOutput)
+	if format == "json" || format == "api-json" {
+		return c.regionalJSON(results)
+	}
+
+	return c.regionalText(results, columns)
+}
+
+// regionalJSON outputs an array of per-location API responses.
+// Both -o json and -o api-json produce the same format: an array of raw responses.
+func (c *CommandConfig) regionalJSON(results []locResult) error {
+	if viper.GetBool(constants.ArgQuiet) {
+		return nil
+	}
+
+	var rawResponses []any
+	for _, r := range results {
+		if r.err == nil {
+			rawResponses = append(rawResponses, r.data)
+		}
+	}
+
+	var data any = rawResponses
+	data, err := table.ApplyQueryFilter(data)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return c.Out(string(out)+"\n", nil)
+}
+
+// regionalText builds a merged table with Location as the first column.
+func (c *CommandConfig) regionalText(results []locResult, columns []table.Column) error {
+	// Prepend Location column
+	allCols := append([]table.Column{{Name: "Location", Default: true}}, columns...)
+	t := table.New(allCols)
+
+	for _, r := range results {
+		if r.err != nil {
+			continue
+		}
+
+		// Extract rows from this location's response
+		locTable := table.New(columns, table.WithPrefix("items"))
+		if err := locTable.Extract(r.data); err != nil {
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to parse response from %s: %v\n", r.location, err)
+			continue
+		}
+
+		for _, row := range locTable.Rows() {
+			row["Location"] = r.location
+			t.AppendRow(row)
+		}
+	}
+
+	return c.Out(t.Render(table.ResolveCols(allCols, c.Cols())))
+}
+
+// findRegionalConfig walks parent commands to find regional annotations
+// set by [WithRegionalConfigOverride].
+func findRegionalConfig(cmd *cobra.Command) (locations []string, templateURL string, found bool) {
+	for c := cmd; c != nil; c = c.Parent() {
+		locs, hasLocs := c.Annotations[AnnotationLocations]
+		tmpl, hasTmpl := c.Annotations[AnnotationTemplateURL]
+		if hasLocs && hasTmpl {
+			return strings.Split(locs, ","), tmpl, true
+		}
+	}
+	return nil, "", false
+}

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -36,12 +36,17 @@ type locResult struct {
 	err      error
 }
 
-// ListAllLocations queries all locations concurrently when --location is not
-// explicitly set, merging results into a single table with a Location column.
+// ListAllLocations queries all locations concurrently when the API has more
+// than one location and --location is not set, merging results into one view.
 //
-// For text output: merged table with "Location" as the first column.
-// For JSON/api-json output: array of untouched per-location API responses.
-// When --location is explicitly set: single-location behavior (unchanged).
+//   - text: merged table with "Location" as the first column.
+//   - json: items from all locations merged under "items", each stamped with a
+//     "location" field.
+//   - api-json: array of per-location responses, each with a "location" field.
+//
+// For single-location APIs, non-regional commands, or when --location is set,
+// it falls back to single-location behavior: the raw response is printed
+// unchanged (no Location column, no merging, no array wrapping).
 //
 // The fetchFn receives a [shared.Configuration] for the target location URL.
 // It must create its own SDK client from the config and execute the API call.
@@ -318,6 +323,16 @@ func (c *CommandConfig) RunForAllLocations(fn func(cfg *shared.Configuration, lo
 			loc = locations[0]
 		}
 		return fn(client.NewRegionalConfig(viper.GetString(constants.ArgServerUrl)), loc)
+	}
+
+	// Make the wider blast radius visible: a bulk op with no --location now
+	// spans every location. Without this line, an existing `--all --force`
+	// script that used to touch only the default location would silently act
+	// across all of them.
+	if !viper.GetBool(constants.ArgQuiet) {
+		fmt.Fprintf(c.Command.Command.ErrOrStderr(),
+			"Operating across all %d locations: %s (use --location to target a single one)\n",
+			len(locations), strings.Join(locations, ", "))
 	}
 
 	var errs []error

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -408,6 +408,26 @@ func (c *PreCommandConfig) CheckRequiredFlagsAndLocation(flags ...string) error 
 	return CheckRequiredFlags(c.Command, c.NS, flags...)
 }
 
+// CheckRequiredFlagsSetsAndLocation is the [CheckRequiredFlagsSets] equivalent
+// of [PreCommandConfig.CheckRequiredFlagsAndLocation]: on multi-location
+// regional APIs it also requires --location, adding it to every flag set so the
+// requirement shows up in the usage/error alongside the other required flags.
+//
+// Only use this for commands where --location is needed regardless of which set
+// is satisfied (create/update/get). Do NOT use it for delete commands whose
+// sets include an --all escape that must fan out without --location; those
+// enforce --location inside their single-resource branch instead.
+func (c *PreCommandConfig) CheckRequiredFlagsSetsAndLocation(sets ...[]string) error {
+	if requireExplicitLocation(c.Command.Command) != nil {
+		withLocation := make([][]string, len(sets))
+		for i, set := range sets {
+			withLocation[i] = append(append([]string{}, set...), constants.FlagLocation)
+		}
+		sets = withLocation
+	}
+	return CheckRequiredFlagsSets(c.Command, c.NS, sets...)
+}
+
 // RequireExplicitLocation enforces that --location is set for location-scoped
 // (single-resource) operations on regional APIs. This CommandConfig variant is
 // for hybrid list commands that only take a single-location branch at runtime

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -119,16 +119,58 @@ func (c *CommandConfig) ListAllLocations(
 
 	// Determine output format
 	format := viper.GetString(constants.ArgOutput)
-	if format == "json" || format == "api-json" {
-		return c.regionalJSON(results)
+	switch format {
+	case "json":
+		return c.regionalLegacyJSON(results)
+	case "api-json":
+		return c.regionalAPIJSON(results)
 	}
 
 	return c.regionalText(results, columns)
 }
 
-// regionalJSON outputs an array of per-location API responses.
-// Both -o json and -o api-json produce the same format: an array of raw responses.
-func (c *CommandConfig) regionalJSON(results []locResult) error {
+// regionalLegacyJSON merges items from all locations into {"items": [...]}.
+// This matches the single-location -o json format (non-breaking).
+func (c *CommandConfig) regionalLegacyJSON(results []locResult) error {
+	if viper.GetBool(constants.ArgQuiet) {
+		return nil
+	}
+
+	allItems := make([]any, 0)
+	for _, r := range results {
+		if r.err != nil {
+			continue
+		}
+		// Marshal/unmarshal to get a generic map, then extract items
+		b, err := json.Marshal(r.data)
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			continue
+		}
+		if items, ok := m["items"].([]any); ok {
+			allItems = append(allItems, items...)
+		}
+	}
+
+	var data any = map[string]any{"items": allItems}
+	data, err := table.ApplyQueryFilter(data)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return c.Out(string(out)+"\n", nil)
+}
+
+// regionalAPIJSON outputs an array of per-location API responses.
+// Each element is the raw, untouched API response for that location.
+func (c *CommandConfig) regionalAPIJSON(results []locResult) error {
 	if viper.GetBool(constants.ArgQuiet) {
 		return nil
 	}

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -36,17 +36,20 @@ type locResult struct {
 	err      error
 }
 
-// ListAllLocations queries all locations concurrently when the API has more
-// than one location and --location is not set, merging results into one view.
+// ListAllLocations runs fetchFn against one or more locations and renders a
+// single, consistently-shaped view. For a regional API the output always
+// carries location provenance, regardless of whether --location was set:
 //
-//   - text: merged table with "Location" as the first column.
-//   - json: items from all locations merged under "items", each stamped with a
-//     "location" field.
+//   - text: table with "Location" as the first column.
+//   - json: items merged under "items", each stamped with a "location" field.
 //   - api-json: array of per-location responses, each with a "location" field.
 //
-// For single-location APIs, non-regional commands, or when --location is set,
-// it falls back to single-location behavior: the raw response is printed
-// unchanged (no Location column, no merging, no array wrapping).
+// The set of locations queried is: the single value of --location if set;
+// otherwise the one location a single-location API exposes; otherwise all
+// locations (queried concurrently). This means the output shape does not shift
+// with --location - only the number of locations queried changes.
+//
+// Non-regional commands (no regional config) print the raw response unchanged.
 //
 // The fetchFn receives a [shared.Configuration] for the target location URL.
 // It must create its own SDK client from the config and execute the API call.
@@ -56,12 +59,8 @@ func (c *CommandConfig) ListAllLocations(
 ) error {
 	locations, templateURL, productNames, found := findRegionalConfig(c.Command.Command)
 
-	// Single-location behavior (raw passthrough, no Location column, no array
-	// wrapping, no key stripping) when: no regional config, the API exposes a
-	// single location (nothing to aggregate), or --location was set explicitly.
-	// This keeps single-location APIs (DNS, CDN, Cert) byte-for-byte compatible
-	// with pre-regional output.
-	if !found || len(locations) <= 1 || c.Command.Command.Flags().Changed(constants.FlagLocation) {
+	// Non-regional command: raw passthrough, no location concept to stamp.
+	if !found {
 		cfg := client.NewRegionalConfig(viper.GetString(constants.ArgServerUrl))
 		data, err := fetchFn(cfg)
 		if err != nil {
@@ -70,22 +69,31 @@ func (c *CommandConfig) ListAllLocations(
 		return c.Printer(columns).Prefix("items").Print(data)
 	}
 
+	// Decide which locations to query. A single target (explicit --location, or
+	// a single-location API) still flows through the same stamped renderers, so
+	// the output shape is identical to the all-locations case.
+	targets := locations
+	if c.Command.Command.Flags().Changed(constants.FlagLocation) {
+		loc, _ := c.Command.Command.Flags().GetString(constants.FlagLocation)
+		targets = []string{loc}
+	}
+
 	// Build all configs before spawning goroutines to avoid racing
 	// on client.Must() singleton (getters.go URL-change rebuild is not synchronized).
 	type locConfig struct {
 		location string
 		cfg      *shared.Configuration
 	}
-	configs := make([]locConfig, len(locations))
-	for i, loc := range locations {
+	configs := make([]locConfig, len(targets))
+	for i, loc := range targets {
 		// Resolve per-location URL honoring overrides (--api-url, env var,
 		// per-location config-file override), falling back to the template.
 		url := findOverridenURL(c.Command.Command, productNames, templateURL, loc)
 		configs[i] = locConfig{location: loc, cfg: client.NewRegionalConfig(url)}
 	}
 
-	// Query all locations concurrently
-	results := make([]locResult, len(locations))
+	// Query all targets concurrently
+	results := make([]locResult, len(targets))
 	var wg sync.WaitGroup
 
 	for i, lc := range configs {
@@ -113,6 +121,10 @@ func (c *CommandConfig) ListAllLocations(
 	}
 
 	if !anySuccess {
+		// Single target: return its error verbatim (no "all locations" framing).
+		if len(targets) == 1 {
+			return lastErr
+		}
 		// All failed : return single error, no warnings
 		if len(errCounts) == 1 {
 			return fmt.Errorf("failed to list from all locations: %w", lastErr)

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -85,7 +86,7 @@ func (c *CommandConfig) ListAllLocations(
 	// Collect errors, deduplicate identical messages
 	var lastErr error
 	anySuccess := false
-	errCounts := map[string][]string{} // error message → list of locations
+	errCounts := map[string][]string{} // error message to list of locations
 	for _, r := range results {
 		if r.err != nil {
 			lastErr = r.err
@@ -97,23 +98,31 @@ func (c *CommandConfig) ListAllLocations(
 	}
 
 	if !anySuccess {
-		// All failed — return single error, no warnings
+		// All failed : return single error, no warnings
 		if len(errCounts) == 1 {
 			return fmt.Errorf("failed to list from all locations: %w", lastErr)
 		}
-		// Multiple distinct errors — join them
+		// Multiple distinct errors : join them (sorted for stable output)
 		var parts []string
 		for msg, locs := range errCounts {
+			sort.Strings(locs)
 			parts = append(parts, fmt.Sprintf("%s: %s", strings.Join(locs, ", "), msg))
 		}
+		sort.Strings(parts)
 		return fmt.Errorf("failed to list from all locations:\n  %s", strings.Join(parts, "\n  "))
 	}
 
-	// Partial failure — warn only for failed locations
+	// Partial failure : warn only for failed locations (sorted for stable output)
 	if len(errCounts) > 0 {
 		stderr := c.Command.Command.ErrOrStderr()
+		var warns []string
 		for msg, locs := range errCounts {
-			fmt.Fprintf(stderr, "WARN: failed to list from %s: %s\n", strings.Join(locs, ", "), msg)
+			sort.Strings(locs)
+			warns = append(warns, fmt.Sprintf("WARN: failed to list from %s: %s", strings.Join(locs, ", "), msg))
+		}
+		sort.Strings(warns)
+		for _, w := range warns {
+			fmt.Fprintln(stderr, w)
 		}
 	}
 
@@ -141,13 +150,14 @@ func (c *CommandConfig) regionalLegacyJSON(results []locResult) error {
 		if r.err != nil {
 			continue
 		}
-		// Marshal/unmarshal to get a generic map, then extract items
 		b, err := json.Marshal(r.data)
 		if err != nil {
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to marshal response from %s: %v\n", r.location, err)
 			continue
 		}
 		var m map[string]any
 		if err := json.Unmarshal(b, &m); err != nil {
+			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to parse response from %s: %v\n", r.location, err)
 			continue
 		}
 		if items, ok := m["items"].([]any); ok {

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/cobra"
@@ -29,6 +30,13 @@ const (
 	// up per-location config-file URL overrides (mirrors WithRegionalConfigOverride).
 	AnnotationProductNames = "regional.productNames"
 )
+
+// perLocationTimeout bounds each per-location request in a multi-location list.
+// Healthy locations respond well under this; an unreachable one is cut here
+// (reported as a partial-failure warning) instead of stalling the whole
+// concurrent fan-out for the OS default connect timeout (~30s). It is a var so
+// tests can shorten it.
+var perLocationTimeout = 6 * time.Second
 
 type locResult struct {
 	location string
@@ -100,8 +108,25 @@ func (c *CommandConfig) ListAllLocations(
 		wg.Add(1)
 		go func(i int, lc locConfig) {
 			defer wg.Done()
-			data, err := fetchFn(lc.cfg)
-			results[i] = locResult{location: lc.location, data: data, err: err}
+			// Bound each location so one unreachable region does not stall the
+			// whole fan-out. The SDK ignores our http.Client timeout (it
+			// deep-copies the config and drops the client), so enforce the
+			// deadline here. A timed-out region is reported like any other
+			// failure; its goroutine finishes in the background.
+			done := make(chan locResult, 1)
+			go func() {
+				data, err := fetchFn(lc.cfg)
+				done <- locResult{location: lc.location, data: data, err: err}
+			}()
+			select {
+			case r := <-done:
+				results[i] = r
+			case <-time.After(perLocationTimeout):
+				results[i] = locResult{
+					location: lc.location,
+					err:      fmt.Errorf("timed out after %s", perLocationTimeout),
+				}
+			}
 		}(i, lc)
 	}
 	wg.Wait()

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -23,6 +23,10 @@ const (
 
 	// AnnotationTemplateURL is the URL template with %s placeholder for location.
 	AnnotationTemplateURL = "regional.templateURL"
+
+	// AnnotationProductNames is the comma-separated product names used to look
+	// up per-location config-file URL overrides (mirrors WithRegionalConfigOverride).
+	AnnotationProductNames = "regional.productNames"
 )
 
 type locResult struct {
@@ -44,7 +48,7 @@ func (c *CommandConfig) ListAllLocations(
 	columns []table.Column,
 	fetchFn func(cfg *shared.Configuration) (any, error),
 ) error {
-	locations, templateURL, found := findRegionalConfig(c.Command.Command)
+	locations, templateURL, productNames, found := findRegionalConfig(c.Command.Command)
 
 	// No regional config or --location explicitly set: single-location behavior
 	if !found || c.Command.Command.Flags().Changed(constants.FlagLocation) {
@@ -64,8 +68,9 @@ func (c *CommandConfig) ListAllLocations(
 	}
 	configs := make([]locConfig, len(locations))
 	for i, loc := range locations {
-		normalizedLoc := strings.ReplaceAll(loc, "/", "-")
-		url := fmt.Sprintf(templateURL, normalizedLoc)
+		// Resolve per-location URL honoring overrides (--api-url, env var,
+		// per-location config-file override), falling back to the template.
+		url := findOverridenURL(c.Command.Command, productNames, templateURL, loc)
 		configs[i] = locConfig{location: loc, cfg: client.NewRegionalConfig(url)}
 	}
 
@@ -236,13 +241,17 @@ func (c *CommandConfig) regionalText(results []locResult, columns []table.Column
 
 // findRegionalConfig walks parent commands to find regional annotations
 // set by [WithRegionalConfigOverride].
-func findRegionalConfig(cmd *cobra.Command) (locations []string, templateURL string, found bool) {
+func findRegionalConfig(cmd *cobra.Command) (locations []string, templateURL string, productNames []string, found bool) {
 	for c := cmd; c != nil; c = c.Parent() {
 		locs, hasLocs := c.Annotations[AnnotationLocations]
 		tmpl, hasTmpl := c.Annotations[AnnotationTemplateURL]
 		if hasLocs && hasTmpl {
-			return strings.Split(locs, ","), tmpl, true
+			var prods []string
+			if p, ok := c.Annotations[AnnotationProductNames]; ok && p != "" {
+				prods = strings.Split(p, ",")
+			}
+			return strings.Split(locs, ","), tmpl, prods, true
 		}
 	}
-	return nil, "", false
+	return nil, "", nil, false
 }

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -113,7 +113,7 @@ func (c *CommandConfig) ListAllLocations(
 	}
 
 	// Partial failure : warn only for failed locations (sorted for stable output)
-	if len(errCounts) > 0 {
+	if len(errCounts) > 0 && !viper.GetBool(constants.ArgQuiet) {
 		stderr := c.Command.Command.ErrOrStderr()
 		var warns []string
 		for msg, locs := range errCounts {
@@ -219,7 +219,9 @@ func (c *CommandConfig) regionalText(results []locResult, columns []table.Column
 		// Extract rows from this location's response
 		locTable := table.New(columns, table.WithPrefix("items"))
 		if err := locTable.Extract(r.data); err != nil {
-			fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to parse response from %s: %v\n", r.location, err)
+			if !viper.GetBool(constants.ArgQuiet) {
+				fmt.Fprintf(c.Command.Command.ErrOrStderr(), "WARN: failed to parse response from %s: %v\n", r.location, err)
+			}
 			continue
 		}
 

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -140,3 +140,41 @@ func TestFindOverridenURLPerLocation(t *testing.T) {
 		}
 	})
 }
+
+// TestRequireExplicitLocation guards the child-resource fix: single-resource
+// operations on regional APIs must demand --location instead of silently
+// defaulting to the first allowed location.
+func TestRequireExplicitLocation(t *testing.T) {
+	regionalCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "get"}
+		cmd.Annotations = map[string]string{
+			AnnotationLocations:   "de/fra,de/txl",
+			AnnotationTemplateURL: "https://svc.%s.ionos.com",
+		}
+		cmd.Flags().String(constants.FlagLocation, "de/fra", "")
+		return cmd
+	}
+
+	t.Run("regional command without --location errors", func(t *testing.T) {
+		if err := requireExplicitLocation(regionalCmd()); err == nil {
+			t.Error("expected error when --location unset on regional command")
+		}
+	})
+
+	t.Run("regional command with --location set passes", func(t *testing.T) {
+		cmd := regionalCmd()
+		if err := cmd.Flags().Set(constants.FlagLocation, "de/txl"); err != nil {
+			t.Fatal(err)
+		}
+		if err := requireExplicitLocation(cmd); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("non-regional command passes", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "get"}
+		if err := requireExplicitLocation(cmd); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -178,3 +178,96 @@ func TestRequireExplicitLocation(t *testing.T) {
 		}
 	})
 }
+
+// TestAnnotateLocation guards the api-json provenance fix: each per-location
+// response must carry a "location" field without losing its original data.
+func TestAnnotateLocation(t *testing.T) {
+	t.Run("adds location to a collection object", func(t *testing.T) {
+		type collection struct {
+			Type  string   `json:"type"`
+			Items []string `json:"items"`
+		}
+		got, err := annotateLocation(collection{Type: "collection", Items: []string{"a"}}, "de/txl")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m, ok := got.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map, got %T", got)
+		}
+		if m["location"] != "de/txl" {
+			t.Errorf("location = %v, want de/txl", m["location"])
+		}
+		if m["type"] != "collection" {
+			t.Errorf("original fields lost: %v", m)
+		}
+		items, ok := m["items"].([]any)
+		if !ok || len(items) != 1 || items[0] != "a" {
+			t.Errorf("items not preserved: %v", m["items"])
+		}
+	})
+
+	t.Run("empty collection is kept and annotated", func(t *testing.T) {
+		got, err := annotateLocation(map[string]any{"items": []any{}}, "es/vit")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := got.(map[string]any)
+		if m["location"] != "es/vit" {
+			t.Errorf("location = %v, want es/vit", m["location"])
+		}
+		if items, ok := m["items"].([]any); !ok || len(items) != 0 {
+			t.Errorf("empty items not preserved: %v", m["items"])
+		}
+	})
+
+	t.Run("non-object response returned unmodified", func(t *testing.T) {
+		got, err := annotateLocation([]int{1, 2, 3}, "de/fra")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := got.(map[string]any); ok {
+			t.Errorf("expected non-object passthrough, got map: %v", got)
+		}
+	})
+}
+
+// TestLocationStampedItems guards the -o json merge fix: each item must gain a
+// top-level "location" field while keeping its original fields.
+func TestLocationStampedItems(t *testing.T) {
+	t.Run("stamps each item with location", func(t *testing.T) {
+		data := map[string]any{
+			"items": []any{
+				map[string]any{"id": "a", "properties": map[string]any{"name": "x"}},
+				map[string]any{"id": "b"},
+			},
+		}
+		items, err := locationStampedItems(data, "de/txl")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("want 2 items, got %d", len(items))
+		}
+		for _, it := range items {
+			m := it.(map[string]any)
+			if m["location"] != "de/txl" {
+				t.Errorf("item %v missing location", m)
+			}
+		}
+		// original fields preserved
+		if items[0].(map[string]any)["id"] != "a" {
+			t.Errorf("original id lost: %v", items[0])
+		}
+	})
+
+	t.Run("no items array returns nil", func(t *testing.T) {
+		items, err := locationStampedItems(map[string]any{"type": "collection"}, "de/fra")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if items != nil {
+			t.Errorf("want nil, got %v", items)
+		}
+	})
+}

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,7 @@ func TestFindRegionalConfig(t *testing.T) {
 		setup     func() *cobra.Command
 		wantLocs  []string
 		wantURL   string
+		wantProds []string
 		wantFound bool
 	}{
 		{
@@ -48,6 +50,22 @@ func TestFindRegionalConfig(t *testing.T) {
 			wantFound: true,
 		},
 		{
+			name: "annotations include product names",
+			setup: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.Annotations = map[string]string{
+					AnnotationLocations:    "de/fra,de/txl",
+					AnnotationTemplateURL:  "https://svc.%s.ionos.com",
+					AnnotationProductNames: "cloud,compute",
+				}
+				return cmd
+			},
+			wantLocs:  []string{"de/fra", "de/txl"},
+			wantURL:   "https://svc.%s.ionos.com",
+			wantProds: []string{"cloud", "compute"},
+			wantFound: true,
+		},
+		{
 			name: "no annotations",
 			setup: func() *cobra.Command {
 				return &cobra.Command{Use: "test"}
@@ -70,7 +88,7 @@ func TestFindRegionalConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := tt.setup()
-			locs, url, found := findRegionalConfig(cmd)
+			locs, url, prods, found := findRegionalConfig(cmd)
 
 			if found != tt.wantFound {
 				t.Errorf("found = %v, want %v", found, tt.wantFound)
@@ -84,6 +102,41 @@ func TestFindRegionalConfig(t *testing.T) {
 			if strings.Join(locs, ",") != strings.Join(tt.wantLocs, ",") {
 				t.Errorf("locs = %v, want %v", locs, tt.wantLocs)
 			}
+			if strings.Join(prods, ",") != strings.Join(tt.wantProds, ",") {
+				t.Errorf("productNames = %v, want %v", prods, tt.wantProds)
+			}
 		})
 	}
+}
+
+// TestFindOverridenURLPerLocation guards the regional list --all fix: an
+// explicit --api-url override must win over the per-location template for
+// every location queried.
+func TestFindOverridenURLPerLocation(t *testing.T) {
+	const tmpl = "https://svc.%s.ionos.com"
+
+	t.Run("api-url override wins for all locations", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "list"}
+		cmd.Flags().String(constants.ArgServerUrl, tmpl, "")
+		if err := cmd.Flags().Set(constants.ArgServerUrl, "https://override.example.com"); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, loc := range []string{"de/fra", "de/txl"} {
+			got := findOverridenURL(cmd, []string{"cloud"}, tmpl, loc)
+			if got != "https://override.example.com" {
+				t.Errorf("loc %s: url = %q, want override", loc, got)
+			}
+		}
+	})
+
+	t.Run("no override falls back to per-location template", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "list"}
+		cmd.Flags().String(constants.ArgServerUrl, tmpl, "")
+
+		got := findOverridenURL(cmd, []string{"cloud"}, tmpl, "de/txl")
+		if got != "https://svc.de-txl.ionos.com" {
+			t.Errorf("url = %q, want per-location template", got)
+		}
+	})
 }

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
@@ -468,6 +469,38 @@ func TestListAllLocations_Errors(t *testing.T) {
 			t.Errorf("want wrapped all-locations error, got %v", err)
 		}
 	})
+}
+
+// TestListAllLocations_PerLocationTimeout verifies a hanging location is cut by
+// the per-location deadline and reported as an error, without blocking forever.
+func TestListAllLocations_PerLocationTimeout(t *testing.T) {
+	setOutputFormat(t, "json")
+
+	prev := perLocationTimeout
+	perLocationTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { perLocationTimeout = prev })
+
+	cc, _, _ := newRegionalTestCmd([]string{"de/fra"})
+	if err := cc.Command.Command.Flags().Set(constants.FlagLocation, "de/fra"); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cc.ListAllLocations(nil, func(*shared.Configuration) (any, error) {
+			time.Sleep(2 * time.Second) // simulate an unreachable/slow location
+			return okItems(nil)
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Errorf("want timeout error, got %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("ListAllLocations did not return promptly after the per-location timeout")
+	}
 }
 
 // TestListAllLocations_PartialFailure verifies a failing location warns on

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -1,12 +1,60 @@
 package core
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+// TestMain initializes the client singleton with a dummy token so that
+// client.Must() (reached via client.NewRegionalConfig inside ListAllLocations
+// and RunForAllLocations) does not fatally exit during these unit tests. The
+// token is never used for a real request - every test supplies a fake fetchFn.
+func TestMain(m *testing.M) {
+	os.Setenv(constants.EnvToken, "unit-test-token")
+	// Force the once.Do init to run now, with the token present, so getClientErr
+	// stays nil and Must() returns a usable client.
+	_ = client.Must(func(error) {})
+	os.Exit(m.Run())
+}
+
+// newRegionalTestCmd builds a CommandConfig whose cobra command carries the
+// regional annotations, with output/error captured in the returned buffers.
+func newRegionalTestCmd(locations []string) (*CommandConfig, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Annotations = map[string]string{
+		AnnotationLocations:   strings.Join(locations, ","),
+		AnnotationTemplateURL: "https://svc.%s.ionos.com",
+	}
+	cmd.Flags().String(constants.FlagLocation, locations[0], "")
+	cmd.Flags().StringSlice(constants.ArgCols, nil, "")
+	var out, errb bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	return &CommandConfig{Command: &Command{Command: cmd}}, &out, &errb
+}
+
+// okItems is a fake fetchFn returning a collection with a single item.
+func okItems(*shared.Configuration) (any, error) {
+	return map[string]any{"items": []any{map[string]any{"id": "x"}}, "type": "collection"}, nil
+}
+
+func setOutputFormat(t *testing.T, format string) {
+	t.Helper()
+	prev := viper.GetString(constants.ArgOutput)
+	viper.Set(constants.ArgOutput, format)
+	t.Cleanup(func() { viper.Set(constants.ArgOutput, prev) })
+}
 
 func TestFindRegionalConfig(t *testing.T) {
 	tests := []struct {
@@ -268,6 +316,256 @@ func TestLocationStampedItems(t *testing.T) {
 		}
 		if items != nil {
 			t.Errorf("want nil, got %v", items)
+		}
+	})
+}
+
+// TestListAllLocations_TargetSelection verifies how many locations are queried:
+// all when --location is unset, exactly one when it is set.
+func TestListAllLocations_TargetSelection(t *testing.T) {
+	setOutputFormat(t, "json")
+
+	t.Run("queries all locations when --location unset", func(t *testing.T) {
+		cc, _, _ := newRegionalTestCmd([]string{"de/fra", "de/txl", "es/vit"})
+		var calls atomic.Int32
+		err := cc.ListAllLocations(nil, func(cfg *shared.Configuration) (any, error) {
+			calls.Add(1)
+			return okItems(cfg)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if calls.Load() != 3 {
+			t.Errorf("fetchFn called %d times, want 3", calls.Load())
+		}
+	})
+
+	t.Run("queries one location when --location set", func(t *testing.T) {
+		cc, _, _ := newRegionalTestCmd([]string{"de/fra", "de/txl", "es/vit"})
+		if err := cc.Command.Command.Flags().Set(constants.FlagLocation, "de/txl"); err != nil {
+			t.Fatal(err)
+		}
+		var calls atomic.Int32
+		err := cc.ListAllLocations(nil, func(cfg *shared.Configuration) (any, error) {
+			calls.Add(1)
+			return okItems(cfg)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if calls.Load() != 1 {
+			t.Errorf("fetchFn called %d times, want 1", calls.Load())
+		}
+	})
+}
+
+// TestListAllLocations_JSONStamping verifies merged -o json output stamps each
+// item with its source location, and that the shape is the same whether or not
+// --location is set (only the item count differs).
+func TestListAllLocations_JSONStamping(t *testing.T) {
+	setOutputFormat(t, "json")
+
+	parseItems := func(t *testing.T, out string) []any {
+		t.Helper()
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(out), &payload); err != nil {
+			t.Fatalf("output is not a JSON object: %v\n%s", err, out)
+		}
+		items, ok := payload["items"].([]any)
+		if !ok {
+			t.Fatalf("output has no items array: %s", out)
+		}
+		return items
+	}
+
+	t.Run("all locations, each item stamped", func(t *testing.T) {
+		cc, out, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		if err := cc.ListAllLocations(nil, okItems); err != nil {
+			t.Fatal(err)
+		}
+		items := parseItems(t, out.String())
+		if len(items) != 2 {
+			t.Fatalf("want 2 merged items, got %d: %s", len(items), out.String())
+		}
+		got := map[string]bool{}
+		for _, it := range items {
+			got[it.(map[string]any)["location"].(string)] = true
+		}
+		if !got["de/fra"] || !got["de/txl"] {
+			t.Errorf("items not stamped with both locations: %v", got)
+		}
+	})
+
+	t.Run("single location has same shape", func(t *testing.T) {
+		cc, out, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		if err := cc.Command.Command.Flags().Set(constants.FlagLocation, "de/txl"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cc.ListAllLocations(nil, okItems); err != nil {
+			t.Fatal(err)
+		}
+		items := parseItems(t, out.String())
+		if len(items) != 1 {
+			t.Fatalf("want 1 item, got %d", len(items))
+		}
+		if items[0].(map[string]any)["location"] != "de/txl" {
+			t.Errorf("item not stamped with de/txl: %v", items[0])
+		}
+	})
+}
+
+// TestListAllLocations_APIJSON verifies -o api-json is an array with one
+// annotated element per location.
+func TestListAllLocations_APIJSON(t *testing.T) {
+	setOutputFormat(t, "api-json")
+
+	cc, out, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+	if err := cc.ListAllLocations(nil, okItems); err != nil {
+		t.Fatal(err)
+	}
+
+	var arr []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &arr); err != nil {
+		t.Fatalf("api-json is not an array of objects: %v\n%s", err, out.String())
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 per-location responses, got %d", len(arr))
+	}
+	got := map[string]bool{}
+	for _, resp := range arr {
+		loc, _ := resp["location"].(string)
+		got[loc] = true
+		if _, ok := resp["items"]; !ok {
+			t.Errorf("per-location response lost its body: %v", resp)
+		}
+	}
+	if !got["de/fra"] || !got["de/txl"] {
+		t.Errorf("responses not annotated with both locations: %v", got)
+	}
+}
+
+// TestListAllLocations_Errors covers error aggregation: a single target returns
+// its error verbatim, while all-locations failures are wrapped.
+func TestListAllLocations_Errors(t *testing.T) {
+	setOutputFormat(t, "json")
+	boom := func(*shared.Configuration) (any, error) { return nil, errors.New("boom") }
+
+	t.Run("single target returns verbatim error", func(t *testing.T) {
+		cc, _, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		if err := cc.Command.Command.Flags().Set(constants.FlagLocation, "de/txl"); err != nil {
+			t.Fatal(err)
+		}
+		err := cc.ListAllLocations(nil, boom)
+		if err == nil || err.Error() != "boom" {
+			t.Errorf("want verbatim \"boom\", got %v", err)
+		}
+	})
+
+	t.Run("all locations failing is wrapped", func(t *testing.T) {
+		cc, _, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		err := cc.ListAllLocations(nil, boom)
+		if err == nil || !strings.Contains(err.Error(), "failed to list from all locations") {
+			t.Errorf("want wrapped all-locations error, got %v", err)
+		}
+	})
+}
+
+// TestListAllLocations_PartialFailure verifies a failing location warns on
+// stderr while succeeding locations still render.
+func TestListAllLocations_PartialFailure(t *testing.T) {
+	setOutputFormat(t, "json")
+
+	cc, out, errb := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+	err := cc.ListAllLocations(nil, func(cfg *shared.Configuration) (any, error) {
+		if strings.Contains(cfg.Servers[0].URL, "de-txl") {
+			return nil, errors.New("txl-down")
+		}
+		return okItems(cfg)
+	})
+	if err != nil {
+		t.Fatalf("partial failure should not error out: %v", err)
+	}
+	if !strings.Contains(errb.String(), "de/txl") || !strings.Contains(errb.String(), "txl-down") {
+		t.Errorf("expected warning for de/txl, stderr: %s", errb.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("bad output: %v", err)
+	}
+	if items := payload["items"].([]any); len(items) != 1 {
+		t.Errorf("want 1 surviving item, got %d", len(items))
+	}
+}
+
+// TestRunForAllLocations covers the delete --all fan-out helper: it runs once
+// per location, aggregates errors, and announces the blast radius.
+func TestRunForAllLocations(t *testing.T) {
+	t.Run("runs once per location and announces blast radius", func(t *testing.T) {
+		cc, _, errb := newRegionalTestCmd([]string{"de/fra", "de/txl", "es/vit"})
+		var got []string
+		err := cc.RunForAllLocations(func(_ *shared.Configuration, loc string) error {
+			got = append(got, loc)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Join(got, ",") != "de/fra,de/txl,es/vit" {
+			t.Errorf("ran for %v, want all three in order", got)
+		}
+		if !strings.Contains(errb.String(), "Operating across all 3 locations") {
+			t.Errorf("missing blast-radius notice, stderr: %s", errb.String())
+		}
+	})
+
+	t.Run("aggregates per-location errors", func(t *testing.T) {
+		cc, _, _ := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		err := cc.RunForAllLocations(func(_ *shared.Configuration, loc string) error {
+			if loc == "de/txl" {
+				return errors.New("nope")
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "location de/txl: nope") {
+			t.Errorf("want aggregated error naming de/txl, got %v", err)
+		}
+	})
+
+	t.Run("single target runs once without blast-radius notice", func(t *testing.T) {
+		cc, _, errb := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		if err := cc.Command.Command.Flags().Set(constants.FlagLocation, "de/txl"); err != nil {
+			t.Fatal(err)
+		}
+		var calls int
+		var seen string
+		err := cc.RunForAllLocations(func(_ *shared.Configuration, loc string) error {
+			calls++
+			seen = loc
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if calls != 1 || seen != "de/txl" {
+			t.Errorf("want single run for de/txl, got calls=%d loc=%q", calls, seen)
+		}
+		if strings.Contains(errb.String(), "Operating across") {
+			t.Errorf("single target should not announce blast radius, stderr: %s", errb.String())
+		}
+	})
+
+	t.Run("blast-radius notice suppressed with --quiet", func(t *testing.T) {
+		prev := viper.GetBool(constants.ArgQuiet)
+		viper.Set(constants.ArgQuiet, true)
+		t.Cleanup(func() { viper.Set(constants.ArgQuiet, prev) })
+
+		cc, _, errb := newRegionalTestCmd([]string{"de/fra", "de/txl"})
+		err := cc.RunForAllLocations(func(_ *shared.Configuration, _ string) error { return nil })
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(errb.String(), "Operating across") {
+			t.Errorf("--quiet should suppress blast-radius notice, stderr: %s", errb.String())
 		}
 	})
 }

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestFindRegionalConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func() *cobra.Command
+		wantLocs   []string
+		wantURL    string
+		wantFound  bool
+	}{
+		{
+			name: "annotations on direct command",
+			setup: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.Annotations = map[string]string{
+					AnnotationLocations:   "de/fra,de/txl,es/vit",
+					AnnotationTemplateURL: "https://svc.%s.ionos.com",
+				}
+				return cmd
+			},
+			wantLocs:  []string{"de/fra", "de/txl", "es/vit"},
+			wantURL:   "https://svc.%s.ionos.com",
+			wantFound: true,
+		},
+		{
+			name: "annotations on parent command",
+			setup: func() *cobra.Command {
+				parent := &cobra.Command{Use: "kafka"}
+				parent.Annotations = map[string]string{
+					AnnotationLocations:   "de/fra,us/las",
+					AnnotationTemplateURL: "https://kafka.%s.ionos.com",
+				}
+				child := &cobra.Command{Use: "cluster"}
+				leaf := &cobra.Command{Use: "list"}
+				child.AddCommand(leaf)
+				parent.AddCommand(child)
+				return leaf
+			},
+			wantLocs:  []string{"de/fra", "us/las"},
+			wantURL:   "https://kafka.%s.ionos.com",
+			wantFound: true,
+		},
+		{
+			name: "no annotations",
+			setup: func() *cobra.Command {
+				return &cobra.Command{Use: "test"}
+			},
+			wantFound: false,
+		},
+		{
+			name: "partial annotations (missing URL)",
+			setup: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.Annotations = map[string]string{
+					AnnotationLocations: "de/fra",
+				}
+				return cmd
+			},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setup()
+			locs, url, found := findRegionalConfig(cmd)
+
+			if found != tt.wantFound {
+				t.Errorf("found = %v, want %v", found, tt.wantFound)
+			}
+			if !tt.wantFound {
+				return
+			}
+			if url != tt.wantURL {
+				t.Errorf("url = %q, want %q", url, tt.wantURL)
+			}
+			if strings.Join(locs, ",") != strings.Join(tt.wantLocs, ",") {
+				t.Errorf("locs = %v, want %v", locs, tt.wantLocs)
+			}
+		})
+	}
+}

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestFindRegionalConfig(t *testing.T) {
 	tests := []struct {
-		name       string
-		setup      func() *cobra.Command
-		wantLocs   []string
-		wantURL    string
-		wantFound  bool
+		name      string
+		setup     func() *cobra.Command
+		wantLocs  []string
+		wantURL   string
+		wantFound bool
 	}{
 		{
 			name: "annotations on direct command",

--- a/internal/printer/table/table.go
+++ b/internal/printer/table/table.go
@@ -163,6 +163,18 @@ func (t *Table) Raw() any {
 	return t.raw
 }
 
+// AppendRow adds a pre-built row to the table.
+// Used by ListAllLocations to merge rows from different API calls.
+func (t *Table) AppendRow(row map[string]any) {
+	t.rows = append(t.rows, row)
+}
+
+// SetRaw replaces the raw source data used for JSON output modes.
+// Used by ListAllLocations to set the merged array of per-location responses.
+func (t *Table) SetRaw(data any) {
+	t.raw = data
+}
+
 // SetCell sets a value for a specific column in a specific row.
 // Useful for post-extraction adjustments.
 func (t *Table) SetCell(row int, col string, value any) {
@@ -464,6 +476,11 @@ func marshalJSON(data any) (string, error) {
 		return "", err
 	}
 	return string(out) + "\n", nil
+}
+
+// ApplyQueryFilter applies the --query JMESPath filter to data, if set.
+func ApplyQueryFilter(data any) (any, error) {
+	return applyQueryFilter(data)
 }
 
 func applyQueryFilter(data any) (any, error) {

--- a/internal/printer/table/table.go
+++ b/internal/printer/table/table.go
@@ -169,12 +169,6 @@ func (t *Table) AppendRow(row map[string]any) {
 	t.rows = append(t.rows, row)
 }
 
-// SetRaw replaces the raw source data used for JSON output modes.
-// Used by ListAllLocations to set the merged array of per-location responses.
-func (t *Table) SetRaw(data any) {
-	t.raw = data
-}
-
 // SetCell sets a value for a specific column in a specific row.
 // Useful for post-extraction adjustments.
 func (t *Table) SetCell(row int, col string, value any) {


### PR DESCRIPTION
- List resources from all locations by default on regional APIs (DNS, CDN, Certificate Manager, Kafka, VPN, Logging, Monitoring, DBaaS). Output shows a `Location` column, and `-o json`/`-o api-json` items include a `location` field. Use `--location` to list a single location; the output shape is the same either way.
- Tab completion for regional resource IDs (e.g. `--cluster-id`) now shows resources from all locations.
- `--location` is now required for create, get, update, and delete on regional APIs with more than one location. Previously these defaulted to the first location and returned a 404 if the resource was elsewhere.
- `delete --all` on regional APIs now deletes from all locations by default, matching `list`. Previously it only deleted from the first location. Use `--location` to limit it to one location.