### PR TITLE
chore: align brand references to IONOS CLOUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=cli-ionosctl&metric=alert_status)](https://sonarcloud.io/dashboard?id=cli-ionosctl)
 
 
-![IONOS Cloud](.github/IONOS.CLOUD.BLU.svg?raw=true "IONOS Cloud")
+![IONOS CLOUD](.github/IONOS.CLOUD.BLU.svg?raw=true "IONOS CLOUD")
 
 # ionosctl
 
-The command-line interface for [IONOS Cloud](https://www.ionos.com/enterprise-cloud/signup). Create and manage cloud resources -- virtual machines, networks, storage, databases, Kubernetes clusters, DNS, and more -- directly from your terminal.
+The command-line interface for [IONOS CLOUD](https://www.ionos.com/enterprise-cloud/signup). Create and manage cloud resources -- virtual machines, networks, storage, databases, Kubernetes clusters, DNS, and more -- directly from your terminal.
 
 [Ionosctl usage overview](https://github.com/user-attachments/assets/78b2b920-70bb-4df1-8144-32b860b7ff70)
 
-> **Prerequisites:** You need an [IONOS Cloud account](https://www.ionos.com/enterprise-cloud/signup) to use ionosctl.
+> **Prerequisites:** You need an [IONOS CLOUD account](https://www.ionos.com/enterprise-cloud/signup) to use ionosctl.
 
 ## Table of Contents
 
@@ -369,7 +369,7 @@ ionosctl completion powershell > ionosctl.ps1
 
 ## Configuration
 
-`ionosctl login` generates a YAML config file that stores your token and per-product API endpoint URLs (auto-discovered from the IONOS Cloud API index). Default location:
+`ionosctl login` generates a YAML config file that stores your token and per-product API endpoint URLs (auto-discovered from the IONOS CLOUD API index). Default location:
 
 | OS | Path |
 |----|------|
@@ -435,7 +435,7 @@ ionosctl version --updates
 | Resource | Link |
 |----------|------|
 | Full CLI Reference | [docs.ionos.com/cli-ionosctl](https://docs.ionos.com/cli-ionosctl) |
-| IONOS Cloud User Guide | [docs.ionos.com/cloud](https://docs.ionos.com/cloud) |
+| IONOS CLOUD User Guide | [docs.ionos.com/cloud](https://docs.ionos.com/cloud) |
 | API Reference | [api.ionos.com/docs](https://api.ionos.com/docs/) |
 | Cloud Console (DCD) | [dcd.ionos.com](https://dcd.ionos.com/) |
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ from the folder where you cloned the ionosctl git.
 
 ### Authenticating with IONOS CLOUD
 
-Before using `ionosctl` to perform any operations, you will need to set your credentials for IONOS Cloud account. The authentication mechanism is first checking the environment variables and if these are not set, it is checking if a configuration file exists and if the user has the right permissions for it.
+Before using `ionosctl` to perform any operations, you will need to set your credentials for IONOS CLOUD account. The authentication mechanism is first checking the environment variables and if these are not set, it is checking if a configuration file exists and if the user has the right permissions for it.
 
 You can provide your credentials:
 
@@ -159,8 +159,8 @@ After a successful authentication, you will no longer need to provide credential
 
 | Environment Variable | Description                                                                                                                                                                                                                    |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `IONOS_USERNAME`     | Specify the username used to login, to authenticate against the IONOS Cloud API                                                                                                                                                | 
-| `IONOS_PASSWORD`     | Specify the password used to login, to authenticate against the IONOS Cloud API                                                                                                                                                | 
+| `IONOS_USERNAME`     | Specify the username used to login, to authenticate against the IONOS CLOUD API                                                                                                                                                | 
+| `IONOS_PASSWORD`     | Specify the password used to login, to authenticate against the IONOS CLOUD API                                                                                                                                                | 
 | `IONOS_TOKEN`        | Specify the token used to login, if a token is being used instead of username and password                                                                                                                                     |
 | `IONOS_API_URL`      | Specify the API URL. It will overwrite the API endpoint default value `api.ionos.com`. Note: the host URL does not contain the `/cloudapi/v5` path, so it should _not_ be included in the `IONOS_API_URL` environment variable |
 | `IONOS_LOG_LEVEL`    | Specify the Log Level used to log messages sent to the API. Possible values: `Off`, `Debug`, `Trace`                                                                                                                           |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-IonosCTL is a tool to help you manage your Ionos Cloud resources directly from your terminal.
+IonosCTL is a tool to help you manage your IONOS CLOUD resources directly from your terminal.
 
 ## Overview
 
@@ -9,7 +9,7 @@ Cobra is both a library for creating powerful modern command-line interface (CLI
 
 ## Getting started
 
-Before you begin you will need to have signed-up for a [Ionos Cloud](https://www.ionos.com/enterprise-cloud/signup) account. The credentials you establish during sign-up will be used to authenticate against the [Ionos Cloud API](https://dcd.ionos.com/latest/).
+Before you begin you will need to have signed-up for a [IONOS CLOUD](https://www.ionos.com/enterprise-cloud/signup) account. The credentials you establish during sign-up will be used to authenticate against the [IONOS CLOUD API](https://dcd.ionos.com/latest/).
 
 ### Installing `ionosctl`
 
@@ -87,7 +87,7 @@ go install
 ```
 from the folder where you cloned the ionosctl git.
 
-### Authenticating with Ionos Cloud
+### Authenticating with IONOS CLOUD
 
 Before using `ionosctl` to perform any operations, you will need to set your credentials for IONOS Cloud account. The authentication mechanism is first checking the environment variables and if these are not set, it is checking if a configuration file exists and if the user has the right permissions for it.
 


### PR DESCRIPTION
Aligns user-facing prose references to the IONOS CLOUD brand.

Out of scope: Go package paths, env vars, binary names, URL slugs, and other identifiers are unchanged.

Verification: no remaining 'Ionos Cloud' / 'ionos cloud' prose in docs/README.md and no collapsed duplicate tokens.