### PR TITLE
fix: show LicenceType column in snapshot list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Added the `LicenceType` column to `compute snapshot list` output.
+
 ## [v6.10.1] – May 2026
 
 ### Added

--- a/commands/compute/snapshot/snapshot.go
+++ b/commands/compute/snapshot/snapshot.go
@@ -10,7 +10,7 @@ import (
 var allSnapshotCols = []table.Column{
 	{Name: "SnapshotId", JSONPath: "id", Default: true},
 	{Name: "Name", JSONPath: "properties.name", Default: true},
-	{Name: "LicenceType", JSONPath: "properties.licenseType", Default: true},
+	{Name: "LicenceType", JSONPath: "properties.licenceType", Default: true},
 	{Name: "Size", JSONPath: "properties.size", Default: true},
 	{Name: "State", JSONPath: "metadata.state", Default: true},
 }


### PR DESCRIPTION
`compute snapshot list --cols ...,LicenceType,...` never showed the LicenceType column. The column path was `properties.licenseType`, but the API serializes the field as `licenceType`, so the value always resolved empty and empty columns get dropped from the output.

Corrected the column path.