### PR TITLE
doc: default location fix

### DIFF
--- a/commands/object-storage/bucket/create.go
+++ b/commands/object-storage/bucket/create.go
@@ -27,7 +27,14 @@ func CreateBucketCmd() *core.Command {
 		},
 		CmdRun: func(c *core.CommandConfig) error {
 			name := viper.GetString(core.GetFlagName(c.NS, constants.FlagName))
+			// --location is optional here: when unset it falls back to the first
+			// Object Storage location, matching the endpoint that PersistentPreRunE
+			// resolves for the same unset case. Sourced explicitly rather than from
+			// the flag default so the LocationConstraint and endpoint stay in sync.
 			location := viper.GetString(constants.FlagLocation)
+			if location == "" {
+				location = constants.ObjectStorageLocations[0]
+			}
 			objectLock := viper.GetBool(core.GetFlagName(c.NS, flagObjectLock))
 
 			cfg := objectstorage.NewCreateBucketConfiguration()

--- a/commands/object-storage/bucket/head.go
+++ b/commands/object-storage/bucket/head.go
@@ -45,10 +45,18 @@ func HeadBucketCmd() *core.Command {
 				return fmt.Errorf("checking if bucket %q exists: %w", name, err)
 			}
 
+			// Report the bucket's actual region rather than echoing --location,
+			// which may be unset or differ from where the bucket really lives.
+			region := ""
+			if loc, _, locErr := client.MustObjectStorage().ObjectStorageClient.BucketsApi.
+				GetBucketLocation(c.Context, name).Execute(); locErr == nil {
+				region = loc.GetLocationConstraint()
+			}
+
 			result := headResult{
 				Name:   name,
 				Status: "exists and is accessible",
-				Region: viper.GetString(constants.FlagLocation),
+				Region: region,
 			}
 
 			cols, _ := c.Command.Command.Flags().GetStringSlice(constants.ArgCols)

--- a/commands/object-storage/completer/completer.go
+++ b/commands/object-storage/completer/completer.go
@@ -16,11 +16,19 @@ func BucketNames() []string {
 		return nil
 	}
 
+	// Only filter by location when --location was explicitly set; otherwise
+	// list buckets from every region (matching `bucket list`). Filtering
+	// against an unset location would drop every bucket.
+	filterByLocation := viper.IsSet(constants.FlagLocation)
+	wantLocation := viper.GetString(constants.FlagLocation)
+
 	var names []string
 	for _, b := range result.GetBuckets() {
-		loc, _, locErr := client.MustObjectStorage().ObjectStorageClient.BucketsApi.GetBucketLocation(context.Background(), b.GetName()).Execute()
-		if locErr != nil || loc.GetLocationConstraint() != viper.GetString(constants.FlagLocation) {
-			continue
+		if filterByLocation {
+			loc, _, locErr := client.MustObjectStorage().ObjectStorageClient.BucketsApi.GetBucketLocation(context.Background(), b.GetName()).Execute()
+			if locErr != nil || loc.GetLocationConstraint() != wantLocation {
+				continue
+			}
 		}
 
 		names = append(names, b.GetName())

--- a/commands/object-storage/object_storage.go
+++ b/commands/object-storage/object_storage.go
@@ -21,9 +21,18 @@ func Root() *core.Command {
 	cmd.AddCommand(bucket.BucketCommand())
 	cmd.AddCommand(object.ObjectCommand())
 
-	return core.WithRegionalConfigOverride(cmd,
+	cmd = core.WithRegionalConfigOverride(cmd,
 		[]string{fileconfiguration.ObjectStorage},
 		constants.ObjectStorageApiRegionalURL,
 		constants.ObjectStorageLocations,
 	)
+
+	// Document the default. The shared flag has no cobra default (list queries all
+	// locations when unset), but single-resource commands fall back to the first
+	// location, so note it here rather than as a misleading global cobra default.
+	if f := cmd.Command.PersistentFlags().Lookup(constants.FlagLocation); f != nil {
+		f.Usage += ". Defaults to " + constants.ObjectStorageLocations[0]
+	}
+
+	return cmd
 }

--- a/docs/subcommands/CDN/distribution/create.md
+++ b/docs/subcommands/CDN/distribution/create.md
@@ -42,7 +42,7 @@ Create a CDN distribution. Wiki: https://docs.ionos.com/cloud/network-services/c
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/CDN/distribution/delete.md
+++ b/docs/subcommands/CDN/distribution/delete.md
@@ -42,7 +42,7 @@ Delete a distribution
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/get.md
+++ b/docs/subcommands/CDN/distribution/get.md
@@ -41,7 +41,7 @@ Retrieve a distribution
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/list.md
+++ b/docs/subcommands/CDN/distribution/list.md
@@ -41,7 +41,7 @@ Retrieve all distributions using pagination and optional filters
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/CDN/distribution/routingrules/get.md
+++ b/docs/subcommands/CDN/distribution/routingrules/get.md
@@ -47,7 +47,7 @@ Retrieve a distribution routing rules
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/CDN/distribution/update.md
+++ b/docs/subcommands/CDN/distribution/update.md
@@ -43,7 +43,7 @@ Partially modify a distribution's properties. This command uses a combination of
   -f, --force                    Force command to execute without user input
   -h, --help                     Print usage
       --limit int                Maximum number of items to return per request (default 50)
-  -l, --location string          Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string          Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers               Don't print table headers when table output is used
       --offset int               Number of items to skip before starting to collect the results
       --order-by string          Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/create.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/create.md
@@ -48,7 +48,7 @@ Create an AutoCertificate. Requires an enabled DNS Zone with the same name as th
   -h, --help                                Print usage
       --key-algorithm string                The key algorithm used to generate the certificate. (required)
       --limit int                           Maximum number of items to return per request (default 50)
-  -l, --location string                     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string                     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string                         The name of the AutoCertificate
       --no-headers                          Don't print table headers when table output is used
       --offset int                          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/autocertificate/delete.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/delete.md
@@ -48,7 +48,7 @@ Delete an AutoCertificate
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/get.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/get.md
@@ -47,7 +47,7 @@ Retrieve an AutoCertificate
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/list.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/list.md
@@ -47,7 +47,7 @@ Retrieve AutoCertificate list
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/autocertificate/update.md
+++ b/docs/subcommands/Certificate-Manager/autocertificate/update.md
@@ -47,7 +47,7 @@ Update an AutoCertificate.
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string                 The new name of the AutoCertificate (required)
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/certificate/create.md
+++ b/docs/subcommands/Certificate-Manager/certificate/create.md
@@ -51,7 +51,7 @@ Use this command to add a Certificate.
   -f, --force                           Force command to execute without user input
   -h, --help                            Print usage
       --limit int                       Maximum number of items to return per request (default 50)
-  -l, --location string                 Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string                 Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers                      Don't print table headers when table output is used
       --offset int                      Number of items to skip before starting to collect the results
       --order-by string                 Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/delete.md
+++ b/docs/subcommands/Certificate-Manager/certificate/delete.md
@@ -48,7 +48,7 @@ Use this command to delete a Certificate by ID.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/get.md
+++ b/docs/subcommands/Certificate-Manager/certificate/get.md
@@ -49,7 +49,7 @@ Use this command to retrieve a Certificate by ID.
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/list.md
+++ b/docs/subcommands/Certificate-Manager/certificate/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve all Certificates.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Certificate-Manager/certificate/update.md
+++ b/docs/subcommands/Certificate-Manager/certificate/update.md
@@ -48,7 +48,7 @@ Use this change a certificate's name.
   -f, --force                     Force command to execute without user input
   -h, --help                      Print usage
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results
       --order-by string           Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/create.md
+++ b/docs/subcommands/Certificate-Manager/provider/create.md
@@ -49,7 +49,7 @@ Create an Provider
       --key-id string       The key ID of the external account binding
       --key-secret string   The key secret of the external account binding
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string         The name of the certificate Provider
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Certificate-Manager/provider/delete.md
+++ b/docs/subcommands/Certificate-Manager/provider/delete.md
@@ -47,7 +47,7 @@ Delete an Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/get.md
+++ b/docs/subcommands/Certificate-Manager/provider/get.md
@@ -46,7 +46,7 @@ Retrieve a Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/list.md
+++ b/docs/subcommands/Certificate-Manager/provider/list.md
@@ -46,7 +46,7 @@ Retrieve Provider list
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Certificate-Manager/provider/update.md
+++ b/docs/subcommands/Certificate-Manager/provider/update.md
@@ -46,7 +46,7 @@ Modify an Provider
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new name of the Provider (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Compute Engine/monitoring/central/disable.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/disable.md
@@ -40,7 +40,7 @@ Disable CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/central/enable.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/enable.md
@@ -40,7 +40,7 @@ Enable CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/central/get.md
+++ b/docs/subcommands/Compute Engine/monitoring/central/get.md
@@ -40,7 +40,7 @@ Retrieve CentralMonitoring
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/key/create.md
+++ b/docs/subcommands/Compute Engine/monitoring/key/create.md
@@ -38,7 +38,7 @@ Create a new key for a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/create.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/create.md
@@ -40,7 +40,7 @@ Create an pipeline
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
   -n, --name string       The name of the Monitoring pipeline
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/delete.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/delete.md
@@ -41,7 +41,7 @@ Delete a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/get.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/get.md
@@ -40,7 +40,7 @@ Retrieve a pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/list.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/list.md
@@ -40,7 +40,7 @@ Retrieve pipelines
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Compute Engine/monitoring/pipeline/update.md
+++ b/docs/subcommands/Compute Engine/monitoring/pipeline/update.md
@@ -40,7 +40,7 @@ Partially modify a pipeline's properties. This command uses a combination of GET
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/bhx, gb/lhr, fr/par, us/mci
   -n, --name string          The new name of the Monitoring Pipeline (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/dnssec/create.md
+++ b/docs/subcommands/DNS/dnssec/create.md
@@ -42,7 +42,7 @@ Enable DNSSEC keys and create associated DNSKEY records for your DNS zone
   -h, --help                   Print usage
       --ksk-bits int           Key signing key length in bits. kskBits >= zskBits: [1024/2048/4096] (default 1024)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string        Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers             Don't print table headers when table output is used
       --nsec-mode string       NSEC mode.. Can be one of: NSEC, NSEC3 (default "NSEC")
       --nsec3-iterations int   Number of iterations for NSEC3. [0..50]

--- a/docs/subcommands/DNS/dnssec/delete.md
+++ b/docs/subcommands/DNS/dnssec/delete.md
@@ -40,7 +40,7 @@ Removes ALL associated DNSKEY records for your DNS zone and disables DNSSEC keys
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/dnssec/list.md
+++ b/docs/subcommands/DNS/dnssec/list.md
@@ -40,7 +40,7 @@ Retrieve your zone's DNSSEC keys
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/quota/get.md
+++ b/docs/subcommands/DNS/quota/get.md
@@ -40,7 +40,7 @@ Retrieve your quotas
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/create.md
+++ b/docs/subcommands/DNS/record/create.md
@@ -42,7 +42,7 @@ Create a record. Wiki: https://docs.ionos.com/cloud/network-services/cloud-dns/a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name \*           The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/record/delete.md
+++ b/docs/subcommands/DNS/record/delete.md
@@ -51,7 +51,7 @@ Here, PARTIAL_NAME is a part of the name of the DNS record you want to delete. I
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/get.md
+++ b/docs/subcommands/DNS/record/get.md
@@ -40,7 +40,7 @@ Retrieve a record
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/record/list.md
+++ b/docs/subcommands/DNS/record/list.md
@@ -41,7 +41,7 @@ Retrieve all records from either a primary or secondary zone
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string             Filter used to fetch only the records that contain specified record name. NOTE: Only available for zone records.
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/record/update.md
+++ b/docs/subcommands/DNS/record/update.md
@@ -42,7 +42,7 @@ Partially modify a record's properties. This command uses a combination of GET a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name \*           The name of the DNS record.  Provide a wildcard i.e. \* to match requests for non-existent names under your DNS Zone name. Note that some terminals require '*' to be escaped, e.g. '\*' (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/reverse/record/create.md
+++ b/docs/subcommands/DNS/reverse/record/create.md
@@ -42,7 +42,7 @@ Create a record. Wiki: https://docs.ionos.com/cloud/network-services/cloud-dns/a
   -h, --help                 Print usage
       --ip string            [IPv4/IPv6] Specifies for which IP address the reverse record should be created. The IP addresses needs to be owned by the contract (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string          The name of the DNS Reverse Record. (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/reverse/record/delete.md
+++ b/docs/subcommands/DNS/reverse/record/delete.md
@@ -41,7 +41,7 @@ Delete a record
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/get.md
+++ b/docs/subcommands/DNS/reverse/record/get.md
@@ -40,7 +40,7 @@ Find a record by IP or ID
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/list.md
+++ b/docs/subcommands/DNS/reverse/record/list.md
@@ -41,7 +41,7 @@ Retrieve all reverse records
   -h, --help              Print usage
   -i, --ips string        Optional filter for the IP address of the reverse record
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/reverse/record/update.md
+++ b/docs/subcommands/DNS/reverse/record/update.md
@@ -42,7 +42,7 @@ Update a record
   -h, --help                 Print usage
       --ip string            The new IP
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new record name
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/create.md
+++ b/docs/subcommands/DNS/secondary/zone/create.md
@@ -44,7 +44,7 @@ IPv6: 2001:8d8:fe:53::5cd:25
   -f, --force                 Force command to execute without user input
   -h, --help                  Print usage
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string       Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string           Name of the secondary zone
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/delete.md
+++ b/docs/subcommands/DNS/secondary/zone/delete.md
@@ -41,7 +41,7 @@ Delete a secondary zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/get.md
+++ b/docs/subcommands/DNS/secondary/zone/get.md
@@ -34,7 +34,7 @@ Retrieve a secondary zone by its ID or name
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/list.md
+++ b/docs/subcommands/DNS/secondary/zone/list.md
@@ -34,7 +34,7 @@ List all secondary zones. Default limit is the first 100 items. Use pagination q
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string       Filter used to fetch only the zones that contain the specified zone name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/secondary/zone/transfer/get.md
+++ b/docs/subcommands/DNS/secondary/zone/transfer/get.md
@@ -46,7 +46,7 @@ Get the transfer status for a secondary zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/transfer/start.md
+++ b/docs/subcommands/DNS/secondary/zone/transfer/start.md
@@ -46,7 +46,7 @@ Initiate zone transfer
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/secondary/zone/update.md
+++ b/docs/subcommands/DNS/secondary/zone/update.md
@@ -35,7 +35,7 @@ Update or create a secondary zone
   -f, --force                 Force command to execute without user input
   -h, --help                  Print usage
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string       Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results
       --order-by string       Property to order the results by

--- a/docs/subcommands/DNS/zone/create.md
+++ b/docs/subcommands/DNS/zone/create.md
@@ -42,7 +42,7 @@ Create a zone
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string          The name of the DNS zone, e.g. foo.com
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/zone/delete.md
+++ b/docs/subcommands/DNS/zone/delete.md
@@ -41,7 +41,7 @@ Delete a zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/file/get.md
+++ b/docs/subcommands/DNS/zone/file/get.md
@@ -46,7 +46,7 @@ Get the exported zone file in BIND format (RFC 1035)
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/file/update.md
+++ b/docs/subcommands/DNS/zone/file/update.md
@@ -40,7 +40,7 @@ Update a zone file
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string    Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/DNS/zone/get.md
+++ b/docs/subcommands/DNS/zone/get.md
@@ -40,7 +40,7 @@ Retrieve a zone
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/DNS/zone/list.md
+++ b/docs/subcommands/DNS/zone/list.md
@@ -40,7 +40,7 @@ Retrieve zones
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string       Filter used to fetch only the zones that contain the specified zone name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/DNS/zone/update.md
+++ b/docs/subcommands/DNS/zone/update.md
@@ -42,7 +42,7 @@ Partially modify a zone's properties. This command uses a combination of GET and
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra (default "de/fra")
   -n, --name string          The new name of the DNS zone, e.g. foo.com
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/create.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/create.md
@@ -69,7 +69,7 @@ volatile-ttl: The key with the nearest time to live will be removed first, but o
   -h, --help                      Print usage
       --lan-id string             The numeric Private LAN ID to connect your instance to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of the Replica Set (required)

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/delete.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/delete.md
@@ -47,7 +47,7 @@ Delete In-Memory DB Replica Sets
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/get.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/get.md
@@ -46,7 +46,7 @@ Get an In-Memory DB Replica Set
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results
       --order-by string         Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/replicaset/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Replica Sets
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
   -n, --name string       You can filter the Replica Sets by name
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Snapshots
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/create.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/create.md
@@ -47,7 +47,7 @@ Create an In-Memory DB Restore
   -f, --force                   Force command to execute without user input
   -h, --help                    Print usage
       --limit int               Maximum number of items to return per request (default 50)
-  -l, --location string         Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string         Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
   -n, --name string             The human readable name of your snapshot
       --no-headers              Don't print table headers when table output is used
       --offset int              Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/list.md
+++ b/docs/subcommands/Database-as-a-Service/In-Memory-DB/snapshot/restore/list.md
@@ -46,7 +46,7 @@ List In-Memory DB Restores
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/txl, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/backup/get.md
@@ -47,7 +47,7 @@ Get a MariaDB Backup
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string    Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/backup/list.md
@@ -47,7 +47,7 @@ List all MariaDB Backups, or optionally provide a Cluster ID to list those of a 
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/create.md
@@ -51,7 +51,7 @@ Create DBaaS MariaDB clusters
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries) (default 1)
       --lan-id string             The numeric LAN ID with which you connect your cluster (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
       --maintenance-time string   Time for the MaintenanceWindows. The MaintenanceWindow is a weekly 4 hour-long windows, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random day during Mon-Fri, during the hours 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")
   -n, --name string               The name of your cluster (required)

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/delete.md
@@ -48,7 +48,7 @@ Delete a MariaDB Cluster by ID
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
   -n, --name                When deleting all clusters, filter the clusters by a name
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/get.md
@@ -47,7 +47,7 @@ Get a MariaDB Cluster by ID
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of MariaDB Clusters provisioned under your a
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
   -n, --name string       Response filter to list only the MariaDB Clusters that contain the specified name in the DisplayName field. The value is case insensitive
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/mariadb/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/mariadb/cluster/update.md
@@ -49,7 +49,7 @@ Update a MariaDB Cluster
   -h, --help                      Print usage
       --instances int32           The total number of instances of the cluster (one primary and n-1 secondaries). Instances can only be increased (3,5,7)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci (default "de/txl")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, us/ewr, us/las, us/mci
       --maintenance-day string    Day Of the Week for the MaintenanceWindows. e.g.: Monday. To change maintenance provide both --maintenance-day and --maintenance-time
       --maintenance-time string   Time for the MaintenanceWindows. e.g.: 16:30:59. To change maintenance provide both --maintenance-day and --maintenance-time
   -n, --name string               The name of your cluster

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force              Force command to execute without user input
   -h, --help               Print usage
       --limit int          Maximum number of items to return per request (default 50)
-  -l, --location string    Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string    Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers         Don't print table headers when table output is used
       --offset int         Number of items to skip before starting to collect the results
       --order-by string    Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/list.md
@@ -47,7 +47,7 @@ Use this command to retrieve a list of PostgreSQL Backups.
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int32         The limit of the number of items to return (default 100)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers          Don't print table headers when table output is used
       --offset int32        The offset of the listing
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers                  Don't print table headers when table output is used
       --offset int                  Number of items to skip before starting to collect the results
       --order-by string             Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/backup/location/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of PostgreSQL Backup Locations.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The limit of the number of items to return (default 100)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers        Don't print table headers when table output is used
       --offset int32      The offset of the listing
       --order-by string   Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/create.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/create.md
@@ -66,7 +66,7 @@ Required values to run command:
   -I, --instances int              The number of instances in your cluster (one primary and n-1 standbys). Minimum: 1, Maximum: 5 (default 1)
   -L, --lan-id string              The unique ID of the LAN to connect your cluster to (required)
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string            Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --logs-enabled               Enable collection and reporting of logs for this cluster
   -d, --maintenance-day string     Day of the week for the MaintenanceWindow. Defaults to a random day during Mon-Fri. Can be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday (default "Random (Mon-Fri 10:00-16:00)")
   -T, --maintenance-time string    Time for the MaintenanceWindow. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59. Defaults to a random time during 10:00-16:00 (default "Random (Mon-Fri 10:00-16:00)")

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/delete.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/delete.md
@@ -52,7 +52,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
   -n, --name string         Delete all Clusters after filtering based on name. It does not require an exact match. Can be used with --all flag
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/get.md
@@ -51,7 +51,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of PostgreSQL Clusters provisioned under you
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The maximum number of elements to return (default 100)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
   -n, --name string       Response filter to list only the PostgreSQL Clusters that contain the specified name in the DisplayName field. The value is case insensitive
       --no-headers        Don't print table headers when table output is used
       --offset int32      The first element to return

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/restore.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/restore.md
@@ -55,7 +55,7 @@ Required values to run command:
   -f, --force                  Force command to execute without user input
   -h, --help                   Print usage
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string        Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results
       --order-by string        Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/update.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/cluster/update.md
@@ -60,7 +60,7 @@ Required values to run command:
   -I, --instances int              The number of instances in your cluster. Minimum: 1, Maximum: 5
   -L, --lan-id string              The unique ID of the LAN to connect your cluster to
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string            Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --logs-enabled               Enable collection and reporting of logs for this cluster
   -d, --maintenance-day string     Day of the week for the MaintenanceWindow. Must be specified together with --maintenance-time. Can be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday
   -T, --maintenance-time string    Time for the MaintenanceWindow. The MaintenanceWindow is a weekly 4 hour-long window, during which maintenance might occur. e.g.: 16:30:59. Must be specified together with --maintenance-day

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/version/get.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/version/get.md
@@ -50,7 +50,7 @@ Required values to run command:
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Database-as-a-Service/postgres/v2/version/list.md
+++ b/docs/subcommands/Database-as-a-Service/postgres/v2/version/list.md
@@ -46,7 +46,7 @@ Use this command to retrieve a list of available PostgreSQL Versions.
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int32       The maximum number of elements to return (default 100)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, es/vit, fr/par, gb/lhr, gb/bhx, us/las, us/mci, us/ewr
       --no-headers        Don't print table headers when table output is used
       --offset int32      The first element to return
       --order-by string   Property to order the results by

--- a/docs/subcommands/Kafka/cluster/create.md
+++ b/docs/subcommands/Kafka/cluster/create.md
@@ -43,7 +43,7 @@ Create a kafka cluster. Wiki: https://docs.ionos.com/cloud/data-analytics/kafka/
   -h, --help                       Print usage
       --lan-id string              The ID of the LAN (required)
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string            Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
   -n, --name string                The name of the kafka cluster (required)
       --no-headers                 Don't print table headers when table output is used
       --offset int                 Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/cluster/delete.md
+++ b/docs/subcommands/Kafka/cluster/delete.md
@@ -42,7 +42,7 @@ Delete a cluster
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/cluster/get.md
+++ b/docs/subcommands/Kafka/cluster/get.md
@@ -41,7 +41,7 @@ Retrieve a cluster
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/cluster/list.md
+++ b/docs/subcommands/Kafka/cluster/list.md
@@ -40,7 +40,7 @@ Retrieve all clusters using pagination and optional filters
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --name string       Filter used to fetch only the records that contain specified name.
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/topic/create.md
+++ b/docs/subcommands/Kafka/topic/create.md
@@ -41,7 +41,7 @@ Create a kafka topic
   -f, --force                      Force command to execute without user input
   -h, --help                       Print usage
       --limit int                  Maximum number of items to return per request (default 50)
-  -l, --location string            Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string            Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
   -n, --name string                The name of the topic (required)
       --no-headers                 Don't print table headers when table output is used
       --offset int                 Number of items to skip before starting to collect the results

--- a/docs/subcommands/Kafka/topic/delete.md
+++ b/docs/subcommands/Kafka/topic/delete.md
@@ -42,7 +42,7 @@ Delete a kafka topic
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/topic/get.md
+++ b/docs/subcommands/Kafka/topic/get.md
@@ -41,7 +41,7 @@ Get a kafka topic
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/topic/list.md
+++ b/docs/subcommands/Kafka/topic/list.md
@@ -41,7 +41,7 @@ List all kafka topics
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/user/get/access.md
+++ b/docs/subcommands/Kafka/user/get/access.md
@@ -49,7 +49,7 @@ IMPORTANT: Keep these credentials secure. The private key should never be shared
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Kafka/user/list.md
+++ b/docs/subcommands/Kafka/user/list.md
@@ -41,7 +41,7 @@ List a cluster's users
   -f, --force               Force command to execute without user input
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, gb/lhr, gb/bhx, us/ewr, us/las, us/mci, fr/par
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/Logging-Service/central/disable.md
+++ b/docs/subcommands/Logging-Service/central/disable.md
@@ -44,7 +44,7 @@ Disable CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/central/enable.md
+++ b/docs/subcommands/Logging-Service/central/enable.md
@@ -44,7 +44,7 @@ Enable CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/central/get.md
+++ b/docs/subcommands/Logging-Service/central/get.md
@@ -44,7 +44,7 @@ Retrieve CentralLogging
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/logs/add.md
+++ b/docs/subcommands/Logging-Service/logs/add.md
@@ -26,7 +26,7 @@ Add a log to a logging pipeline
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp (required)
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/logs/get.md
+++ b/docs/subcommands/Logging-Service/logs/get.md
@@ -26,7 +26,7 @@ Retrieve a log from a logging pipeline
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --log-tag string       The tag of the pipeline log that you want to retrieve (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Logging-Service/logs/list.md
+++ b/docs/subcommands/Logging-Service/logs/list.md
@@ -41,7 +41,7 @@ Retrieve logging pipeline logs
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/logs/remove.md
+++ b/docs/subcommands/Logging-Service/logs/remove.md
@@ -26,7 +26,7 @@ Remove a log from a logging pipeline. NOTE:There needs to be at least one log in
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --log-tag string       The tag of the pipeline log that you want to delete (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Logging-Service/logs/update.md
+++ b/docs/subcommands/Logging-Service/logs/update.md
@@ -26,7 +26,7 @@ Update a log from a logging pipeline
   -f, --force                       Force command to execute without user input
   -h, --help                        Print usage
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/pipeline/create.md
+++ b/docs/subcommands/Logging-Service/pipeline/create.md
@@ -42,7 +42,7 @@ Create a logging pipeline
       --json-properties string      Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example     If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                   Maximum number of items to return per request (default 50)
-  -l, --location string             Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string             Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --log-labels strings          Sets the labels for the pipeline log
       --log-protocol string         Sets the protocol for the pipeline log. Can be one of: http, tcp
       --log-retention-time string   Sets the retention time in days for the pipeline log. Can be one of: 7, 14, 30 (default "30")

--- a/docs/subcommands/Logging-Service/pipeline/delete.md
+++ b/docs/subcommands/Logging-Service/pipeline/delete.md
@@ -41,7 +41,7 @@ Delete a logging pipeline using its ID
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/get.md
+++ b/docs/subcommands/Logging-Service/pipeline/get.md
@@ -40,7 +40,7 @@ Retrieve a logging pipeline by ID
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/key.md
+++ b/docs/subcommands/Logging-Service/pipeline/key.md
@@ -40,7 +40,7 @@ Generate a new key for a logging pipeline, invalidating the old one. The key is 
   -f, --force                Force command to execute without user input
   -h, --help                 Print usage
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results
       --order-by string      Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/list.md
+++ b/docs/subcommands/Logging-Service/pipeline/list.md
@@ -46,7 +46,7 @@ Retrieve logging pipelines
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Logging-Service/pipeline/update.md
+++ b/docs/subcommands/Logging-Service/pipeline/update.md
@@ -42,7 +42,7 @@ Update a logging pipeline
       --json-properties string    Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example   If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx (default "de/txl")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/txl, de/fra, gb/lhr, fr/par, es/vit, us/mci, gb/bhx
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results
       --order-by string           Property to order the results by

--- a/docs/subcommands/Object-Storage/bucket/cors/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/delete.md
@@ -40,7 +40,7 @@ Delete the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/delete.md
@@ -40,7 +40,7 @@ Delete the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/get.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/get.md
@@ -40,7 +40,7 @@ Get the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/get.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/get.md
@@ -40,7 +40,7 @@ Get the CORS configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/put.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/put.md
@@ -42,7 +42,7 @@ Create or replace the CORS configuration for a bucket. The configuration must be
       --json-properties string    Path to a JSON file containing the CORS configuration
       --json-properties-example   Print an example CORS configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/cors/put.md
+++ b/docs/subcommands/Object-Storage/bucket/cors/put.md
@@ -42,7 +42,7 @@ Create or replace the CORS configuration for a bucket. The configuration must be
       --json-properties string    Path to a JSON file containing the CORS configuration
       --json-properties-example   Print an example CORS configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/create.md
+++ b/docs/subcommands/Object-Storage/bucket/create.md
@@ -46,7 +46,7 @@ Create a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket to create (required)
       --no-headers        Don't print table headers when table output is used
       --object-lock       Enable Object Lock on the new bucket (cannot be changed after creation)

--- a/docs/subcommands/Object-Storage/bucket/create.md
+++ b/docs/subcommands/Object-Storage/bucket/create.md
@@ -46,7 +46,7 @@ Create a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket to create (required)
       --no-headers        Don't print table headers when table output is used
       --object-lock       Enable Object Lock on the new bucket (cannot be changed after creation)

--- a/docs/subcommands/Object-Storage/bucket/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/delete.md
@@ -47,7 +47,7 @@ Delete a contract-owned bucket, or all buckets using --all. The bucket must be e
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket to delete
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/delete.md
@@ -47,7 +47,7 @@ Delete a contract-owned bucket, or all buckets using --all. The bucket must be e
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket to delete
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/delete.md
@@ -46,7 +46,7 @@ Delete the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/delete.md
@@ -46,7 +46,7 @@ Delete the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/get.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/get.md
@@ -46,7 +46,7 @@ Get the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/get.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/get.md
@@ -46,7 +46,7 @@ Get the default encryption configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/put.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/put.md
@@ -48,7 +48,7 @@ Create or replace the default encryption configuration for a bucket. The configu
       --json-properties string    Path to a JSON file containing the encryption configuration
       --json-properties-example   Print an example encryption configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/encryption/put.md
+++ b/docs/subcommands/Object-Storage/bucket/encryption/put.md
@@ -48,7 +48,7 @@ Create or replace the default encryption configuration for a bucket. The configu
       --json-properties string    Path to a JSON file containing the encryption configuration
       --json-properties-example   Print an example encryption configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/get.md
+++ b/docs/subcommands/Object-Storage/bucket/get.md
@@ -46,7 +46,7 @@ Get details of a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket to retrieve (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/get.md
+++ b/docs/subcommands/Object-Storage/bucket/get.md
@@ -46,7 +46,7 @@ Get details of a contract-owned bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket to retrieve (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/head.md
+++ b/docs/subcommands/Object-Storage/bucket/head.md
@@ -46,7 +46,7 @@ Check if a bucket exists and you have access
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket to check (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/head.md
+++ b/docs/subcommands/Object-Storage/bucket/head.md
@@ -46,7 +46,7 @@ Check if a bucket exists and you have access
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket to check (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
@@ -46,7 +46,7 @@ Delete the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/delete.md
@@ -46,7 +46,7 @@ Delete the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
@@ -46,7 +46,7 @@ Get the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/get.md
@@ -46,7 +46,7 @@ Get the lifecycle configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
@@ -48,7 +48,7 @@ Create or replace the lifecycle configuration for a bucket. The configuration mu
       --json-properties string    Path to a JSON file containing the lifecycle configuration
       --json-properties-example   Print an example lifecycle configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
+++ b/docs/subcommands/Object-Storage/bucket/lifecycle/put.md
@@ -48,7 +48,7 @@ Create or replace the lifecycle configuration for a bucket. The configuration mu
       --json-properties string    Path to a JSON file containing the lifecycle configuration
       --json-properties-example   Print an example lifecycle configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/list.md
+++ b/docs/subcommands/Object-Storage/bucket/list.md
@@ -46,7 +46,7 @@ List all contract-owned buckets
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Object-Storage/bucket/list.md
+++ b/docs/subcommands/Object-Storage/bucket/list.md
@@ -46,7 +46,7 @@ List all contract-owned buckets
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/Object-Storage/bucket/object/lock/get.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/get.md
@@ -46,7 +46,7 @@ Get the Object Lock configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/object/lock/get.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/get.md
@@ -46,7 +46,7 @@ Get the Object Lock configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/object/lock/put.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/put.md
@@ -47,7 +47,7 @@ Apply an Object Lock configuration to a bucket. The bucket must have been create
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
       --mode string       Default retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/bucket/object/lock/put.md
+++ b/docs/subcommands/Object-Storage/bucket/object/lock/put.md
@@ -47,7 +47,7 @@ Apply an Object Lock configuration to a bucket. The bucket must have been create
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
       --mode string       Default retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/bucket/policy/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/delete.md
@@ -46,7 +46,7 @@ Delete the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/delete.md
@@ -46,7 +46,7 @@ Delete the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/get.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/get.md
@@ -46,7 +46,7 @@ Get the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/get.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/get.md
@@ -46,7 +46,7 @@ Get the bucket policy
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/put.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/put.md
@@ -48,7 +48,7 @@ Create or replace the bucket policy. The policy must be provided as a path to a 
       --json-properties string    Path to a JSON file containing the bucket policy
       --json-properties-example   Print an example bucket policy JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/put.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/put.md
@@ -48,7 +48,7 @@ Create or replace the bucket policy. The policy must be provided as a path to a 
       --json-properties string    Path to a JSON file containing the bucket policy
       --json-properties-example   Print an example bucket policy JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/status.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/status.md
@@ -46,7 +46,7 @@ Check if a bucket policy makes the bucket public
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/policy/status.md
+++ b/docs/subcommands/Object-Storage/bucket/policy/status.md
@@ -46,7 +46,7 @@ Check if a bucket policy makes the bucket public
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
@@ -46,7 +46,7 @@ Delete the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/delete.md
@@ -46,7 +46,7 @@ Delete the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
@@ -46,7 +46,7 @@ Get the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/get.md
@@ -46,7 +46,7 @@ Get the public access block configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
@@ -48,7 +48,7 @@ Create or replace the public access block configuration for a bucket. The config
       --json-properties string    Path to a JSON file containing the public access block configuration
       --json-properties-example   Print an example public access block configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
+++ b/docs/subcommands/Object-Storage/bucket/public/access/block/put.md
@@ -48,7 +48,7 @@ Create or replace the public access block configuration for a bucket. The config
       --json-properties string    Path to a JSON file containing the public access block configuration
       --json-properties-example   Print an example public access block configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/delete.md
@@ -46,7 +46,7 @@ Delete the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/delete.md
@@ -46,7 +46,7 @@ Delete the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/get.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/get.md
@@ -46,7 +46,7 @@ Get the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/get.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/get.md
@@ -46,7 +46,7 @@ Get the tagging configuration for a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/put.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/put.md
@@ -48,7 +48,7 @@ Create or replace the tagging configuration for a bucket. The configuration must
       --json-properties string    Path to a JSON file containing the tagging configuration
       --json-properties-example   Print an example tagging configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/tagging/put.md
+++ b/docs/subcommands/Object-Storage/bucket/tagging/put.md
@@ -48,7 +48,7 @@ Create or replace the tagging configuration for a bucket. The configuration must
       --json-properties string    Path to a JSON file containing the tagging configuration
       --json-properties-example   Print an example tagging configuration JSON and exit
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/get.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/get.md
@@ -46,7 +46,7 @@ Get the versioning state of a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/get.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/get.md
@@ -46,7 +46,7 @@ Get the versioning state of a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/set.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/set.md
@@ -46,7 +46,7 @@ Enable or suspend versioning on a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/bucket/versioning/set.md
+++ b/docs/subcommands/Object-Storage/bucket/versioning/set.md
@@ -46,7 +46,7 @@ Enable or suspend versioning on a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/copy.md
+++ b/docs/subcommands/Object-Storage/object/copy.md
@@ -48,7 +48,7 @@ Copy an object within or between buckets. The --copy-source must be in the forma
   -h, --help                 Print usage
   -k, --key string           Destination object key (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string          Destination bucket name (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/copy.md
+++ b/docs/subcommands/Object-Storage/object/copy.md
@@ -48,7 +48,7 @@ Copy an object within or between buckets. The --copy-source must be in the forma
   -h, --help                 Print usage
   -k, --key string           Destination object key (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string          Destination bucket name (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/delete.md
+++ b/docs/subcommands/Object-Storage/object/delete.md
@@ -49,7 +49,7 @@ Delete a single object by key, or all objects (including versions and delete mar
   -h, --help                          Print usage
   -k, --key string                    Object key to delete
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used
       --offset int                    Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/delete.md
+++ b/docs/subcommands/Object-Storage/object/delete.md
@@ -49,7 +49,7 @@ Delete a single object by key, or all objects (including versions and delete mar
   -h, --help                          Print usage
   -k, --key string                    Object key to delete
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used
       --offset int                    Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/get.md
+++ b/docs/subcommands/Object-Storage/object/get.md
@@ -48,7 +48,7 @@ Download an object to a file
   -h, --help                 Print usage
   -k, --key string           Object key to download (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string          Name of the bucket (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/get.md
+++ b/docs/subcommands/Object-Storage/object/get.md
@@ -48,7 +48,7 @@ Download an object to a file
   -h, --help                 Print usage
   -k, --key string           Object key to download (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string          Name of the bucket (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/head.md
+++ b/docs/subcommands/Object-Storage/object/head.md
@@ -47,7 +47,7 @@ Get object metadata
   -h, --help              Print usage
   -k, --key string        Object key (required)
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/head.md
+++ b/docs/subcommands/Object-Storage/object/head.md
@@ -47,7 +47,7 @@ Get object metadata
   -h, --help              Print usage
   -k, --key string        Object key (required)
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/get.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/get.md
@@ -47,7 +47,7 @@ Get the legal hold status of an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/get.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/get.md
@@ -47,7 +47,7 @@ Get the legal hold status of an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/put.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/put.md
@@ -47,7 +47,7 @@ Apply or remove a legal hold configuration on an object. Requires the bucket to 
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/legal/hold/put.md
+++ b/docs/subcommands/Object-Storage/object/legal/hold/put.md
@@ -47,7 +47,7 @@ Apply or remove a legal hold configuration on an object. Requires the bucket to 
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/list.md
+++ b/docs/subcommands/Object-Storage/object/list.md
@@ -46,7 +46,7 @@ List objects in a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
       --max-keys int32    Maximum number of objects to return (0 for no limit) (default 1000)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/list.md
+++ b/docs/subcommands/Object-Storage/object/list.md
@@ -46,7 +46,7 @@ List objects in a bucket
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
       --max-keys int32    Maximum number of objects to return (0 for no limit) (default 1000)
   -n, --name string       Name of the bucket (required)
       --no-headers        Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/put.md
+++ b/docs/subcommands/Object-Storage/object/put.md
@@ -48,7 +48,7 @@ Upload a file as an object
   -h, --help                  Print usage
   -k, --key string            Object key (path in the bucket) (required)
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string       Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string           Name of the bucket (required)
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/put.md
+++ b/docs/subcommands/Object-Storage/object/put.md
@@ -48,7 +48,7 @@ Upload a file as an object
   -h, --help                  Print usage
   -k, --key string            Object key (path in the bucket) (required)
       --limit int             Maximum number of items to return per request (default 50)
-  -l, --location string       Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string       Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string           Name of the bucket (required)
       --no-headers            Don't print table headers when table output is used
       --offset int            Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/retention/get.md
+++ b/docs/subcommands/Object-Storage/object/retention/get.md
@@ -47,7 +47,7 @@ Get the Object Lock retention configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/retention/get.md
+++ b/docs/subcommands/Object-Storage/object/retention/get.md
@@ -47,7 +47,7 @@ Get the Object Lock retention configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/retention/put.md
+++ b/docs/subcommands/Object-Storage/object/retention/put.md
@@ -48,7 +48,7 @@ Place an Object Lock retention configuration on an object. Requires the bucket t
   -h, --help                          Print usage
   -k, --key string                    Object key (required)
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
       --mode string                   Retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/retention/put.md
+++ b/docs/subcommands/Object-Storage/object/retention/put.md
@@ -48,7 +48,7 @@ Place an Object Lock retention configuration on an object. Requires the bucket t
   -h, --help                          Print usage
   -k, --key string                    Object key (required)
       --limit int                     Maximum number of items to return per request (default 50)
-  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string               Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
       --mode string                   Retention mode: GOVERNANCE or COMPLIANCE (required)
   -n, --name string                   Name of the bucket (required)
       --no-headers                    Don't print table headers when table output is used

--- a/docs/subcommands/Object-Storage/object/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/object/tagging/delete.md
@@ -47,7 +47,7 @@ Delete the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/delete.md
+++ b/docs/subcommands/Object-Storage/object/tagging/delete.md
@@ -47,7 +47,7 @@ Delete the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/get.md
+++ b/docs/subcommands/Object-Storage/object/tagging/get.md
@@ -47,7 +47,7 @@ Get the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/get.md
+++ b/docs/subcommands/Object-Storage/object/tagging/get.md
@@ -47,7 +47,7 @@ Get the tagging configuration for an object
   -h, --help                Print usage
   -k, --key string          Object key (required)
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string         Name of the bucket (required)
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/put.md
+++ b/docs/subcommands/Object-Storage/object/tagging/put.md
@@ -49,7 +49,7 @@ Create or replace the tagging configuration for an object. The configuration mus
       --json-properties-example   Print an example tagging configuration JSON and exit
   -k, --key string                Object key (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: eu-central-3, eu-central-4, us-central-1 (default "eu-central-3")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/Object-Storage/object/tagging/put.md
+++ b/docs/subcommands/Object-Storage/object/tagging/put.md
@@ -49,7 +49,7 @@ Create or replace the tagging configuration for an object. The configuration mus
       --json-properties-example   Print an example tagging configuration JSON and exit
   -k, --key string                Object key (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: eu-central-3, eu-central-4, us-central-1. Defaults to eu-central-3
   -n, --name string               Name of the bucket (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/create.md
@@ -45,7 +45,7 @@ Create a IPSec Gateway
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string        Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/delete.md
@@ -42,7 +42,7 @@ Delete a gateway
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/get.md
@@ -41,7 +41,7 @@ Find a gateway by ID
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/list.md
@@ -40,7 +40,7 @@ List IPSec Gateways
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/gateway/update.md
@@ -46,7 +46,7 @@ Update a IPSec Gateway
   -h, --help                   Print usage
       --lan-id string          The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int              Maximum number of items to return per request (default 50)
-  -l, --location string        Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string        Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string            Name of the IPSec Gateway (required)
       --no-headers             Don't print table headers when table output is used
       --offset int             Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/create.md
@@ -55,7 +55,7 @@ Create IPSec tunnels
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                         Maximum number of items to return per request (default 50)
-  -l, --location string                   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string                   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
       --offset int                        Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/delete.md
@@ -42,7 +42,7 @@ Remove a IPSec Tunnel
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/get.md
@@ -41,7 +41,7 @@ Find a tunnel by ID
       --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/list.md
@@ -41,7 +41,7 @@ List IPSec Tunnels
   -i, --gateway-id string   The ID of the IPSec Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
+++ b/docs/subcommands/VPN Gateway/ipsec/tunnel/update.md
@@ -55,7 +55,7 @@ Update a IPSec Tunnel
       --json-properties string            Path to a JSON file containing the desired properties. Overrides any other properties set.
       --json-properties-example           If set, prints a complete JSON which could be used for --json-properties and exits. Hint: Pipe me to a .json file
       --limit int                         Maximum number of items to return per request (default 50)
-  -l, --location string                   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string                   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string                       Name of the IPSec Tunnel (required)
       --no-headers                        Don't print table headers when table output is used
       --offset int                        Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/create.md
@@ -52,7 +52,7 @@ Create a WireGuard Gateway
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/delete.md
@@ -48,7 +48,7 @@ Delete a gateway
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/get.md
@@ -47,7 +47,7 @@ Find a gateway by ID
   -i, --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/list.md
@@ -46,7 +46,7 @@ List WireGuard Gateways
   -f, --force             Force command to execute without user input
   -h, --help              Print usage
       --limit int         Maximum number of items to return per request (default 50)
-  -l, --location string   Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string   Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers        Don't print table headers when table output is used
       --offset int        Number of items to skip before starting to collect the results
       --order-by string   Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/gateway/update.md
@@ -53,7 +53,7 @@ Update a WireGuard Gateway. Note: The private key MUST be provided again (or cha
       --interface-ip string       The IPv4 or IPv6 address (with CIDR mask) to be assigned to the WireGuard interface (required)
       --lan-id string             The numeric LAN ID to connect your VPN Gateway to (required)
       --limit int                 Maximum number of items to return per request (default 50)
-  -l, --location string           Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string           Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string               Name of the WireGuard Gateway (required)
       --no-headers                Don't print table headers when table output is used
       --offset int                Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/peer/create.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/create.md
@@ -50,7 +50,7 @@ Create WireGuard Peers. There is a limit to the total number of peers. Please re
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/delete.md
@@ -48,7 +48,7 @@ Remove a WireGuard Peer
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/get.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/get.md
@@ -47,7 +47,7 @@ Find a peer by ID
       --gateway-id string   The ID of the WireGuard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/list.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/list.md
@@ -47,7 +47,7 @@ List WireGuard Peers
   -i, --gateway-id string   The ID of the Wireguard Gateway (required)
   -h, --help                Print usage
       --limit int           Maximum number of items to return per request (default 50)
-  -l, --location string     Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string     Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
       --no-headers          Don't print table headers when table output is used
       --offset int          Number of items to skip before starting to collect the results
       --order-by string     Property to order the results by

--- a/docs/subcommands/VPN Gateway/wireguard/peer/update.md
+++ b/docs/subcommands/VPN Gateway/wireguard/peer/update.md
@@ -50,7 +50,7 @@ Update a WireGuard Peer
       --host string          Hostname or IPV4 address that the WireGuard Server will connect to (required)
       --ips strings          Comma separated subnets of CIDRs that are allowed to connect to the WireGuard Gateway. Specify "a.b.c.d/32" for an individual IP address. Specify "0.0.0.0/0" or "::/0" for all addresses (required)
       --limit int            Maximum number of items to return per request (default 50)
-  -l, --location string      Location of the resource to operate on. List commands query all locations when unset. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci (default "de/fra")
+  -l, --location string      Location of the resource to operate on. When unset, list commands query all locations. Can be one of: de/fra, de/txl, es/vit, fr/par, gb/lhr, gb/bhx, us/ewr, us/las, us/mci
   -n, --name string          Name of the WireGuard Peer (required)
       --no-headers           Don't print table headers when table output is used
       --offset int           Number of items to skip before starting to collect the results

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -67,10 +67,20 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 			"Preferred over the config file override '%s' and env var '%s'", productNames[0], constants.EnvServerUrl),
 	)
 
-	// Add the location flag
+	// Add the location flag. The default is left empty on multi-location APIs so
+	// cobra does not print a misleading "(default "<first-loc>")": when unset, list
+	// commands query all locations and single-resource commands require --location.
+	// Single-location APIs keep the sole location as an explicit default, which is
+	// accurate there. The empty default is resolved to allowedLocations[0] in
+	// PersistentPreRunE below (via findOverridenURL returning "").
+	locationDefault := ""
+	if len(allowedLocations) == 1 {
+		locationDefault = allowedLocations[0]
+	}
 	c.Command.PersistentFlags().StringP(
-		constants.FlagLocation, constants.FlagLocationShort, allowedLocations[0],
-		"Location of the resource to operate on. List commands query all locations when unset. Can be one of: "+strings.Join(allowedLocations, ", "),
+		constants.FlagLocation, constants.FlagLocationShort, locationDefault,
+		"Location of the resource to operate on. When unset, list commands query all locations. "+
+			"Can be one of: "+strings.Join(allowedLocations, ", "),
 	)
 	viper.BindPFlag(constants.FlagLocation, c.Command.PersistentFlags().Lookup(constants.FlagLocation))
 	c.Command.RegisterFlagCompletionFunc(constants.FlagLocation,


### PR DESCRIPTION
For Regional APIs with a single location, keep `(default "de-fra")` notation on `--location` flag.

For Object Storage API, keep eu-central-1 as a default location.

Remove this notation from Regional APIs with more than one location.
