### PR TITLE
fix: normalize config keys before reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning follows [SemVer](https://semver.org/). Sections: **Added**, **Changed
 - Consistent `delete --all` across all resources: Bulk deletion now prints a preview of every resource that will be deleted (with identifying details such as name, ID, public IP, location, and description), confirms per item, reports per-item success, and ends with a `deleted / skipped / failed` summary instead of staying silent unless an error occurred. On regional APIs the preview and deletion span all locations by default (use `--location` to target one). This also fixes a bug where when deleting certain resources and answering 'no' for only one of them, all the remaining resources would be skipped.
 
 ### Fixed
+- Config-file endpoint overrides for regional products (e.g. `object-storage`) now apply regardless of whether the location is spelled with slashes (`eu/central/3`) or dashes (`eu-central-3`). Previously the lookup was case-exact on separators, so an override written in one convention was ignored when the command used the other, silently falling back to the default endpoint.
 - `dbaas mariadb cluster delete --all --name` and `dbaas mongo cluster delete --all --name` now filter by the given name. The `--name` flag was previously registered as a boolean and could not accept a value, so the filter never applied.
 - `vpn wireguard peer delete` no longer reports success when the deletion fails. The single-peer path was discarding the API error and always exiting 0.
 

--- a/internal/client/config_integration.go
+++ b/internal/client/config_integration.go
@@ -54,7 +54,7 @@ func retrieveConfigFile() (ConfigSource, error) {
 // The --config flag carries a computed default (the standard config location).
 // When it still holds that default and IONOS_CONFIG_FILE is set, defer to
 // loadFromEnvVar so the env var is not silently shadowed by the default path.
-// An explicitly-set --config still takes precedence over the env var.
+// A --config value that differs from the default still takes precedence over the env var.
 func loadFromFlag() (ConfigSource, error) {
 	path := viper.GetString(constants.ArgConfig)
 	if path == "" {

--- a/internal/client/config_integration.go
+++ b/internal/client/config_integration.go
@@ -50,9 +50,17 @@ func retrieveConfigFile() (ConfigSource, error) {
 
 // loadFromFlag tries --config; if empty or missing -> (nil, ""), nil;
 // on I/O/parse error -> err; on success -> (*FileConfig, path), nil.
+//
+// The --config flag carries a computed default (the standard config location).
+// When it still holds that default and IONOS_CONFIG_FILE is set, defer to
+// loadFromEnvVar so the env var is not silently shadowed by the default path.
+// An explicitly-set --config still takes precedence over the env var.
 func loadFromFlag() (ConfigSource, error) {
 	path := viper.GetString(constants.ArgConfig)
 	if path == "" {
+		return ConfigSource{}, nil
+	}
+	if os.Getenv(shared.IonosFilePathEnvVar) != "" && path == cfg.DefaultConfigFilePath() {
 		return ConfigSource{}, nil
 	}
 	return tryLoad(path, "--config")

--- a/internal/client/config_integration_test.go
+++ b/internal/client/config_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	cfg "github.com/ionos-cloud/ionosctl/v6/internal/config"
 	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
 	"github.com/ionos-cloud/sdk-go-bundle/shared"
 	"github.com/spf13/viper"
@@ -70,6 +71,69 @@ func TestRetrieveConfigFile_EnvVarAsFallback(t *testing.T) {
 	}
 	if src.Config == nil {
 		t.Errorf("expected Config non-nil when env file exists")
+	}
+}
+
+// TestRetrieveConfigFile_EnvVarNotShadowedByDefaultFlag guards the fix for the
+// --config flag's computed default silently shadowing IONOS_CONFIG_FILE. When
+// --config still holds its default (user did not pass it explicitly) and the env
+// var is set, the env var must win - even if the default config file exists.
+func TestRetrieveConfigFile_EnvVarNotShadowedByDefaultFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+
+	// Create the default config file (the --config flag's default target).
+	defaultPath := cfg.DefaultConfigFilePath()
+	if err := os.MkdirAll(filepath.Dir(defaultPath), 0o755); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+	writeMinimalYAML(t, defaultPath)
+
+	// The flag holds its computed default (user did not pass --config).
+	viper.Set(constants.ArgConfig, defaultPath)
+	t.Cleanup(func() { viper.Set(constants.ArgConfig, "") })
+
+	// IONOS_CONFIG_FILE points elsewhere and must take precedence.
+	envCfg := filepath.Join(home, "env.yaml")
+	writeMinimalYAML(t, envCfg)
+	t.Setenv(shared.IonosFilePathEnvVar, envCfg)
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.Path != envCfg {
+		t.Errorf("env var shadowed by default flag: expected Path %q, got %q", envCfg, src.Path)
+	}
+}
+
+// TestRetrieveConfigFile_ExplicitFlagWinsOverEnv ensures an explicitly-set
+// --config (different from the default) still takes precedence over the env var.
+func TestRetrieveConfigFile_ExplicitFlagWinsOverEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+
+	flagCfg := filepath.Join(home, "flag.yaml")
+	writeMinimalYAML(t, flagCfg)
+	viper.Set(constants.ArgConfig, flagCfg)
+	t.Cleanup(func() { viper.Set(constants.ArgConfig, "") })
+
+	envCfg := filepath.Join(home, "env.yaml")
+	writeMinimalYAML(t, envCfg)
+	t.Setenv(shared.IonosFilePathEnvVar, envCfg)
+
+	src, err := retrieveConfigFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.Path != flagCfg {
+		t.Errorf("explicit --config should win over env var: expected %q, got %q", flagCfg, src.Path)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,17 @@ import (
 	"github.com/spf13/viper"
 )
 
+// DefaultConfigFilePath returns the standard config file location, ignoring the
+// --config flag and any viper overrides. It is the value used as the --config
+// flag default, so callers can tell whether --config still holds its default.
+func DefaultConfigFilePath() string {
+	path := filepath.Join(getConfigHomeDir(), constants.DefaultConfigFileName)
+	if absPath, err := filepath.Abs(path); err == nil {
+		return absPath
+	}
+	return path
+}
+
 // GetConfigFilePath sanitizes the --config flag input and returns the path to the config file.
 // If none set, it returns the default config path.
 func GetConfigFilePath() string {

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -94,7 +94,17 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 		c.Command.MarkFlagsMutuallyExclusive(constants.ArgServerUrl, constants.FlagLocation)
 		location, _ := cmd.Flags().GetString(constants.FlagLocation)
 
-		url := findOverridenURL(cmd, productNames, templateFallbackURL, location)
+		// Single-resource commands operate on one location. When --location is
+		// unset, resolve the default (first allowed location) so the config-file
+		// override for that region is honored, not just the bare template URL.
+		// List commands ignore this viper value; they resolve a URL per location
+		// via ListAllLocations instead.
+		lookupLocation := location
+		if lookupLocation == "" {
+			lookupLocation = allowedLocations[0]
+		}
+
+		url := findOverridenURL(cmd, productNames, templateFallbackURL, lookupLocation)
 		if url == "" {
 			url = fmt.Sprintf(templateFallbackURL, strings.ReplaceAll(allowedLocations[0], "/", "-"))
 		}
@@ -139,6 +149,25 @@ func WithConfigOverride(c *Command, productNames []string, fallbackURL string) *
 	return c
 }
 
+// locationVariants returns the candidate spellings of a location to look up in
+// the config file. IONOS regions are written with slashes in some contexts
+// (e.g. "de/fra", "eu/central/3") and with dashes in others (e.g.
+// "eu-central-3"). The command flags and the config file do not always use the
+// same convention, so try the location as given plus its slash/dash variants.
+func locationVariants(location string) []string {
+	if location == "" {
+		return []string{""}
+	}
+	variants := []string{location}
+	if slash := strings.ReplaceAll(location, "-", "/"); slash != location {
+		variants = append(variants, slash)
+	}
+	if dash := strings.ReplaceAll(location, "/", "-"); dash != location {
+		variants = append(variants, dash)
+	}
+	return variants
+}
+
 func findOverridenURL(cmd *cobra.Command, productNames []string, fallbackURL, location string) string {
 	// Check if the --server-url flag is set
 	if cmd.Flags().Changed(constants.ArgServerUrl) {
@@ -157,8 +186,10 @@ func findOverridenURL(cmd *cobra.Command, productNames []string, fallbackURL, lo
 	cl, _ := client.Get()
 	if cl != nil && cl.Config != nil {
 		for _, prod := range productNames {
-			if override := cl.Config.GetOverride(prod, location); override != nil {
-				return override.Name
+			for _, loc := range locationVariants(location) {
+				if override := cl.Config.GetOverride(prod, loc); override != nil {
+					return override.Name
+				}
 			}
 		}
 	}

--- a/internal/core/config_integration.go
+++ b/internal/core/config_integration.go
@@ -72,7 +72,7 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 	// commands query all locations and single-resource commands require --location.
 	// Single-location APIs keep the sole location as an explicit default, which is
 	// accurate there. The empty default is resolved to allowedLocations[0] in
-	// PersistentPreRunE below (via findOverridenURL returning "").
+	// PersistentPreRunE below (via findOverriddenURL returning "").
 	locationDefault := ""
 	if len(allowedLocations) == 1 {
 		locationDefault = allowedLocations[0]
@@ -104,7 +104,7 @@ func WithRegionalConfigOverride(c *Command, productNames []string, templateFallb
 			lookupLocation = allowedLocations[0]
 		}
 
-		url := findOverridenURL(cmd, productNames, templateFallbackURL, lookupLocation)
+		url := findOverriddenURL(cmd, productNames, templateFallbackURL, lookupLocation)
 		if url == "" {
 			url = fmt.Sprintf(templateFallbackURL, strings.ReplaceAll(allowedLocations[0], "/", "-"))
 		}
@@ -134,7 +134,7 @@ func WithConfigOverride(c *Command, productNames []string, fallbackURL string) *
 
 	originalPreRun := c.Command.PersistentPreRunE
 	c.Command.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		url := findOverridenURL(cmd, productNames, fallbackURL, "")
+		url := findOverriddenURL(cmd, productNames, fallbackURL, "")
 		if url == "" {
 			url = fallbackURL
 		}
@@ -168,7 +168,7 @@ func locationVariants(location string) []string {
 	return variants
 }
 
-func findOverridenURL(cmd *cobra.Command, productNames []string, fallbackURL, location string) string {
+func findOverriddenURL(cmd *cobra.Command, productNames []string, fallbackURL, location string) string {
 	// Check if the --server-url flag is set
 	if cmd.Flags().Changed(constants.ArgServerUrl) {
 		serverURL, _ := cmd.Flags().GetString(constants.ArgServerUrl)

--- a/internal/core/config_integration_test.go
+++ b/internal/core/config_integration_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // withClientConfig temporarily installs cfg as the singleton client's config so
-// findOverridenURL can read config-file overrides during unit tests.
+// findOverriddenURL can read config-file overrides during unit tests.
 func withClientConfig(t *testing.T, cfg *fileconfiguration.FileConfig) {
 	t.Helper()
 	cl := client.Must(func(error) {})
@@ -36,11 +36,11 @@ func osConfig(location, url string) *fileconfiguration.FileConfig {
 	}
 }
 
-// TestFindOverridenURL_LocationFormatMismatch guards the object-storage config
+// TestFindOverriddenURL_LocationFormatMismatch guards the object-storage config
 // override fix: the config file may spell a region with slashes (eu/central/3)
 // while the command flag uses dashes (eu-central-3), or vice versa. The override
 // must resolve regardless of which convention each side uses.
-func TestFindOverridenURL_LocationFormatMismatch(t *testing.T) {
+func TestFindOverriddenURL_LocationFormatMismatch(t *testing.T) {
 	const tmpl = constants.ObjectStorageApiRegionalURL
 	const cfgURL = "https://cfg-override.example.com"
 
@@ -54,7 +54,7 @@ func TestFindOverridenURL_LocationFormatMismatch(t *testing.T) {
 
 	t.Run("config uses slashes, flag uses dashes", func(t *testing.T) {
 		withClientConfig(t, osConfig("eu/central/3", cfgURL))
-		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu-central-3")
+		got := findOverriddenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu-central-3")
 		if got != cfgURL {
 			t.Errorf("url = %q, want config override %q", got, cfgURL)
 		}
@@ -62,7 +62,7 @@ func TestFindOverridenURL_LocationFormatMismatch(t *testing.T) {
 
 	t.Run("config uses dashes, flag uses slashes", func(t *testing.T) {
 		withClientConfig(t, osConfig("eu-central-3", cfgURL))
-		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
+		got := findOverriddenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
 		if got != cfgURL {
 			t.Errorf("url = %q, want config override %q", got, cfgURL)
 		}
@@ -70,7 +70,7 @@ func TestFindOverridenURL_LocationFormatMismatch(t *testing.T) {
 
 	t.Run("no override falls back to normalized template", func(t *testing.T) {
 		withClientConfig(t, nil)
-		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
+		got := findOverriddenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
 		if got != "https://s3.eu-central-3.ionoscloud.com" {
 			t.Errorf("url = %q, want per-location template", got)
 		}

--- a/internal/core/config_integration_test.go
+++ b/internal/core/config_integration_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/ionos-cloud/ionosctl/v6/internal/client"
+	"github.com/ionos-cloud/ionosctl/v6/internal/constants"
+	"github.com/ionos-cloud/sdk-go-bundle/shared/fileconfiguration"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// withClientConfig temporarily installs cfg as the singleton client's config so
+// findOverridenURL can read config-file overrides during unit tests.
+func withClientConfig(t *testing.T, cfg *fileconfiguration.FileConfig) {
+	t.Helper()
+	cl := client.Must(func(error) {})
+	prev := cl.Config
+	cl.Config = cfg
+	t.Cleanup(func() { cl.Config = prev })
+}
+
+// osConfig builds an in-memory config exposing a single object-storage endpoint
+// override for the given location spelling.
+func osConfig(location, url string) *fileconfiguration.FileConfig {
+	return &fileconfiguration.FileConfig{
+		CurrentProfile: "p",
+		Profiles:       []fileconfiguration.Profile{{Name: "p", Environment: "env"}},
+		Environments: []fileconfiguration.Environment{{
+			Name: "env",
+			Products: []fileconfiguration.Product{{
+				Name:      fileconfiguration.ObjectStorage,
+				Endpoints: []fileconfiguration.Endpoint{{Location: location, Name: url}},
+			}},
+		}},
+	}
+}
+
+// TestFindOverridenURL_LocationFormatMismatch guards the object-storage config
+// override fix: the config file may spell a region with slashes (eu/central/3)
+// while the command flag uses dashes (eu-central-3), or vice versa. The override
+// must resolve regardless of which convention each side uses.
+func TestFindOverridenURL_LocationFormatMismatch(t *testing.T) {
+	const tmpl = constants.ObjectStorageApiRegionalURL
+	const cfgURL = "https://cfg-override.example.com"
+
+	t.Setenv(constants.EnvServerUrl, "")
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "get"}
+		cmd.Flags().String(constants.ArgServerUrl, tmpl, "")
+		return cmd
+	}
+
+	t.Run("config uses slashes, flag uses dashes", func(t *testing.T) {
+		withClientConfig(t, osConfig("eu/central/3", cfgURL))
+		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu-central-3")
+		if got != cfgURL {
+			t.Errorf("url = %q, want config override %q", got, cfgURL)
+		}
+	})
+
+	t.Run("config uses dashes, flag uses slashes", func(t *testing.T) {
+		withClientConfig(t, osConfig("eu-central-3", cfgURL))
+		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
+		if got != cfgURL {
+			t.Errorf("url = %q, want config override %q", got, cfgURL)
+		}
+	})
+
+	t.Run("no override falls back to normalized template", func(t *testing.T) {
+		withClientConfig(t, nil)
+		got := findOverridenURL(newCmd(), []string{fileconfiguration.ObjectStorage}, tmpl, "eu/central/3")
+		if got != "https://s3.eu-central-3.ionoscloud.com" {
+			t.Errorf("url = %q, want per-location template", got)
+		}
+	})
+}
+
+// TestWithRegionalConfigOverride_DefaultLocationHonorsOverride guards the fix for
+// single-resource commands run without --location: the override for the default
+// (first allowed) region must be applied, not just the bare template URL.
+func TestWithRegionalConfigOverride_DefaultLocationHonorsOverride(t *testing.T) {
+	const cfgURL = "https://default-loc-override.example.com"
+	// object-storage's first allowed location is eu-central-3; store it slash-form
+	// to also exercise the format-mismatch path.
+	withClientConfig(t, osConfig("eu/central/3", cfgURL))
+	t.Setenv(constants.EnvServerUrl, "")
+
+	c := &Command{Command: &cobra.Command{Use: "os"}}
+	c = WithRegionalConfigOverride(c, []string{fileconfiguration.ObjectStorage},
+		constants.ObjectStorageApiRegionalURL, constants.ObjectStorageLocations)
+
+	prev := viper.GetString(constants.ArgServerUrl)
+	t.Cleanup(func() { viper.Set(constants.ArgServerUrl, prev) })
+	viper.Set(constants.ArgServerUrl, "")
+
+	// No --location provided.
+	if err := c.Command.PersistentPreRunE(c.Command, nil); err != nil {
+		t.Fatalf("PersistentPreRunE: %v", err)
+	}
+	if got := viper.GetString(constants.ArgServerUrl); got != cfgURL {
+		t.Errorf("server URL = %q, want default-location override %q", got, cfgURL)
+	}
+}

--- a/internal/core/regional_list.go
+++ b/internal/core/regional_list.go
@@ -96,7 +96,7 @@ func (c *CommandConfig) ListAllLocations(
 	for i, loc := range targets {
 		// Resolve per-location URL honoring overrides (--api-url, env var,
 		// per-location config-file override), falling back to the template.
-		url := findOverridenURL(c.Command.Command, productNames, templateURL, loc)
+		url := findOverriddenURL(c.Command.Command, productNames, templateURL, loc)
 		configs[i] = locConfig{location: loc, cfg: client.NewRegionalConfig(url)}
 	}
 
@@ -374,7 +374,7 @@ func (c *CommandConfig) RunForAllLocations(fn func(cfg *shared.Configuration, lo
 
 	var errs []error
 	for _, loc := range locations {
-		url := findOverridenURL(c.Command.Command, productNames, templateURL, loc)
+		url := findOverriddenURL(c.Command.Command, productNames, templateURL, loc)
 		if err := fn(client.NewRegionalConfig(url), loc); err != nil {
 			errs = append(errs, fmt.Errorf("location %s: %w", loc, err))
 		}

--- a/internal/core/regional_list_test.go
+++ b/internal/core/regional_list_test.go
@@ -158,10 +158,10 @@ func TestFindRegionalConfig(t *testing.T) {
 	}
 }
 
-// TestFindOverridenURLPerLocation guards the regional list --all fix: an
+// TestFindOverriddenURLPerLocation guards the regional list --all fix: an
 // explicit --api-url override must win over the per-location template for
 // every location queried.
-func TestFindOverridenURLPerLocation(t *testing.T) {
+func TestFindOverriddenURLPerLocation(t *testing.T) {
 	const tmpl = "https://svc.%s.ionos.com"
 
 	t.Run("api-url override wins for all locations", func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestFindOverridenURLPerLocation(t *testing.T) {
 		}
 
 		for _, loc := range []string{"de/fra", "de/txl"} {
-			got := findOverridenURL(cmd, []string{"cloud"}, tmpl, loc)
+			got := findOverriddenURL(cmd, []string{"cloud"}, tmpl, loc)
 			if got != "https://override.example.com" {
 				t.Errorf("loc %s: url = %q, want override", loc, got)
 			}
@@ -183,7 +183,7 @@ func TestFindOverridenURLPerLocation(t *testing.T) {
 		cmd := &cobra.Command{Use: "list"}
 		cmd.Flags().String(constants.ArgServerUrl, tmpl, "")
 
-		got := findOverridenURL(cmd, []string{"cloud"}, tmpl, "de/txl")
+		got := findOverriddenURL(cmd, []string{"cloud"}, tmpl, "de/txl")
 		if got != "https://svc.de-txl.ionos.com" {
 			t.Errorf("url = %q, want per-location template", got)
 		}


### PR DESCRIPTION
Config-file endpoint overrides for regional products (e.g. `object-storage`) now apply regardless of whether the location is spelled with slashes (`eu/central/3`) or dashes (`eu-central-3`). Previously the lookup was case-exact on separators, so an override written in one convention was ignored when the command used the other, silently falling back to the default endpoint.