### PR TITLE
feat: add volume performance classes to volume --type completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v6.10.2] – July 2026
+
+### Added
+- `volume create`: added the new volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to `--type` shell completion.
+
+### Fixed
+- `volume create`: `--type` shell completion was registered on the wrong flag (`--licence-type`) and never offered. It now completes on `--type`.
+
 ## [v6.10.1] – May 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `volume create`: added the new volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to `--type` shell completion.
 
 ### Fixed
-- `volume create`: `--type` shell completion was registered on the wrong flag (`--licence-type`) and never offered. It now completes on `--type`.
+- `volume create`: `--type` now provides shell completion for the available volume types.
 
 ## [v6.10.1] – May 2026
 

--- a/commands/compute/volume/create.go
+++ b/commands/compute/volume/create.go
@@ -51,8 +51,8 @@ ionosctl compute volume create --datacenter-id DATACENTER_ID --name NAME --image
 	})
 	cmd.AddSetFlag(cloudapiv6.ArgLicenceType, "", "LINUX", constants.EnumLicenceType, "Licence Type of the Volume")
 	cmd.AddStringFlag(constants.FlagType, "", "HDD", "Type of the Volume")
-	_ = cmd.Command.RegisterFlagCompletionFunc(cloudapiv6.ArgLicenceType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"HDD", "SSD", "SSD Standard", "SSD Premium"}, cobra.ShellCompDirectiveNoFileComp
+	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"HDD", "SSD", "SSD Standard", "SSD Premium", "ESSENTIAL", "BALANCED", "PERFORMANCE"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.AddStringFlag(constants.FlagAvailabilityZone, constants.FlagAvailabilityZoneShort, "AUTO", "Availability zone of the Volume. Storage zone can only be selected prior provisioning")
 	_ = cmd.Command.RegisterFlagCompletionFunc(constants.FlagAvailabilityZone, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Adds the new volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to the `volume create --type` shell completion. Also fixes a pre-existing bug where this completion was registered on `--licence-type` instead of `--type`, so `--type` had no completion at all.

Draft until the classes are live on the API.